### PR TITLE
feat: add standalone CLI for querying activity history

### DIFF
--- a/bin/memorylane
+++ b/bin/memorylane
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# memorylane — CLI for querying MemoryLane screen activity history.
+#
+# Works in two modes:
+#   1. Packaged app: discovers the Electron binary and bundled cli-entry.js
+#      inside the .app bundle (Contents/Resources/bin/memorylane).
+#   2. Dev checkout: uses the local Electron binary from node_modules and
+#      the built output in out/main/cli-entry.js.
+#
+# Stdout isolation:
+#   The Electron runtime and various modules print init messages to stdout.
+#   To keep CLI output clean, we save the real stdout as fd 3, redirect
+#   process stdout to stderr, and tell cli-entry.ts to write output to fd 3
+#   via CLI_STDOUT_FD=3.
+#
+# Usage:
+#   memorylane search "PR review" --limit 10
+#   memorylane timeline --start "1 hour ago" --end now --json
+#   memorylane details <id> --db /path/to/memorylane.db
+#   memorylane help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- Packaged .app mode ---
+# Layout: MemoryLane.app/Contents/Resources/bin/memorylane  (this script)
+#         MemoryLane.app/Contents/MacOS/MemoryLane           (Electron binary)
+#         MemoryLane.app/Contents/Resources/app.asar/...     (bundled JS)
+PACKAGED_ELECTRON="$SCRIPT_DIR/../MacOS/MemoryLane"
+PACKAGED_CLI_ENTRY="$SCRIPT_DIR/../Resources/app.asar/out/main/cli-entry.js"
+
+# When installed to Contents/Resources/bin/, the MacOS dir is two levels up
+# (Resources/bin -> Resources -> Contents -> Contents/MacOS)
+if [ ! -f "$PACKAGED_ELECTRON" ]; then
+  PACKAGED_ELECTRON="$SCRIPT_DIR/../../MacOS/MemoryLane"
+  PACKAGED_CLI_ENTRY="$SCRIPT_DIR/../app.asar/out/main/cli-entry.js"
+fi
+
+if [ -f "$PACKAGED_ELECTRON" ] && [ -f "$PACKAGED_CLI_ENTRY" ]; then
+  export ELECTRON_RUN_AS_NODE=1
+  export CLI_STDOUT_FD=3
+  exec 3>&1 1>&2 "$PACKAGED_ELECTRON" "$PACKAGED_CLI_ENTRY" "$@"
+fi
+
+# --- Dev checkout mode ---
+# Layout: <project>/bin/memorylane         (this script)
+#         <project>/node_modules/electron/  (Electron package)
+#         <project>/out/main/cli-entry.js   (built JS)
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+DEV_CLI_ENTRY="$PROJECT_ROOT/out/main/cli-entry.js"
+
+if [ ! -f "$DEV_CLI_ENTRY" ]; then
+  echo "Error: cli-entry.js not found. Run 'npm run build' first." >&2
+  exit 1
+fi
+
+# Resolve the Electron binary path from the node module
+ELECTRON_BIN="$PROJECT_ROOT/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron"
+
+# Fallback: try Linux/Windows electron binary path
+if [ ! -f "$ELECTRON_BIN" ]; then
+  ELECTRON_BIN="$PROJECT_ROOT/node_modules/electron/dist/electron"
+fi
+
+if [ ! -f "$ELECTRON_BIN" ]; then
+  echo "Error: Electron binary not found. Run 'npm install' first." >&2
+  exit 1
+fi
+
+export ELECTRON_RUN_AS_NODE=1
+export CLI_STDOUT_FD=3
+exec 3>&1 1>&2 "$ELECTRON_BIN" "$DEV_CLI_ENTRY" "$@"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -29,6 +29,10 @@ extraResources:
     to: powershell
     filter:
       - '*.ps1'
+  - from: bin
+    to: bin
+    filter:
+      - memorylane
 
 asar: true
 asarUnpack:

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/main/index.ts'),
           'mcp-entry': resolve(__dirname, 'src/main/mcp-entry.ts'),
