### PR TITLE
Fix V2 image-only media handling

### DIFF
--- a/src/main/settings/capture-settings-manager.test.ts
+++ b/src/main/settings/capture-settings-manager.test.ts
@@ -42,7 +42,7 @@ describe('CaptureSettingsManager', () => {
       expect(defaults.clickDebounceMs).toBe(INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS)
       expect(defaults.minActivityDurationMs).toBe(ACTIVITY_CONFIG.MIN_ACTIVITY_DURATION_MS)
       expect(defaults.maxActivityDurationMs).toBe(ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS)
-      expect(defaults.maxScreenshotsPerActivity).toBe(ACTIVITY_CONFIG.MAX_SCREENSHOTS_PER_ACTIVITY)
+      expect(defaults.maxScreenshotsPerActivity).toBe(ACTIVITY_CONFIG.MAX_SCREENSHOTS_FOR_LLM)
       expect(defaults.semanticPipelineMode).toBe('auto')
     })
 
@@ -136,7 +136,7 @@ describe('CaptureSettingsManager', () => {
       clickDebounceMs: INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS,
       minActivityDurationMs: ACTIVITY_CONFIG.MIN_ACTIVITY_DURATION_MS,
       maxActivityDurationMs: ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS,
-      maxScreenshotsPerActivity: ACTIVITY_CONFIG.MAX_SCREENSHOTS_PER_ACTIVITY,
+      maxScreenshotsPerActivity: ACTIVITY_CONFIG.MAX_SCREENSHOTS_FOR_LLM,
     }
 
     afterEach(() => {
@@ -146,17 +146,18 @@ describe('CaptureSettingsManager', () => {
       INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS = original.clickDebounceMs
       ACTIVITY_CONFIG.MIN_ACTIVITY_DURATION_MS = original.minActivityDurationMs
       ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS = original.maxActivityDurationMs
-      ACTIVITY_CONFIG.MAX_SCREENSHOTS_PER_ACTIVITY = original.maxScreenshotsPerActivity
+      ACTIVITY_CONFIG.MAX_SCREENSHOTS_FOR_LLM = original.maxScreenshotsPerActivity
     })
 
     it('mutates the shared constants to match saved settings', () => {
       const p = makeTmpPath()
       const manager = new CaptureSettingsManager(p)
-      manager.save({ typingDebounceMs: 8000, visualThreshold: 3 })
+      manager.save({ typingDebounceMs: 8000, visualThreshold: 3, maxScreenshotsPerActivity: 4 })
       manager.applyToConstants()
 
       expect(INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS).toBe(8000)
       expect(VISUAL_DETECTOR_CONFIG.DHASH_THRESHOLD_PERCENT).toBe(3)
+      expect(ACTIVITY_CONFIG.MAX_SCREENSHOTS_FOR_LLM).toBe(4)
     })
 
     it('after reset, applyToConstants restores constants to defaults', () => {

--- a/src/main/settings/capture-settings-manager.ts
+++ b/src/main/settings/capture-settings-manager.ts
@@ -16,7 +16,7 @@ const DEFAULTS: CaptureSettings = {
   clickDebounceMs: INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS,
   minActivityDurationMs: ACTIVITY_CONFIG.MIN_ACTIVITY_DURATION_MS,
   maxActivityDurationMs: ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS,
-  maxScreenshotsPerActivity: ACTIVITY_CONFIG.MAX_SCREENSHOTS_PER_ACTIVITY,
+  maxScreenshotsPerActivity: ACTIVITY_CONFIG.MAX_SCREENSHOTS_FOR_LLM,
   semanticPipelineMode: 'auto',
 }
 
@@ -93,6 +93,6 @@ export class CaptureSettingsManager {
     INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS = cs.clickDebounceMs
     ACTIVITY_CONFIG.MIN_ACTIVITY_DURATION_MS = cs.minActivityDurationMs
     ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS = cs.maxActivityDurationMs
-    ACTIVITY_CONFIG.MAX_SCREENSHOTS_PER_ACTIVITY = cs.maxScreenshotsPerActivity
+    ACTIVITY_CONFIG.MAX_SCREENSHOTS_FOR_LLM = cs.maxScreenshotsPerActivity
   }
 }

--- a/src/main/v2/activity-semantic-service.test.ts
+++ b/src/main/v2/activity-semantic-service.test.ts
@@ -404,10 +404,9 @@ describe('V2ActivitySemanticService', () => {
     expect(diagnostics?.chosenMode).toBe('snapshot')
   })
 
-  it('supports image-only mode without attempting video', async () => {
+  it('supports image-only mode without attempting video or requiring a stitched file', async () => {
     const tempDir = createTempDir()
     tempDirs.push(tempDir)
-    const videoPath = createVideoFile(tempDir)
 
     const frames = [
       makeFrame(createImageFile(tempDir, 'f0.png'), 1_000, 0),
@@ -423,7 +422,6 @@ describe('V2ActivitySemanticService', () => {
 
     const result = await service.summarizeFromVideo({
       activity: makeActivity({ frames }),
-      videoPath,
       ocrText: 'ignored',
     })
 
@@ -673,10 +671,10 @@ describe('V2ActivitySemanticService', () => {
     ])
   })
 
-  it('snapshot sampling obeys ACTIVITY_CONFIG.MAX_SCREENSHOTS_PER_ACTIVITY=6', async () => {
+  it('snapshot sampling obeys ACTIVITY_CONFIG.MAX_SCREENSHOTS_FOR_LLM=6', async () => {
     const tempDir = createTempDir()
     tempDirs.push(tempDir)
-    ACTIVITY_CONFIG.MAX_SCREENSHOTS_PER_ACTIVITY = 6
+    ACTIVITY_CONFIG.MAX_SCREENSHOTS_FOR_LLM = 6
     VISUAL_DETECTOR_CONFIG.DHASH_THRESHOLD_PERCENT = 0
 
     const frames: V2ActivityFrame[] = []
@@ -842,7 +840,7 @@ describe('V2ActivitySemanticService', () => {
   it('snapshot sampling always includes first and last when available', async () => {
     const tempDir = createTempDir()
     tempDirs.push(tempDir)
-    ACTIVITY_CONFIG.MAX_SCREENSHOTS_PER_ACTIVITY = 3
+    ACTIVITY_CONFIG.MAX_SCREENSHOTS_FOR_LLM = 3
     VISUAL_DETECTOR_CONFIG.DHASH_THRESHOLD_PERCENT = 0
 
     const frames = [

--- a/src/main/v2/activity-transformer-types.ts
+++ b/src/main/v2/activity-transformer-types.ts
@@ -26,7 +26,7 @@ export interface ActivityOcrService {
 export interface ActivitySemanticService {
   summarizeFromVideo(input: {
     activity: V2Activity
-    videoPath: string
+    videoPath?: string
     ocrText: string
   }): Promise<string>
 }

--- a/src/main/v2/activity-transformer.test.ts
+++ b/src/main/v2/activity-transformer.test.ts
@@ -134,6 +134,24 @@ describe('DefaultActivityTransformer', () => {
     })
   })
 
+  it('skips video stitching when pipeline preference is image', async () => {
+    const { stitcher, ocr, semantic, embedder } = makeDeps()
+    const transformer = new DefaultActivityTransformer(stitcher, ocr, semantic, embedder, {
+      outputDir: OUTPUT_DIR,
+      getPipelinePreference: () => 'image',
+    })
+
+    const activity = makeActivity(3)
+    await transformer.transform(activity)
+
+    expect(stitcher.stitch).not.toHaveBeenCalled()
+    expect(semantic.summarizeFromVideo).toHaveBeenCalledWith({
+      activity,
+      videoPath: undefined,
+      ocrText: 'ocr text',
+    })
+  })
+
   it('uses the 5th screenshot from the end for OCR when there are at least 5 frames', async () => {
     const { stitcher, ocr, semantic, embedder } = makeDeps()
     ;(ocr.extractText as ReturnType<typeof vi.fn>).mockResolvedValue('Selected OCR text')

--- a/src/main/v2/activity-transformer.ts
+++ b/src/main/v2/activity-transformer.ts
@@ -7,10 +7,12 @@ import type {
   ActivitySemanticService,
   ActivityEmbeddingService,
 } from './activity-transformer-types'
+import type { SemanticPipelinePreference } from './activity-semantic-service'
 import log from '../logger'
 
 export interface DefaultActivityTransformerConfig {
   outputDir: string
+  getPipelinePreference?: () => SemanticPipelinePreference
 }
 
 const OCR_FRAME_POSITION_FROM_END = 5
@@ -30,16 +32,19 @@ export class DefaultActivityTransformer implements ActivityTransformer {
       timestamp: f.frame.timestamp,
     }))
 
-    const outputPath = `${this.config.outputDir}/${activity.id}.mp4`
+    const shouldStitchVideo = this.config.getPipelinePreference?.() !== 'image'
+    const outputPath = shouldStitchVideo ? `${this.config.outputDir}/${activity.id}.mp4` : undefined
 
     const [videoAsset, ocrText] = await Promise.all([
-      this.stitcher.stitch({ activityId: activity.id, frames, outputPath }),
+      shouldStitchVideo && outputPath
+        ? this.stitcher.stitch({ activityId: activity.id, frames, outputPath })
+        : Promise.resolve(null),
       this.extractOcrText(activity),
     ])
 
     const summary = await this.semantic.summarizeFromVideo({
       activity,
-      videoPath: videoAsset.videoPath,
+      videoPath: videoAsset?.videoPath,
       ocrText,
     })
 

--- a/src/main/v2/runtime.ts
+++ b/src/main/v2/runtime.ts
@@ -77,7 +77,10 @@ export async function createV2MainRuntime(params?: {
     activityOcrService,
     semanticService,
     new EmbeddingService(),
-    { outputDir },
+    {
+      outputDir,
+      getPipelinePreference: () => semanticService.getPipelinePreference(),
+    },
   )
   const sink = new SqliteActivitySink(storage.activities)
 

--- a/src/main/v2/semantic/service.ts
+++ b/src/main/v2/semantic/service.ts
@@ -158,7 +158,7 @@ export class V2ActivitySemanticService implements ActivitySemanticService {
 
   async summarizeFromVideo(input: {
     activity: V2Activity
-    videoPath: string
+    videoPath?: string
     ocrText: string
   }): Promise<string> {
     this.assertInput(input)
@@ -200,7 +200,7 @@ export class V2ActivitySemanticService implements ActivitySemanticService {
             model: this.customEndpointModel,
           }),
         )
-      } else {
+      } else if (typeof input.videoPath === 'string' && input.videoPath.trim().length > 0) {
         const videoAsset = tryLoadVideoAsDataUrl(input.videoPath, this.maxVideoBytes)
         if (videoAsset) {
           diagnostics.videoSizeBytes = videoAsset.sizeBytes
@@ -243,6 +243,8 @@ export class V2ActivitySemanticService implements ActivitySemanticService {
         } else {
           diagnostics.fallbackReason = 'video unavailable or exceeds configured size limit'
         }
+      } else {
+        diagnostics.fallbackReason = 'video unavailable'
       }
     } else {
       diagnostics.fallbackReason = 'video pipeline disabled by preference'
@@ -336,15 +338,12 @@ export class V2ActivitySemanticService implements ActivitySemanticService {
     }
   }
 
-  private assertInput(input: { activity: V2Activity; videoPath: string; ocrText: string }): void {
+  private assertInput(input: { activity: V2Activity; videoPath?: string; ocrText: string }): void {
     if (!input.activity || typeof input.activity !== 'object') {
       throw new Error('summarizeFromVideo requires a valid activity object')
     }
     if (!input.activity.id || input.activity.id.trim().length === 0) {
       throw new Error('summarizeFromVideo requires activity.id')
-    }
-    if (typeof input.videoPath !== 'string' || input.videoPath.trim().length === 0) {
-      throw new Error('summarizeFromVideo requires a non-empty videoPath')
     }
   }
 

--- a/src/renderer/pages/main-window/AdvancedSettingsPage.tsx
+++ b/src/renderer/pages/main-window/AdvancedSettingsPage.tsx
@@ -385,10 +385,10 @@ export function AdvancedSettingsPage({ onBack }: { onBack: () => void }): React.
                     onCommit={(v) => commit('maxActivityDurationMs', v)}
                   />
                   <SliderRow
-                    label="Max screenshots per activity"
+                    label="Max snapshots for AI"
                     value={form.maxScreenshotsPerActivity}
-                    min={5}
-                    max={50}
+                    min={1}
+                    max={12}
                     step={1}
                     format={(v) => `${v}`}
                     onChange={(v) => set('maxScreenshotsPerActivity', v)}


### PR DESCRIPTION
## Summary
- skip MP4 stitching in V2 when the semantic pipeline is set to image-only while keeping live setting updates working
- repurpose the existing screenshot-cap setting to control the V2 LLM snapshot cap and relabel the UI accordingly
- update tests for the new transformer and semantic-service behavior

## Testing
- npm test -- src/main/v2/activity-transformer.test.ts src/main/v2/activity-semantic-service.test.ts src/main/settings/capture-settings-manager.test.ts