### PR TITLE
Fix Windows auto-update when MemoryLane MCP is in use

### DIFF
--- a/src/main/ui/tray.ts
+++ b/src/main/ui/tray.ts
@@ -113,7 +113,7 @@ export const updateTrayMenu = async (): Promise<void> => {
   const contextMenu = Menu.buildFromTemplate([
     ...(updateState === 'ready'
       ? [
-          { label: 'Install Update Now (Restart)', click: () => quitAndInstall() },
+          { label: 'Install Update Now (Restart)', click: () => void quitAndInstall() },
           { type: 'separator' as const },
         ]
       : updateState === 'downloading'

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,6 +1,7 @@
 import { app, Notification } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import log from './logger'
+import { confirmWindowsUpdateInstall } from './windows-update-install'
 
 export type UpdateState = 'idle' | 'downloading' | 'ready'
 let state: UpdateState = 'idle'
@@ -19,11 +20,16 @@ const isAutoUpdateDisabled = (): boolean => {
   return ['1', 'true', 'yes', 'on'].includes(normalizedValue)
 }
 
-export const quitAndInstall = (): void => {
+export const quitAndInstall = async (): Promise<void> => {
   if (reminderInterval) {
     clearInterval(reminderInterval)
     reminderInterval = null
   }
+
+  if (!(await confirmWindowsUpdateInstall(process.execPath))) {
+    return
+  }
+
   log.info('[Updater] Requesting quit-and-install')
   // isForceRunAfter=true is required for tray apps that have no main window,
   // otherwise the quit sequence can stall.
@@ -48,7 +54,7 @@ const showUpdateNotification = (version: string): void => {
     body: `Version ${version} is ready. Click to restart and update.`,
     silent: true,
   })
-  currentNotification.on('click', () => quitAndInstall())
+  currentNotification.on('click', () => void quitAndInstall())
   currentNotification.show()
 }
 

--- a/src/main/windows-update-blockers.test.ts
+++ b/src/main/windows-update-blockers.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { formatBlockingHostNames, type UpdateBlockingMcpProcess } from './windows-update-blockers'
+
+function createBlocker(hostName: string | null, pid: number): UpdateBlockingMcpProcess {
+  return {
+    pid,
+    commandLine: 'MemoryLane.exe out/main/mcp-entry.js',
+    host: hostName ? { pid: pid + 1000, name: hostName } : null,
+  }
+}
+
+describe('formatBlockingHostNames', () => {
+  it('deduplicates names and strips .exe suffixes', () => {
+    const result = formatBlockingHostNames([
+      createBlocker('Claude.exe', 1),
+      createBlocker('claude.EXE', 2),
+      createBlocker('Cursor.exe', 3),
+    ])
+
+    expect(result).toEqual(['Claude', 'Cursor'])
+  })
+
+  it('ignores blockers without a resolved host', () => {
+    const result = formatBlockingHostNames([createBlocker(null, 1)])
+
+    expect(result).toEqual([])
+  })
+})

--- a/src/main/windows-update-blockers.ts
+++ b/src/main/windows-update-blockers.ts
@@ -1,0 +1,173 @@
+import { execFileSync } from 'node:child_process'
+
+export interface UpdateBlockingHostProcess {
+  pid: number
+  name: string
+}
+
+export interface UpdateBlockingMcpProcess {
+  pid: number
+  commandLine: string
+  host: UpdateBlockingHostProcess | null
+}
+
+interface RawMcpProcess {
+  pid: number
+  parentPid: number
+  name: string
+  executablePath: string | null
+  commandLine: string
+}
+
+function escapePowerShellLiteral(value: string): string {
+  return value.replace(/'/g, "''")
+}
+
+function encodePowerShellScript(script: string): string {
+  return Buffer.from(script, 'utf16le').toString('base64')
+}
+
+function runPowerShellLines(script: string): string[] {
+  const stdout = execFileSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-EncodedCommand',
+      encodePowerShellScript(script),
+    ],
+    {
+      encoding: 'utf-8',
+      timeout: 7_500,
+      maxBuffer: 512 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
+function parseMcpProcessLines(lines: string[]): RawMcpProcess[] {
+  return lines.flatMap((line) => {
+    const [pidText, parentPidText, name, executablePath, ...commandLineParts] = line.split('\t')
+    const pid = Number.parseInt(pidText ?? '', 10)
+    const parentPid = Number.parseInt(parentPidText ?? '', 10)
+    if (!Number.isFinite(pid) || !Number.isFinite(parentPid) || !name) return []
+
+    return [
+      {
+        pid,
+        parentPid,
+        name,
+        executablePath: executablePath || null,
+        commandLine: commandLineParts.join('\t'),
+      } satisfies RawMcpProcess,
+    ]
+  })
+}
+
+function queryMcpProcesses(execPath: string): RawMcpProcess[] {
+  const escapedExecPath = escapePowerShellLiteral(execPath)
+  const script = [
+    "$ErrorActionPreference = 'Stop'",
+    "$ProgressPreference = 'SilentlyContinue'",
+    `$targetExe = '${escapedExecPath}'`,
+    '$processes = Get-CimInstance Win32_Process | Where-Object {',
+    "  $_.ExecutablePath -eq $targetExe -and $_.CommandLine -like '*mcp-entry.js*'",
+    '}',
+    'foreach ($proc in $processes) {',
+    "  $commandLine = if ($null -eq $proc.CommandLine) { '' } else { [string]$proc.CommandLine }",
+    '  $safeCommandLine = $commandLine -replace "`t", " "',
+    '  $safeExecutablePath = if ($null -eq $proc.ExecutablePath) { \'\' } else { ([string]$proc.ExecutablePath) -replace "`t", " " }',
+    '  [Console]::Out.WriteLine("$([int]$proc.ProcessId)`t$([int]$proc.ParentProcessId)`t$([string]$proc.Name)`t$safeExecutablePath`t$safeCommandLine")',
+    '}',
+  ].join('\n')
+
+  return parseMcpProcessLines(runPowerShellLines(script))
+}
+
+function queryHostNamesByPid(pids: number[]): Map<number, string> {
+  if (pids.length === 0) return new Map()
+
+  const pidList = [...new Set(pids)].join(', ')
+  const script = [
+    "$ErrorActionPreference = 'Stop'",
+    "$ProgressPreference = 'SilentlyContinue'",
+    `$targetPids = @(${pidList})`,
+    '$processes = Get-CimInstance Win32_Process | Where-Object {',
+    '  $targetPids -contains [int]$_.ProcessId',
+    '}',
+    'foreach ($proc in $processes) {',
+    '  [Console]::Out.WriteLine("$([int]$proc.ProcessId)`t$([string]$proc.Name)")',
+    '}',
+  ].join('\n')
+
+  const entries = runPowerShellLines(script).flatMap((line) => {
+    const [pidText, name] = line.split('\t')
+    const pid = Number.parseInt(pidText ?? '', 10)
+    if (!Number.isFinite(pid) || !name) return []
+    return [[pid, name] as const]
+  })
+
+  return new Map(entries)
+}
+
+export function findWindowsUpdateBlockingMcpProcesses(
+  execPath: string,
+): UpdateBlockingMcpProcess[] {
+  const mcpProcesses = queryMcpProcesses(execPath)
+  const hostNamesByPid = queryHostNamesByPid(
+    mcpProcesses.map((processInfo) => processInfo.parentPid),
+  )
+
+  return mcpProcesses.map((processInfo) => ({
+    pid: processInfo.pid,
+    commandLine: processInfo.commandLine,
+    host: hostNamesByPid.has(processInfo.parentPid)
+      ? {
+          pid: processInfo.parentPid,
+          name: hostNamesByPid.get(processInfo.parentPid)!,
+        }
+      : null,
+  }))
+}
+
+export function formatBlockingHostNames(blockers: UpdateBlockingMcpProcess[]): string[] {
+  const names = new Map<string, string>()
+
+  for (const blocker of blockers) {
+    const hostName = blocker.host?.name?.trim()
+    if (!hostName) continue
+
+    const normalized = hostName.replace(/\.exe$/i, '')
+    const label = normalized || hostName
+    const key = label.toLowerCase()
+    const existing = names.get(key)
+
+    if (!existing || (/^[A-Z]/.test(label) && !/^[A-Z]/.test(existing))) {
+      names.set(key, label)
+    }
+  }
+
+  return [...names.values()].sort((left, right) => left.localeCompare(right))
+}
+
+export function stopWindowsHostProcesses(blockers: UpdateBlockingMcpProcess[]): void {
+  const hostPids = [
+    ...new Set(blockers.map((blocker) => blocker.host?.pid).filter((pid) => pid != null)),
+  ]
+  if (hostPids.length === 0) return
+
+  for (const pid of hostPids) {
+    execFileSync('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
+      stdio: 'ignore',
+      timeout: 7_500,
+      maxBuffer: 128 * 1024,
+    })
+  }
+}

--- a/src/main/windows-update-install.ts
+++ b/src/main/windows-update-install.ts
@@ -1,0 +1,103 @@
+import { dialog } from 'electron'
+import log from './logger'
+import {
+  findWindowsUpdateBlockingMcpProcesses,
+  formatBlockingHostNames,
+  stopWindowsHostProcesses,
+} from './windows-update-blockers'
+
+function formatHostLabel(hostName: string): string {
+  return /^[a-z]+$/.test(hostName) ? hostName.charAt(0).toUpperCase() + hostName.slice(1) : hostName
+}
+
+function buildHostCloseButtonLabel(hostNames: string[]): string {
+  const labels = hostNames.map(formatHostLabel)
+
+  if (labels.length === 1) {
+    return `Close ${labels[0]}`
+  }
+
+  return 'Close Apps'
+}
+
+function buildBlockingHostsDetail(hostNames: string[]): string {
+  if (hostNames.length === 0) {
+    return 'Please close the app using MemoryLane, then click Try Again.'
+  }
+
+  const labels = hostNames.map(formatHostLabel)
+
+  if (labels.length === 1) {
+    return `Close ${labels[0]}, then click Try Again.`
+  }
+
+  const hostList = labels.map((name) => `- ${name}`).join('\n')
+  return `Close these apps, then click Try Again:\n${hostList}`
+}
+
+export async function confirmWindowsUpdateInstall(execPath: string): Promise<boolean> {
+  if (process.platform !== 'win32') return true
+
+  let installBlocked = true
+  while (installBlocked) {
+    let blockers
+    try {
+      blockers = findWindowsUpdateBlockingMcpProcesses(execPath)
+    } catch (error) {
+      log.warn('[Updater] Failed to inspect MCP helper processes before install', error)
+      return true
+    }
+
+    if (blockers.length === 0) {
+      installBlocked = false
+      continue
+    }
+
+    const hostNames = formatBlockingHostNames(blockers)
+    const buttons = ['Try Again', 'Cancel']
+    const closeHostButtonIndex =
+      hostNames.length > 0 ? buttons.push(buildHostCloseButtonLabel(hostNames)) - 1 : -1
+
+    const hostLabels = hostNames.map(formatHostLabel)
+    const title =
+      hostLabels.length === 1
+        ? `Close ${hostLabels[0]} to Update MemoryLane`
+        : 'Close Apps to Update MemoryLane'
+    const message =
+      hostLabels.length === 1
+        ? `MemoryLane needs ${hostLabels[0]} to be closed before the update can continue.`
+        : 'MemoryLane needs some apps to be closed before the update can continue.'
+
+    const { response } = await dialog.showMessageBox({
+      type: 'warning',
+      buttons,
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true,
+      title,
+      message,
+      detail: buildBlockingHostsDetail(hostNames),
+    })
+
+    if (response === 1) return false
+
+    if (response === closeHostButtonIndex && closeHostButtonIndex >= 0) {
+      try {
+        stopWindowsHostProcesses(blockers)
+      } catch (error) {
+        log.warn('[Updater] Failed to stop host app before install', error)
+        await dialog.showMessageBox({
+          type: 'error',
+          buttons: ['OK'],
+          defaultId: 0,
+          noLink: true,
+          title: 'Could Not Close the App',
+          message: 'MemoryLane could not close the app automatically.',
+          detail: 'Please close it yourself, then click Try Again.',
+        })
+      }
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
## Summary
- detect running MemoryLane.exe ... mcp-entry.js helper processes on Windows before install
- block quitAndInstall() behind a user-friendly dialog that asks the user to close the host app or lets MemoryLane close it
- keep the updater async flow wired from the tray and notification entry points

## Verification
- ran the Windows blocker detection logic against the live OS process list
- ran 
ode ./scripts/enode.js ./node_modules/vitest/vitest.mjs src/main/windows-update-blockers.test.ts
- ran 
px eslint src/main/ui/tray.ts src/main/updater.ts src/main/windows-update-install.ts src/main/windows-update-blockers.ts src/main/windows-update-blockers.test.ts

Closes #95