### PR TITLE
Add privacy mode popup notification

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
       rollupOptions: {
         input: {
           'main-window': resolve(__dirname, 'src/renderer/main-window.html'),
+          'privacy-notification': resolve(__dirname, 'src/renderer/privacy-notification.html'),
         },
       },
     },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -123,13 +123,19 @@ app.on('ready', async () => {
   const { setupTray, updateTrayMenu, setPrivacyBlockedState } = await import('./ui/tray')
   const { initMainWindowIPC, openMainWindow, sendStatusToRenderer } =
     await import('./ui/main-window')
+  const { showPrivacyModeNotification } = await import('./ui/privacy-notification')
 
   runtime = await createMainRuntime({
     onCaptureStateChanged: () => {
       void updateTrayMenu()
       void sendStatusToRenderer()
     },
-    onPrivacyBlockingChanged: setPrivacyBlockedState,
+    onPrivacyBlockingChanged: (blocked) => {
+      setPrivacyBlockedState(blocked)
+      if (runtime?.capture.isCapturingNow()) {
+        showPrivacyModeNotification(blocked)
+      }
+    },
     semanticPipelinePreference: initialCaptureSettings.semanticPipelineMode,
     semanticRequestTimeoutMs: initialCaptureSettings.semanticRequestTimeoutMs,
     excludedApps: initialCaptureSettings.excludedApps,

--- a/src/main/ui/privacy-notification.ts
+++ b/src/main/ui/privacy-notification.ts
@@ -1,0 +1,126 @@
+import { app, BrowserWindow, screen } from 'electron'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import log from '../logger'
+
+const POPUP_WIDTH = 252
+const POPUP_HEIGHT = 60
+const POPUP_MARGIN = 32
+const POPUP_DURATION_MS = 3000
+
+type PrivacyNotificationState = 'entering' | 'exiting'
+
+let privacyNotificationWindow: BrowserWindow | null = null
+let hideTimer: ReturnType<typeof setTimeout> | null = null
+let notificationGeneration = 0
+
+const clearHideTimer = (): void => {
+  if (!hideTimer) return
+  clearTimeout(hideTimer)
+  hideTimer = null
+}
+
+const closePrivacyNotification = (): void => {
+  clearHideTimer()
+  if (!privacyNotificationWindow || privacyNotificationWindow.isDestroyed()) {
+    privacyNotificationWindow = null
+    return
+  }
+  privacyNotificationWindow.close()
+}
+
+const buildNotificationUrl = (state: PrivacyNotificationState): string => {
+  if (!app.isPackaged) {
+    return `http://localhost:5173/privacy-notification.html?state=${state}`
+  }
+
+  const notificationPath = path.join(
+    app.getAppPath(),
+    'out',
+    'renderer',
+    'privacy-notification.html',
+  )
+  const fileUrl = pathToFileURL(notificationPath)
+  fileUrl.searchParams.set('state', state)
+  return fileUrl.toString()
+}
+
+export const showPrivacyModeNotification = (blocked: boolean): void => {
+  if (!app.isReady()) {
+    log.info('[PrivacyNotification] App is not ready; skipping popup')
+    return
+  }
+
+  try {
+    notificationGeneration += 1
+    const generation = notificationGeneration
+    closePrivacyNotification()
+
+    const state: PrivacyNotificationState = blocked ? 'entering' : 'exiting'
+    const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
+    const { x, y, width } = display.workArea
+    const popupX = Math.round(x + width - POPUP_WIDTH - POPUP_MARGIN)
+    const popupY = Math.round(y + POPUP_MARGIN)
+
+    const nextWindow = new BrowserWindow({
+      width: POPUP_WIDTH,
+      height: POPUP_HEIGHT,
+      x: popupX,
+      y: popupY,
+      show: false,
+      frame: false,
+      transparent: true,
+      resizable: false,
+      movable: false,
+      minimizable: false,
+      maximizable: false,
+      closable: true,
+      focusable: false,
+      skipTaskbar: true,
+      alwaysOnTop: true,
+      fullscreenable: false,
+      hasShadow: false,
+      useContentSize: true,
+      backgroundColor: '#00000000',
+      webPreferences: {
+        sandbox: true,
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    })
+    privacyNotificationWindow = nextWindow
+
+    nextWindow.setAlwaysOnTop(true, 'screen-saver')
+    nextWindow.once('closed', () => {
+      if (privacyNotificationWindow === nextWindow) {
+        privacyNotificationWindow = null
+      }
+      if (generation === notificationGeneration) {
+        clearHideTimer()
+      }
+    })
+
+    void nextWindow.loadURL(buildNotificationUrl(state))
+
+    nextWindow.once('ready-to-show', () => {
+      if (generation !== notificationGeneration) {
+        nextWindow.close()
+        return
+      }
+      if (privacyNotificationWindow !== nextWindow || nextWindow.isDestroyed()) return
+      nextWindow.showInactive()
+    })
+
+    hideTimer = setTimeout(() => {
+      if (generation !== notificationGeneration) return
+      closePrivacyNotification()
+    }, POPUP_DURATION_MS)
+    hideTimer.unref?.()
+  } catch (error) {
+    log.error('[PrivacyNotification] Failed to show popup:', error)
+  }
+}
+
+app.on('before-quit', () => {
+  closePrivacyNotification()
+})

--- a/src/renderer/pages/privacy-notification/PrivacyNotificationApp.tsx
+++ b/src/renderer/pages/privacy-notification/PrivacyNotificationApp.tsx
@@ -1,0 +1,56 @@
+import type * as React from 'react'
+import logoImage from '@assets/tray-icon-full-size.png'
+import { Button } from '@components/ui/button'
+import { Card, CardContent } from '@components/ui/card'
+
+type PrivacyState = 'entering' | 'exiting'
+
+interface PrivacyNotificationCopy {
+  message: string
+}
+
+const copyByState: Record<PrivacyState, PrivacyNotificationCopy> = {
+  entering: {
+    message: 'Privacy mode on',
+  },
+  exiting: {
+    message: 'Privacy mode off',
+  },
+}
+
+function getPrivacyState(): PrivacyState {
+  const state = new URLSearchParams(window.location.search).get('state')
+  return state === 'exiting' ? 'exiting' : 'entering'
+}
+
+export function PrivacyNotificationApp(): React.JSX.Element {
+  const privacyState = getPrivacyState()
+  const copy = copyByState[privacyState]
+
+  return (
+    <main className="flex h-full w-full items-start justify-center overflow-hidden bg-transparent">
+      <Card
+        size="sm"
+        className="group h-full w-full overflow-hidden rounded-none border border-border bg-background py-0 shadow-[0_10px_24px_rgba(15,23,42,0.14)]"
+      >
+        <CardContent className="relative flex h-full items-center gap-3 px-3.5">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="absolute top-2 right-2 h-5 w-5 rounded-none p-0 opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+            onClick={() => window.close()}
+            aria-label="Dismiss"
+          >
+            <span className="text-[11px] leading-none">x</span>
+          </Button>
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border border-border bg-muted/70">
+            <img src={logoImage} alt="" className="h-4 w-4 object-contain dark:invert-0 invert" />
+          </div>
+          <p className="min-w-0 text-[12.5px] font-medium tracking-[0.01em] text-foreground">
+            {copy.message}
+          </p>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/src/renderer/privacy-notification.html
+++ b/src/renderer/privacy-notification.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en" suppressHydrationWarning>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+    />
+    <style>
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: transparent;
+      }
+    </style>
+    <title>MemoryLane</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./privacy-notification.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/privacy-notification.tsx
+++ b/src/renderer/privacy-notification.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { ThemeProvider } from './components/theme-provider'
+import { PrivacyNotificationApp } from './pages/privacy-notification/PrivacyNotificationApp'
+import './index.css'
+
+const root = document.getElementById('root')
+if (root === null) throw new Error('Root element not found')
+
+createRoot(root).render(
+  <StrictMode>
+    <ThemeProvider>
+      <PrivacyNotificationApp />
+    </ThemeProvider>
+  </StrictMode>,
+)


### PR DESCRIPTION
## Summary
- add a renderer-backed frameless privacy mode popup notification
- simplify the popup to a compact single-line message with hover dismiss
- handle fast privacy state switches by replacing stale popup windows safely

## Verification
- npm run build
- npm test -- --run src/main/capture-blacklist-coordinator.test.ts