+          'cli-entry': resolve(__dirname, 'src/main/cli-entry.ts'),
         },
         external: [
           'uiohook-napi',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mcp:dev": "node ./scripts/enode.js ./node_modules/.bin/tsx scripts/mcp-dev.ts on",
     "mcp:dev:off": "node ./scripts/enode.js ./node_modules/.bin/tsx scripts/mcp-dev.ts off",
     "mcp:dev:status": "node ./scripts/enode.js ./node_modules/.bin/tsx scripts/mcp-dev.ts status",
+    "cli": "node ./scripts/enode.js ./node_modules/.bin/tsx src/main/cli-entry.ts",
     "install:local": "node ./scripts/install-local.js"
   },
   "keywords": [],

--- a/src/main/cli-entry.ts
+++ b/src/main/cli-entry.ts
@@ -1,0 +1,47 @@
+/**
+ * Standalone CLI entry point.
+ *
+ * Runs under ELECTRON_RUN_AS_NODE=1 so native modules stay ABI-compatible.
+ * Mirrors the MCP tools (search_context, browse_timeline, get_activity_details)
+ * as simple shell commands that agents can invoke directly.
+ *
+ * The shell wrapper (bin/memorylane) redirects stdout to stderr and passes the
+ * original stdout as fd 3 via CLI_STDOUT_FD=3. This entry point opens that fd
+ * as a Writable and passes it to the CLI runner, keeping logger/dotenv noise
+ * out of the real stdout channel.
+ */
+
+import { Writable } from 'node:stream'
+import * as fs from 'node:fs'
+import { config as loadEnv } from 'dotenv'
+
+try {
+  loadEnv()
+} catch {
+  // cwd might not be available in packaged app context
+}
+
+import { run } from './cli/index'
+
+// If the wrapper passed a real-stdout fd, open a Writable to it.
+// Otherwise fall back to process.stdout (dev/npm-script mode).
+// Uses fs.writeSync so output is flushed before process.exit().
+let stdout: Writable | undefined
+const fdStr = process.env.CLI_STDOUT_FD
+if (fdStr) {
+  const fd = parseInt(fdStr, 10)
+  stdout = new Writable({
+    write(chunk, _encoding, callback): void {
+      try {
+        fs.writeSync(fd, typeof chunk === 'string' ? chunk : Buffer.from(chunk))
+        callback()
+      } catch (err) {
+        callback(err as Error)
+      }
+    },
+  })
+}
+
+run(process.argv.slice(2), stdout).then((code) => {
+  process.exit(code)
+})

