### PR TITLE
Skip V2 video stitching in image-only mode

### DIFF
--- a/src/main/v2/activity-semantic-service.test.ts
+++ b/src/main/v2/activity-semantic-service.test.ts
@@ -404,10 +404,9 @@ describe('V2ActivitySemanticService', () => {
     expect(diagnostics?.chosenMode).toBe('snapshot')
   })
 
-  it('supports image-only mode without attempting video', async () => {
+  it('supports image-only mode without attempting video or requiring a stitched file', async () => {
     const tempDir = createTempDir()
     tempDirs.push(tempDir)
-    const videoPath = createVideoFile(tempDir)
 
     const frames = [
       makeFrame(createImageFile(tempDir, 'f0.png'), 1_000, 0),
@@ -423,7 +422,6 @@ describe('V2ActivitySemanticService', () => {
 
     const result = await service.summarizeFromVideo({
       activity: makeActivity({ frames }),
-      videoPath,
       ocrText: 'ignored',
     })
 

--- a/src/main/v2/activity-transformer-types.ts
+++ b/src/main/v2/activity-transformer-types.ts
@@ -26,7 +26,7 @@ export interface ActivityOcrService {
 export interface ActivitySemanticService {
   summarizeFromVideo(input: {
     activity: V2Activity
-    videoPath: string
+    videoPath?: string
     ocrText: string
   }): Promise<string>
 }

--- a/src/main/v2/activity-transformer.test.ts
+++ b/src/main/v2/activity-transformer.test.ts
@@ -134,6 +134,24 @@ describe('DefaultActivityTransformer', () => {
     })
   })
 
+  it('skips video stitching when pipeline preference is image', async () => {
+    const { stitcher, ocr, semantic, embedder } = makeDeps()
+    const transformer = new DefaultActivityTransformer(stitcher, ocr, semantic, embedder, {
+      outputDir: OUTPUT_DIR,
+      getPipelinePreference: () => 'image',
+    })
+
+    const activity = makeActivity(3)
+    await transformer.transform(activity)
+
+    expect(stitcher.stitch).not.toHaveBeenCalled()
+    expect(semantic.summarizeFromVideo).toHaveBeenCalledWith({
+      activity,
+      videoPath: undefined,
+      ocrText: 'ocr text',
+    })
+  })
+
   it('uses the 5th screenshot from the end for OCR when there are at least 5 frames', async () => {
     const { stitcher, ocr, semantic, embedder } = makeDeps()
     ;(ocr.extractText as ReturnType<typeof vi.fn>).mockResolvedValue('Selected OCR text')

--- a/src/main/v2/activity-transformer.ts
+++ b/src/main/v2/activity-transformer.ts
@@ -7,10 +7,12 @@ import type {
   ActivitySemanticService,
   ActivityEmbeddingService,
 } from './activity-transformer-types'
+import type { SemanticPipelinePreference } from './activity-semantic-service'
 import log from '../logger'
 
 export interface DefaultActivityTransformerConfig {
   outputDir: string
+  getPipelinePreference?: () => SemanticPipelinePreference
 }
 
 const OCR_FRAME_POSITION_FROM_END = 5
@@ -30,16 +32,19 @@ export class DefaultActivityTransformer implements ActivityTransformer {
       timestamp: f.frame.timestamp,
     }))
 
-    const outputPath = `${this.config.outputDir}/${activity.id}.mp4`
+    const shouldStitchVideo = this.config.getPipelinePreference?.() !== 'image'
+    const outputPath = shouldStitchVideo ? `${this.config.outputDir}/${activity.id}.mp4` : undefined
 
     const [videoAsset, ocrText] = await Promise.all([
-      this.stitcher.stitch({ activityId: activity.id, frames, outputPath }),
+      shouldStitchVideo && outputPath
+        ? this.stitcher.stitch({ activityId: activity.id, frames, outputPath })
+        : Promise.resolve(null),
       this.extractOcrText(activity),
     ])
 
     const summary = await this.semantic.summarizeFromVideo({
       activity,
-      videoPath: videoAsset.videoPath,
+      videoPath: videoAsset?.videoPath,
       ocrText,
     })
 

--- a/src/main/v2/runtime.ts
+++ b/src/main/v2/runtime.ts
@@ -77,7 +77,10 @@ export async function createV2MainRuntime(params?: {
     activityOcrService,
     semanticService,
     new EmbeddingService(),
-    { outputDir },
+    {
+      outputDir,
+      getPipelinePreference: () => semanticService.getPipelinePreference(),
+    },
   )
   const sink = new SqliteActivitySink(storage.activities)
 

--- a/src/main/v2/semantic/service.ts
+++ b/src/main/v2/semantic/service.ts
@@ -158,7 +158,7 @@ export class V2ActivitySemanticService implements ActivitySemanticService {
 
   async summarizeFromVideo(input: {
     activity: V2Activity
-    videoPath: string
+    videoPath?: string
     ocrText: string
   }): Promise<string> {
     this.assertInput(input)
@@ -200,7 +200,7 @@ export class V2ActivitySemanticService implements ActivitySemanticService {
             model: this.customEndpointModel,
           }),
         )
-      } else {
+      } else if (typeof input.videoPath === 'string' && input.videoPath.trim().length > 0) {
         const videoAsset = tryLoadVideoAsDataUrl(input.videoPath, this.maxVideoBytes)
         if (videoAsset) {
           diagnostics.videoSizeBytes = videoAsset.sizeBytes
@@ -243,6 +243,8 @@ export class V2ActivitySemanticService implements ActivitySemanticService {
         } else {
           diagnostics.fallbackReason = 'video unavailable or exceeds configured size limit'
         }
+      } else {
+        diagnostics.fallbackReason = 'video unavailable'
       }
     } else {
       diagnostics.fallbackReason = 'video pipeline disabled by preference'
@@ -336,15 +338,12 @@ export class V2ActivitySemanticService implements ActivitySemanticService {
     }
   }
 
-  private assertInput(input: { activity: V2Activity; videoPath: string; ocrText: string }): void {
+  private assertInput(input: { activity: V2Activity; videoPath?: string; ocrText: string }): void {
     if (!input.activity || typeof input.activity !== 'object') {
       throw new Error('summarizeFromVideo requires a valid activity object')
     }
     if (!input.activity.id || input.activity.id.trim().length === 0) {
       throw new Error('summarizeFromVideo requires activity.id')
-    }
-    if (typeof input.videoPath !== 'string' || input.videoPath.trim().length === 0) {
-      throw new Error('summarizeFromVideo requires a non-empty videoPath')
     }
   }
 


### PR DESCRIPTION
## Summary
- stop stitching MP4s in the V2 transformer when the semantic pipeline preference is image-only
- let the transformer read the current pipeline preference dynamically so live settings updates still apply
- update transformer and semantic-service tests for image-only runs without a stitched file

## Testing
- npm test -- src/main/v2/activity-transformer.test.ts src/main/v2/activity-semantic-service.test.ts