### PR TITLE
Expose window titles in MCP timeline results

### DIFF
--- a/src/main/mcp/formatting.test.ts
+++ b/src/main/mcp/formatting.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { activityToTimelineEntry, formatTimelineEntry } from './formatting'
+
+describe('mcp formatting', () => {
+  it('includes window title in timeline entries', () => {
+    const entry = activityToTimelineEntry({
+      id: 'activity-1',
+      startTimestamp: new Date('2026-03-02T10:00:00.000Z').getTime(),
+      endTimestamp: new Date('2026-03-02T10:05:00.000Z').getTime(),
+      appName: 'KeePassXC',
+      windowTitle: 'Q - KeePassXC',
+      summary: 'Looked up a credential entry.',
+    })
+
+    expect(entry.windowTitle).toBe('Q - KeePassXC')
+    expect(formatTimelineEntry(entry)).toContain('[window: "Q - KeePassXC"]')
+  })
+
+  it('omits the window field when no title is available', () => {
+    const formatted = formatTimelineEntry({
+      id: 'activity-2',
+      timestamp: new Date('2026-03-02T10:10:00.000Z').getTime(),
+      appName: 'Terminal',
+      windowTitle: '',
+      summary: 'Ran tests.',
+    })
+
+    expect(formatted).not.toContain('[window:')
+  })
+})

--- a/src/main/mcp/formatting.ts
+++ b/src/main/mcp/formatting.ts
@@ -23,6 +23,7 @@ export interface TimelineEntry {
   id: string
   timestamp: number
   appName: string
+  windowTitle: string
   summary: string
 }
 
@@ -34,6 +35,7 @@ export function activityToTimelineEntry(activity: ActivitySummary): TimelineEntr
     id: activity.id,
     timestamp: activity.startTimestamp,
     appName: activity.appName ?? '',
+    windowTitle: activity.windowTitle ?? '',
     summary: activity.summary ?? '',
   }
 }