--- a/src/main/cli/commands.ts
+++ b/src/main/cli/commands.ts
@@ -1,0 +1,245 @@
+/**
+ * CLI command handlers — mirror the MCP tools using the same storage/embedding layer.
+ *
+ * Takes StorageService directly (and an optional embedding service for semantic search)
+ * to avoid importing the ESM-only @huggingface/transformers at module load time.
+ *
+ * All command output goes through the `out` Writable (the real stdout), while errors
+ * go to process.stderr. This keeps the output channel clean when stdout is redirected
+ * to suppress logger/dotenv noise.
+ */
+
+import { Writable } from 'node:stream'
+import { StorageService } from '../processor/storage'
+import { parseTimeString } from '../mcp/parse-time'
+import {
+  formatTimelineEntry,
+  sampleEntries,
+  activityToTimelineEntry,
+  TimelineEntry,
+} from '../mcp/formatting'
+
+interface EmbeddingProvider {
+  generateEmbedding(text: string): Promise<number[]>
+}
+
+// ---------------------------------------------------------------------------
+// search — mirrors search_context
+// ---------------------------------------------------------------------------
+
+export async function handleSearch(
+  storage: StorageService,
+  embeddingService: EmbeddingProvider | null,
+  out: Writable,
+  opts: {
+    query?: string
+    start?: string
+    end?: string
+    app?: string
+    limit?: number
+    json: boolean
+  },
+): Promise<number> {
+  const limit = opts.limit ?? 100
+
+  const startTime = opts.start ? parseTimeString(opts.start) : undefined
+  const endTime = opts.end ? parseTimeString(opts.end) : undefined
+
+  if (opts.start && startTime === null) {
+    process.stderr.write(`Error: Could not parse --start "${opts.start}".\n`)
+    return 1
+  }
+  if (opts.end && endTime === null) {
+    process.stderr.write(`Error: Could not parse --end "${opts.end}".\n`)
+    return 1
+  }
+
+  // No query: chronological listing
+  if (!opts.query) {
+    if (startTime === undefined && endTime === undefined) {
+      process.stderr.write('Error: Either a query or at least --start/--end is required.\n')
+      return 1
+    }
+
+    const activities = await storage.getActivitiesByTimeRange(startTime ?? null, endTime ?? null, {
+      appName: opts.app,
+    })
+    const entries = activities.map(activityToTimelineEntry)
+    const sampled = sampleEntries(entries, limit, 'recent_first')
+
+    if (sampled.length === 0) {
+      out.write('No activities found in the given time range.\n')
+      return 0
+    }
+
+    if (opts.json) {
+      out.write(JSON.stringify(sampled, null, 2) + '\n')
+      return 0
+    }
+
+    const header =
+      sampled.length < entries.length
+        ? `Showing ${sampled.length} of ${entries.length} activities:`
+        : `${entries.length} activit${entries.length === 1 ? 'y' : 'ies'}:`
+    out.write(`${header}\n\n`)
+    out.write(sampled.map(formatTimelineEntry).join('\n') + '\n')
+    return 0
+  }
+
+  // Semantic search (vector + FTS), or FTS-only if embeddings unavailable
+  const filters = {
+    startTime: startTime ?? undefined,
+    endTime: endTime ?? undefined,
+    appName: opts.app,
+  }
+
+  const allResults: TimelineEntry[] = []
+  const seen = new Set<string>()
+
+  if (embeddingService) {
+    const [embedding, ftsResults] = await Promise.all([
+      embeddingService.generateEmbedding(opts.query),
+      storage.searchActivitiesFTS(opts.query, limit, filters).catch(() => []),
+    ])
+    const vectorResults = await storage.searchActivitiesVectors(embedding, limit, filters)
+
+    // Deduplicate: vector results first (relevance order), then FTS extras
+    for (const a of vectorResults) {
+      seen.add(a.id)
+      allResults.push(activityToTimelineEntry(a))
+    }
+    for (const a of ftsResults) {
+      if (!seen.has(a.id)) {
+        seen.add(a.id)
+        allResults.push(activityToTimelineEntry(a))
+      }
+    }
+  } else {
+    // FTS-only fallback
+    const ftsResults = await storage.searchActivitiesFTS(opts.query, limit, filters)
+    for (const a of ftsResults) {
+      allResults.push(activityToTimelineEntry(a))
+    }
+  }
+
+  const truncated = allResults.slice(0, limit)
+
+  if (truncated.length === 0) {
+    out.write('No relevant results found.\n')
+    return 0
+  }
+
+  if (opts.json) {
+    out.write(JSON.stringify(truncated, null, 2) + '\n')
+    return 0
+  }
+
+  out.write(`Found ${truncated.length} relevant results:\n\n`)
+  out.write(truncated.map(formatTimelineEntry).join('\n') + '\n')
+  return 0
+}
+
+// ---------------------------------------------------------------------------
+// timeline — mirrors browse_timeline
+// ---------------------------------------------------------------------------
+
+export async function handleTimeline(
+  storage: StorageService,
+  out: Writable,
+  opts: {
+    start?: string
+    end?: string
+    app?: string
+    limit?: number
+    sampling?: 'uniform' | 'recent_first'
+    json: boolean
+  },
+): Promise<number> {
+  if (!opts.start || !opts.end) {
+    process.stderr.write('Error: --start and --end are required for timeline.\n')
+    return 1
+  }
+
+  const startTime = parseTimeString(opts.start)
+  const endTime = parseTimeString(opts.end)
+
+  if (startTime === null) {
+    process.stderr.write(`Error: Could not parse --start "${opts.start}".\n`)
+    return 1
+  }
+  if (endTime === null) {
+    process.stderr.write(`Error: Could not parse --end "${opts.end}".\n`)
+    return 1
+  }
+
+  const activities = await storage.getActivitiesByTimeRange(startTime, endTime, {
+    appName: opts.app,
+  })
+  const entries = activities.map(activityToTimelineEntry)
+
+  if (entries.length === 0) {
+    out.write('No activities found in the given time range.\n')
+    return 0
+  }
+
+  const limit = opts.limit ?? 100
+  const sampling = opts.sampling ?? 'uniform'
+  const sampled = sampleEntries(entries, limit, sampling)
+
+  if (opts.json) {
+    out.write(JSON.stringify(sampled, null, 2) + '\n')
+    return 0
+  }
+
+  const header =
+    sampled.length < entries.length
+      ? `Showing ${sampled.length} of ${entries.length} activities (${sampling} sampling):`
+      : `${entries.length} activit${entries.length === 1 ? 'y' : 'ies'}:`
+
+  out.write(`${header}\n\n`)
+  out.write(sampled.map(formatTimelineEntry).join('\n') + '\n')
+  return 0
+}
+
+// ---------------------------------------------------------------------------
+// details — mirrors get_activity_details
+// ---------------------------------------------------------------------------
+
+export async function handleDetails(
+  storage: StorageService,
+  out: Writable,
+  opts: {
+    ids: string[]
+    json: boolean
+  },
+): Promise<number> {
+  const activities = await storage.getActivitiesByIds(opts.ids)
+
+  if (activities.length === 0) {
+    out.write('No activities found for the given IDs.\n')
+    return 0
+  }
+
+  if (opts.json) {
+    // Omit the vector field from JSON output — it's large and not useful for consumers
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const cleaned = activities.map(({ vector, ...rest }) => rest)
+    out.write(JSON.stringify(cleaned, null, 2) + '\n')
+    return 0
+  }
+
+  const formatted = activities
+    .map((a) => {
+      const timeStr = new Date(a.startTimestamp).toLocaleString()
+      const endTimeStr = new Date(a.endTimestamp).toLocaleString()
+      const appInfo = a.appName ? ` [${a.appName}]` : ''
+      const durationSec = Math.round(a.durationMs / 1000)
+      const summaryLine = a.summary ? `\nSummary: ${a.summary}` : ''
+      const interactionLine = a.interactionSummary ? `\nInteractions: ${a.interactionSummary}` : ''
+      return `ID: ${a.id}\n[${timeStr} → ${endTimeStr}]${appInfo} (${durationSec}s, ${a.screenshotCount} screenshots)${summaryLine}${interactionLine}\nOCR: ${a.ocrText}`
+    })
+    .join('\n\n---\n\n')
+
+  out.write(`${activities.length} result(s):\n\n${formatted}\n`)
+  return 0
+}