@@ -44,8 +46,9 @@ export function activityToTimelineEntry(activity: ActivitySummary): TimelineEntr
 export function formatTimelineEntry(entry: TimelineEntry): string {
   const timeStr = new Date(entry.timestamp).toLocaleString()
   const appInfo = entry.appName ? ` [${entry.appName}]` : ''
+  const windowInfo = entry.windowTitle ? ` [window: ${JSON.stringify(entry.windowTitle)}]` : ''
   const summary = entry.summary || '(no summary)'
-  return `- ${entry.id} | ${timeStr}${appInfo} | ${summary}`
+  return `- ${entry.id} | ${timeStr}${appInfo}${windowInfo} | ${summary}`
 }
 
 /**

--- a/src/main/mcp/server.ts
+++ b/src/main/mcp/server.ts
@@ -46,7 +46,7 @@ reasoning. \
 100-500 is a good default limit for searches over many hours.
 - **search_context** — targeted recall like "when did I review PR #142?", \
 "find my work on the auth module", or "that error I saw in the terminal". \
-Results are ranked by semantic relevance and return summary-first context.
+Results are ranked by semantic relevance and return summary-first context, including app and window title.
 - **get_activity_details** — fetch full activity details including OCR screen text \
 for specific activity IDs returned by the other tools. Use this only when exact \
 on-screen text is needed; do not use OCR as the primary source for inferring user activity.

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -26,7 +26,7 @@ export function registerTools(
     'search_context',
     {
       description:
-        'Semantic search over recorded screen activity sessions. Each result includes id, time, app, and AI summary for summary-first activity reasoning. Use this for targeted questions (e.g. "when did I review PR #142?", "find my work on the auth module"). For exact strings, call get_activity_details to inspect OCR text. If query is omitted, returns activities chronologically (requires startTime or endTime).',
+        'Semantic search over recorded screen activity sessions. Each result includes id, time, app, window title, and AI summary for summary-first activity reasoning. Use this for targeted questions (e.g. "when did I review PR #142?", "find my work on the auth module"). For exact strings, call get_activity_details to inspect OCR text. If query is omitted, returns activities chronologically (requires startTime or endTime).',
       inputSchema: {
         query: z
           .string()
@@ -62,7 +62,7 @@ export function registerTools(
     'browse_timeline',
     {
       description:
-        'List activity during a time period — best for broad "what did I do?" questions. Each result is a one-line summary (~20 tokens), so use higher limits (30-50) to get a full picture. Supports uniform sampling to cover long ranges. Returns id, timestamp, app, and summary for activity inference; call get_activity_details only when exact OCR text is needed.',
+        'List activity during a time period — best for broad "what did I do?" questions. Each result is a one-line summary (~20 tokens), so use higher limits (30-50) to get a full picture. Supports uniform sampling to cover long ranges. Returns id, timestamp, app, window title, and summary for activity inference; call get_activity_details only when exact OCR text is needed.',
       inputSchema: {
         startTime: z
           .string()

--- a/src/main/storage/activity-repository.test.ts
+++ b/src/main/storage/activity-repository.test.ts
@@ -133,6 +133,7 @@ describe('ActivityRepository', () => {
       storage.activities.add(
         createStoredActivity({
           id: 'fts-light',
+          windowTitle: 'Feature Request.md',
           summary: 'Lightweight check',
           ocrText: 'should not appear',
         }),
@@ -142,6 +143,7 @@ describe('ActivityRepository', () => {
 
       expect(results.length).toBe(1)
       expect(results[0]).toHaveProperty('id')
+      expect(results[0].windowTitle).toBe('Feature Request.md')
       expect(results[0]).toHaveProperty('summary')
       expect(results[0]).not.toHaveProperty('ocrText')
       expect(results[0]).not.toHaveProperty('vector')
@@ -281,6 +283,7 @@ describe('ActivityRepository', () => {
       storage.activities.add(
         createStoredActivity({
           id: 'vec-light',
+          windowTitle: 'src/main/mcp/tools.ts',
           vector: v(1.0),
           ocrText: 'should not appear',
         }),
@@ -290,6 +293,7 @@ describe('ActivityRepository', () => {
 
       expect(results.length).toBe(1)
       expect(results[0]).toHaveProperty('id')
+      expect(results[0].windowTitle).toBe('src/main/mcp/tools.ts')
       expect(results[0]).toHaveProperty('summary')
       expect(results[0]).not.toHaveProperty('ocrText')
       expect(results[0]).not.toHaveProperty('vector')
@@ -401,6 +405,7 @@ describe('ActivityRepository', () => {
         createStoredActivity({
           id: 'light-1',
           startTimestamp: 1000,
+          windowTitle: 'Q - KeePassXC',
           ocrText: 'should not appear',
         }),
       )
@@ -409,6 +414,7 @@ describe('ActivityRepository', () => {
 
       expect(results.length).toBe(1)
       expect(results[0]).toHaveProperty('id')
+      expect(results[0].windowTitle).toBe('Q - KeePassXC')
       expect(results[0]).toHaveProperty('summary')
       expect(results[0]).not.toHaveProperty('ocrText')
       expect(results[0]).not.toHaveProperty('vector')

--- a/src/main/storage/activity-repository.ts
+++ b/src/main/storage/activity-repository.ts
@@ -57,7 +57,7 @@ export class ActivityRepository {
 
     const rows = this.db
       .prepare(
-        `SELECT a.id, a.start_timestamp, a.end_timestamp, a.app_name, a.summary
+        `SELECT a.id, a.start_timestamp, a.end_timestamp, a.app_name, a.window_title, a.summary
        FROM activities_fts fts
        JOIN activities a ON a.rowid = fts.rowid
        WHERE activities_fts MATCH ?
@@ -84,7 +84,7 @@ export class ActivityRepository {
       const effectiveLimit = Math.min(limit, SQLITE_VEC_KNN_MAX)
       const rows = this.db
         .prepare(
-          `SELECT a.id, a.start_timestamp, a.end_timestamp, a.app_name, a.summary
+          `SELECT a.id, a.start_timestamp, a.end_timestamp, a.app_name, a.window_title, a.summary
          FROM (
            SELECT id, distance
            FROM activities_vec
@@ -105,7 +105,7 @@ export class ActivityRepository {
 
     const rows = this.db
       .prepare(
-        `SELECT a.id, a.start_timestamp, a.end_timestamp, a.app_name, a.summary
+        `SELECT a.id, a.start_timestamp, a.end_timestamp, a.app_name, a.window_title, a.summary
        FROM (
          SELECT id, distance
          FROM activities_vec
@@ -148,7 +148,7 @@ export class ActivityRepository {
 
     const rows = this.db
       .prepare(
-        `SELECT id, start_timestamp, end_timestamp, app_name, summary
+        `SELECT id, start_timestamp, end_timestamp, app_name, window_title, summary
        FROM activities
        ${whereClause}
        ORDER BY start_timestamp ASC`,
@@ -222,6 +222,7 @@ export class ActivityRepository {
       startTimestamp: row.start_timestamp as number,
       endTimestamp: row.end_timestamp as number,
       appName: row.app_name as string,
+      windowTitle: row.window_title as string,
       summary: row.summary as string,
     }
   }

--- a/src/main/storage/types.ts
+++ b/src/main/storage/types.ts
@@ -16,6 +16,7 @@ export interface ActivitySummary {
   startTimestamp: number
   endTimestamp: number
   appName: string
+  windowTitle: string
   summary: string
 }
 


### PR DESCRIPTION
## Summary
- include `windowTitle` in lightweight activity summaries returned from storage
- surface the window title in MCP timeline/search formatting as `window=...` context
- add focused tests for storage summaries and MCP formatting

## Testing
- `npm test -- src/main/storage/activity-repository.test.ts`
- `npm test -- src/main/mcp/formatting.test.ts`
- `npm run build`

Fixes #56