--- a/src/main/cli/index.ts
+++ b/src/main/cli/index.ts
@@ -1,0 +1,205 @@
+/**
+ * CLI arg parser and dispatcher.
+ *
+ * Usage:
+ *   memorylane search [query] [--start <time>] [--end <time>] [--app <name>] [--limit N] [--json] [--db <path>]
+ *   memorylane timeline --start <time> --end <time> [--app <name>] [--limit N] [--sampling uniform|recent_first] [--json] [--db <path>]
+ *   memorylane details <id...> [--json] [--db <path>]
+ *
+ * Note: EmbeddingService (which depends on the ESM-only @huggingface/transformers)
+ * is loaded lazily via dynamic import() only when semantic search is needed.
+ * This keeps all other commands working under CJS/tsx without ESM issues.
+ */
+
+import { Writable } from 'node:stream'
+import { StorageService } from '../processor/storage'
+import { getDefaultDbPath } from '../paths'
+import { handleSearch, handleTimeline, handleDetails } from './commands'
+
+const HELP = `\
+memorylane — query your screen activity history
+
+Usage:
+  memorylane search [query] [options]     Semantic search over activity sessions
+  memorylane timeline [options]           Browse activity over a time range
+  memorylane details <id...> [options]    Get full activity details by ID
+  memorylane help                         Show this help message
+
+Global options:
+  --db <path>        Path to the MemoryLane database file (default: auto-detected)
+  --json             Output as JSON
+  --help, -h         Show this help message
+
+Search options:
+  --start <time>     Only include results after this time (ISO 8601 or relative, e.g. "1 hour ago")
+  --end <time>       Only include results before this time
+  --app <name>       Filter by application name
+  --limit <N>        Maximum number of results (default: 100)
+
+Timeline options:
+  --start <time>     Start of time range (required)
+  --end <time>       End of time range (required)
+  --app <name>       Filter by application name
+  --limit <N>        Maximum number of results (default: 100)
+  --sampling <mode>  "uniform" (default) or "recent_first"
+
+Examples:
+  memorylane search "PR review" --limit 10
+  memorylane timeline --start "1 hour ago" --end now
+  memorylane timeline --start yesterday --end now --app "VS Code" --json
+  memorylane details abc123 def456
+  memorylane search --start "2 days ago" --end now --db ~/path/to/memorylane.db
+`
+
+interface ParsedArgs {
+  command: string
+  positionals: string[]
+  db?: string
+  start?: string
+  end?: string
+  app?: string
+  limit?: number
+  sampling?: string
+  json: boolean
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = []
+  let command = ''
+  let db: string | undefined
+  let start: string | undefined
+  let end: string | undefined
+  let app: string | undefined
+  let limit: number | undefined
+  let sampling: string | undefined
+  let json = false
+
+  let i = 0
+
+  // First positional is the command
+  if (i < argv.length && !argv[i].startsWith('--')) {
+    command = argv[i]
+    i++
+  }
+
+  while (i < argv.length) {
+    const arg = argv[i]
+
+    if (arg === '--db' && i + 1 < argv.length) {
+      db = argv[++i]
+    } else if (arg === '--start' && i + 1 < argv.length) {
+      start = argv[++i]
+    } else if (arg === '--end' && i + 1 < argv.length) {
+      end = argv[++i]
+    } else if (arg === '--app' && i + 1 < argv.length) {
+      app = argv[++i]
+    } else if (arg === '--limit' && i + 1 < argv.length) {
+      const n = parseInt(argv[++i], 10)
+      if (!isNaN(n) && n > 0) limit = n
+    } else if (arg === '--sampling' && i + 1 < argv.length) {
+      sampling = argv[++i]
+    } else if (arg === '--json') {
+      json = true
+    } else if (arg === '--help' || arg === '-h') {
+      command = 'help'
+    } else if (!arg.startsWith('--')) {
+      positionals.push(arg)
+    } else {
+      process.stderr.write(`Unknown option: ${arg}\n`)
+    }
+
+    i++
+  }
+
+  return { command, positionals, db, start, end, app, limit, sampling, json }
+}
+
+async function initStorage(dbPath?: string): Promise<StorageService> {
+  const resolvedPath = dbPath || getDefaultDbPath()
+  const storage = new StorageService(resolvedPath)
+  await storage.init()
+  return storage
+}
+
+/**
+ * Lazily load the EmbeddingService to avoid pulling in @huggingface/transformers
+ * (ESM-only) at module load time. Only needed for semantic search with a query.
+ *
+ * Returns null if the embedding module can't be loaded (e.g. ESM resolution
+ * fails under tsx in dev mode). Callers fall back to FTS-only search.
+ */
+async function initEmbeddingService(): Promise<{
+  generateEmbedding(text: string): Promise<number[]>
+} | null> {
+  try {
+    const { EmbeddingService } = await import('../processor/embedding')
+    const svc = new EmbeddingService()
+    await svc.init()
+    return svc
+  } catch {
+    process.stderr.write(
+      'Warning: Embedding service unavailable (vector search disabled, using FTS only).\n',
+    )
+    return null
+  }
+}
+
+/**
+ * @param argv - Command-line arguments (after stripping the node/script path).
+ * @param stdout - Writable stream for command output. Defaults to process.stdout
+ *                 but callers can pass a captured real-stdout to avoid logger noise.
+ */
+export async function run(argv: string[], stdout?: Writable): Promise<number> {
+  const out = stdout ?? process.stdout
+  const args = parseArgs(argv)
+
+  if (!args.command || args.command === 'help') {
+    out.write(HELP)
+    return 0
+  }
+
+  switch (args.command) {
+    case 'search': {
+      const storage = await initStorage(args.db)
+      const needsEmbedding = !!args.positionals.join(' ').trim()
+      const embeddingService = needsEmbedding ? await initEmbeddingService() : null
+      return handleSearch(storage, embeddingService, out, {
+        query: args.positionals.join(' ') || undefined,
+        start: args.start,
+        end: args.end,
+        app: args.app,
+        limit: args.limit,
+        json: args.json,
+      })
+    }
+
+    case 'timeline': {
+      const storage = await initStorage(args.db)
+      return handleTimeline(storage, out, {
+        start: args.start,
+        end: args.end,
+        app: args.app,
+        limit: args.limit,
+        sampling: args.sampling as 'uniform' | 'recent_first' | undefined,
+        json: args.json,
+      })
+    }
+
+    case 'details': {
+      if (args.positionals.length === 0) {
+        process.stderr.write('Error: details requires at least one activity ID.\n')
+        return 1
+      }
+      const storage = await initStorage(args.db)
+      return handleDetails(storage, out, {
+        ids: args.positionals,
+        json: args.json,
+      })
+    }
+
+    default:
+      process.stderr.write(`Unknown command: ${args.command}\n\n`)
+      out.write(HELP)
+      return 1
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a CLI that mirrors the MCP tools (`search_context`, `browse_timeline`, `get_activity_details`) as simple shell commands
- Ships as a shell wrapper (`bin/memorylane`) that works in both dev and packaged app mode
- Supports `--db <path>` to point at any MemoryLane database file, `--json` for structured output
- Clean stdout isolation via fd redirect — logger/dotenv noise goes to stderr only
- Bundled by electron-vite as a third main-process entry point alongside `index` and `mcp-entry`

## Commands

```
memorylane search [query] [--start <time>] [--end <time>] [--app <name>] [--limit N] [--json] [--db <path>]
memorylane timeline --start <time> --end <time> [--app <name>] [--limit N] [--sampling uniform|recent_first] [--json] [--db <path>]
memorylane details <id...> [--json] [--db <path>]
```

## Files changed

- **New**: `src/main/cli-entry.ts`, `src/main/cli/index.ts`, `src/main/cli/commands.ts`, `bin/memorylane`
- **Modified**: `electron.vite.config.ts` (add cli-entry build target), `electron-builder.yml` (include bin/ in extraResources), `package.json` (add cli script)

## Test plan

- [x] `bin/memorylane help` — clean help output, no logger noise on stdout
- [x] `bin/memorylane timeline --start "1 hour ago" --end now --limit 3` — returns activities
- [x] `bin/memorylane search "PR review" --limit 3` — FTS search works
- [x] `bin/memorylane details <id> --json` — JSON output pipes cleanly
- [x] `bin/memorylane search --start "1 hour ago" --end now --db ~/path/to/memorylane.db` — custom DB path
- [x] Error cases: missing args, bad time formats, unknown commands all return exit code 1

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)