### PR TITLE
fix(integrations): rewrite stale MCP entries even when env was stripped

### DIFF
--- a/src/main/integrations/claude-code.ts
+++ b/src/main/integrations/claude-code.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import log from '../logger'
+import { detectStaleSignal, isCurrentCliEntry } from './migration-utils'
 
 interface ClaudeCodeSettings {
   mcpServers?: Record<string, MCPServerEntry>
@@ -76,10 +77,6 @@ function buildMCPEntry(): MCPServerEntry {
   }
 }
 
-function isOldElectronEntry(entry: MCPServerEntry): boolean {
-  return entry.env?.ELECTRON_RUN_AS_NODE === '1'
-}
-
 /**
  * Check whether MemoryLane is currently registered in Claude Code's settings on disk.
  */
@@ -89,20 +86,39 @@ export function isMcpAddedToClaudeCode(): boolean {
 }
 
 /**
- * If the old Electron-based MCP entry exists, replace it with the CLI entry.
+ * If a stale (pre-v0.18) MemoryLane MCP entry exists, replace it with the CLI entry.
+ * Best-effort: never throws — see migrateClaudeDesktop for rationale.
  */
 export function migrateClaudeCode(): void {
   const settingsPath = getClaudeCodeSettingsPath()
   try {
+    if (!fs.existsSync(settingsPath)) {
+      log.debug(`[Claude Code Integration] No settings at ${settingsPath}, skipping migration`)
+      return
+    }
     const settings = readSettings(settingsPath)
     const existing = settings.mcpServers?.[MCP_SERVER_KEY]
-    if (!existing || !isOldElectronEntry(existing)) return
+    if (!existing) {
+      log.debug('[Claude Code Integration] No memorylane entry present, nothing to migrate')
+      return
+    }
+    if (isCurrentCliEntry(existing)) {
+      log.debug('[Claude Code Integration] memorylane entry already current, nothing to migrate')
+      return
+    }
+    const signal = detectStaleSignal(existing)
+    if (!signal) {
+      log.info(
+        '[Claude Code Integration] memorylane entry present but does not match a known stale shape, leaving it alone',
+      )
+      return
+    }
 
     settings.mcpServers![MCP_SERVER_KEY] = buildMCPEntry()
     writeSettings(settingsPath, settings)
-    log.info('[Claude Code Integration] Migrated from Electron MCP to CLI')
-  } catch {
-    // best-effort
+    log.info(`[Claude Code Integration] Migrated from Electron MCP to CLI (signal: ${signal})`)
+  } catch (error) {
+    log.warn('[Claude Code Integration] Migration failed:', error)
   }
 }
 

--- a/src/main/integrations/claude-desktop.ts
+++ b/src/main/integrations/claude-desktop.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import log from '../logger'
+import { detectStaleSignal, isCurrentCliEntry } from './migration-utils'
 
 interface ClaudeDesktopConfig {
   mcpServers?: Record<string, MCPServerEntry>
@@ -91,10 +92,6 @@ function buildMCPEntry(): MCPServerEntry {
   }
 }
 
-function isOldElectronEntry(entry: MCPServerEntry): boolean {
-  return entry.env?.ELECTRON_RUN_AS_NODE === '1'
-}
-
 /**
  * Check whether MemoryLane is currently registered in Claude Desktop's config on disk.
  */
@@ -104,20 +101,40 @@ export function isMcpAddedToClaudeDesktop(): boolean {
 }
 
 /**
- * If the old Electron-based MCP entry exists, replace it with the CLI entry.
+ * If a stale (pre-v0.18) MemoryLane MCP entry exists, replace it with the CLI entry.
+ * Best-effort: never throws — Claude Desktop config may be missing, malformed,
+ * or unwritable, and none of those should block app startup.
  */
 export function migrateClaudeDesktop(): void {
   const configPath = getClaudeConfigPath()
   try {
+    if (!fs.existsSync(configPath)) {
+      log.debug(`[Claude Integration] No config at ${configPath}, skipping migration`)
+      return
+    }
     const config = readClaudeConfig(configPath)
     const existing = config.mcpServers?.[MCP_SERVER_KEY]
-    if (!existing || !isOldElectronEntry(existing)) return
+    if (!existing) {
+      log.debug('[Claude Integration] No memorylane entry present, nothing to migrate')
+      return
+    }
+    if (isCurrentCliEntry(existing)) {
+      log.debug('[Claude Integration] memorylane entry already current, nothing to migrate')
+      return
+    }
+    const signal = detectStaleSignal(existing)
+    if (!signal) {
+      log.info(
+        '[Claude Integration] memorylane entry present but does not match a known stale shape, leaving it alone',
+      )
+      return
+    }
 
     config.mcpServers![MCP_SERVER_KEY] = buildMCPEntry()
     writeClaudeConfig(configPath, config)
-    log.info('[Claude Integration] Migrated from Electron MCP to CLI')
-  } catch {
-    // best-effort
+    log.info(`[Claude Integration] Migrated from Electron MCP to CLI (signal: ${signal})`)
+  } catch (error) {
+    log.warn('[Claude Integration] Migration failed:', error)
   }
 }
 

--- a/src/main/integrations/cursor.ts
+++ b/src/main/integrations/cursor.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import log from '../logger'
+import { detectStaleSignal, isCurrentCliEntry } from './migration-utils'
 
 interface CursorMCPConfig {
   mcpServers?: Record<string, MCPServerEntry>
@@ -74,10 +75,6 @@ function buildMCPEntry(): MCPServerEntry {
   }
 }
 
-function isOldElectronEntry(entry: MCPServerEntry): boolean {
-  return entry.env?.ELECTRON_RUN_AS_NODE === '1'
-}
-
 /**
  * Check whether MemoryLane is currently registered in Cursor's MCP config on disk.
  */
@@ -87,20 +84,39 @@ export function isMcpAddedToCursor(): boolean {
 }
 
 /**
- * If the old Electron-based MCP entry exists, replace it with the CLI entry.
+ * If a stale (pre-v0.18) MemoryLane MCP entry exists, replace it with the CLI entry.
+ * Best-effort: never throws — see migrateClaudeDesktop for rationale.
  */
 export function migrateCursor(): void {
   const configPath = getCursorConfigPath()
   try {
+    if (!fs.existsSync(configPath)) {
+      log.debug(`[Cursor Integration] No config at ${configPath}, skipping migration`)
+      return
+    }
     const config = readCursorConfig(configPath)
     const existing = config.mcpServers?.[MCP_SERVER_KEY]
-    if (!existing || !isOldElectronEntry(existing)) return
+    if (!existing) {
+      log.debug('[Cursor Integration] No memorylane entry present, nothing to migrate')
+      return
+    }
+    if (isCurrentCliEntry(existing)) {
+      log.debug('[Cursor Integration] memorylane entry already current, nothing to migrate')
+      return
+    }
+    const signal = detectStaleSignal(existing)
+    if (!signal) {
+      log.info(
+        '[Cursor Integration] memorylane entry present but does not match a known stale shape, leaving it alone',
+      )
+      return
+    }
 
     config.mcpServers![MCP_SERVER_KEY] = buildMCPEntry()
     writeCursorConfig(configPath, config)
-    log.info('[Cursor Integration] Migrated from Electron MCP to CLI')
-  } catch {
-    // best-effort
+    log.info(`[Cursor Integration] Migrated from Electron MCP to CLI (signal: ${signal})`)
+  } catch (error) {
+    log.warn('[Cursor Integration] Migration failed:', error)
   }
 }
 

--- a/src/main/integrations/migration-utils.test.ts
+++ b/src/main/integrations/migration-utils.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import { detectStaleSignal, isStaleMcpEntry, isCurrentCliEntry } from './migration-utils'
+
+describe('isStaleMcpEntry', () => {
+  describe('returns true for old in-asar entries', () => {
+    it('detects macOS entry with full env, command, and args (the original shape)', () => {
+      const entry = {
+        command: '/Applications/MemoryLane.app/Contents/MacOS/MemoryLane',
+        args: ['/Applications/MemoryLane.app/Contents/Resources/app.asar/out/main/mcp-entry.js'],
+        env: { ELECTRON_RUN_AS_NODE: '1' },
+      }
+      expect(isStaleMcpEntry(entry)).toBe(true)
+    })
+
+    it('detects macOS entry where env was stripped (the screenshot case)', () => {
+      const entry = {
+        command: '/Applications/MemoryLane.app/Contents/MacOS/MemoryLane',
+        args: ['/Applications/MemoryLane.app/Contents/Resources/app.asar/out/main/mcp-entry.js'],
+      }
+      expect(isStaleMcpEntry(entry)).toBe(true)
+    })
+
+    it('detects MemoryLane Enterprise edition on macOS', () => {
+      const entry = {
+        command: '/Applications/MemoryLane Enterprise.app/Contents/MacOS/MemoryLane Enterprise',
+        args: [
+          '/Applications/MemoryLane Enterprise.app/Contents/Resources/app.asar/out/main/mcp-entry.js',
+        ],
+      }
+      expect(isStaleMcpEntry(entry)).toBe(true)
+    })
+
+    it('detects Windows entry by command path and mcp-entry.js arg', () => {
+      const entry = {
+        command: 'C:\\Program Files\\MemoryLane\\MemoryLane.exe',
+        args: ['C:\\Program Files\\MemoryLane\\resources\\app.asar\\out\\main\\mcp-entry.js'],
+      }
+      expect(isStaleMcpEntry(entry)).toBe(true)
+    })
+
+    it('detects entry with only the env signal (command/args replaced by user)', () => {
+      const entry = {
+        command: '/usr/local/bin/node',
+        args: ['/some/wrapper.js'],
+        env: { ELECTRON_RUN_AS_NODE: '1' },
+      }
+      expect(isStaleMcpEntry(entry)).toBe(true)
+    })
+
+    it('detects entry by mcp-entry.js arg alone, even when command was renamed', () => {
+      const entry = {
+        command: 'electron',
+        args: ['out/main/mcp-entry.js'],
+      }
+      expect(isStaleMcpEntry(entry)).toBe(true)
+    })
+
+    it('detects entry by packaged binary command alone (args wiped)', () => {
+      const entry = {
+        command: '/Applications/MemoryLane.app/Contents/MacOS/MemoryLane',
+        args: [],
+      }
+      expect(isStaleMcpEntry(entry)).toBe(true)
+    })
+  })
+
+  describe('returns false for current and unrelated entries', () => {
+    it('does not flag the current CLI entry', () => {
+      const entry = {
+        command: 'npx',
+        args: ['-y', '-p', '@deusxmachina-dev/memorylane-cli', 'memorylane-mcp'],
+      }
+      expect(isStaleMcpEntry(entry)).toBe(false)
+    })
+
+    it('does not flag the current CLI entry with stdio type', () => {
+      const entry = {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '-p', '@deusxmachina-dev/memorylane-cli', 'memorylane-mcp'],
+      }
+      expect(isStaleMcpEntry(entry)).toBe(false)
+    })
+
+    it('does not flag an unrelated MCP server', () => {
+      const entry = {
+        command: 'node',
+        args: ['/some/other/server.js'],
+      }
+      expect(isStaleMcpEntry(entry)).toBe(false)
+    })
+
+    it('does not flag an entry whose env has a different value', () => {
+      const entry = {
+        command: 'node',
+        args: ['/some/server.js'],
+        env: { ELECTRON_RUN_AS_NODE: '0', SOMETHING_ELSE: '1' },
+      }
+      expect(isStaleMcpEntry(entry)).toBe(false)
+    })
+
+    it('handles undefined entry', () => {
+      expect(isStaleMcpEntry(undefined)).toBe(false)
+    })
+
+    it('handles malformed entry (missing fields)', () => {
+      expect(isStaleMcpEntry({} as never)).toBe(false)
+    })
+
+    it('does not flag an entry whose command happens to contain MemoryLane in a folder name', () => {
+      const entry = {
+        command: '/Users/me/MemoryLane-projects/bin/some-server',
+        args: [],
+      }
+      expect(isStaleMcpEntry(entry)).toBe(false)
+    })
+  })
+})
+
+describe('detectStaleSignal', () => {
+  it('reports the env signal when only env matches', () => {
+    expect(
+      detectStaleSignal({
+        command: 'node',
+        args: ['/x.js'],
+        env: { ELECTRON_RUN_AS_NODE: '1' },
+      }),
+    ).toBe('electron-run-as-node-env')
+  })
+
+  it('reports the args signal when only args match', () => {
+    expect(
+      detectStaleSignal({
+        command: 'electron',
+        args: ['out/main/mcp-entry.js'],
+      }),
+    ).toBe('mcp-entry-js-arg')
+  })
+
+  it('reports the binary signal when only command matches', () => {
+    expect(
+      detectStaleSignal({
+        command: '/Applications/MemoryLane.app/Contents/MacOS/MemoryLane',
+        args: [],
+      }),
+    ).toBe('packaged-app-binary')
+  })
+})
+
+describe('isCurrentCliEntry', () => {
+  it('matches the canonical CLI entry', () => {
+    expect(
+      isCurrentCliEntry({
+        command: 'npx',
+        args: ['-y', '-p', '@deusxmachina-dev/memorylane-cli', 'memorylane-mcp'],
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects an npx entry pointing at a different package', () => {
+    expect(
+      isCurrentCliEntry({
+        command: 'npx',
+        args: ['-y', 'some-other-mcp'],
+      }),
+    ).toBe(false)
+  })
+
+  it('rejects a non-npx command', () => {
+    expect(
+      isCurrentCliEntry({
+        command: 'node',
+        args: ['@deusxmachina-dev/memorylane-cli'],
+      }),
+    ).toBe(false)
+  })
+
+  it('handles undefined', () => {
+    expect(isCurrentCliEntry(undefined)).toBe(false)
+  })
+})

--- a/src/main/integrations/migration-utils.ts
+++ b/src/main/integrations/migration-utils.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared helpers for detecting old vs current MemoryLane MCP entries
+ * across Claude Desktop, Claude Code, and Cursor configs.
+ *
+ * Background: in v0.18.0 the MCP server moved out of the Electron app
+ * (out/main/mcp-entry.js running under ELECTRON_RUN_AS_NODE=1) and into
+ * a standalone CLI invoked via `npx @deusxmachina-dev/memorylane-cli`.
+ * Pre-v0.18 entries left over in user config files now point at a script
+ * that no longer exists and surface as "Server disconnected" in clients.
+ *
+ * `isStaleMcpEntry` recognizes those old entries by multiple signals so
+ * we can rewrite them on next launch even if `env` got stripped or
+ * normalized by the client UI.
+ */
+
+export interface McpEntryShape {
+  command?: unknown
+  args?: unknown
+  env?: unknown
+}
+
+/**
+ * Detection signal: which fingerprint matched. Returned for diagnostics
+ * so logs can pinpoint why an entry was treated as stale.
+ */
+export type StaleSignal = 'electron-run-as-node-env' | 'mcp-entry-js-arg' | 'packaged-app-binary'
+
+/**
+ * Returns the matched signal if `entry` looks like a pre-v0.18 in-asar
+ * MemoryLane MCP entry, or `null` if it does not.
+ *
+ * Multiple independent signals are checked because real-world configs
+ * have been observed in shapes the original `env`-only check missed:
+ * Claude Desktop's UI re-serializes entries without preserving env, and
+ * users sometimes hand-edit the file.
+ */
+export function detectStaleSignal(entry: McpEntryShape | undefined): StaleSignal | null {
+  if (!entry || typeof entry !== 'object') return null
+
+  // Signal 1: ELECTRON_RUN_AS_NODE env var (the original detection).
+  const env = entry.env
+  if (env && typeof env === 'object' && !Array.isArray(env)) {
+    const electronEnv = (env as Record<string, unknown>).ELECTRON_RUN_AS_NODE
+    if (electronEnv === '1') return 'electron-run-as-node-env'
+  }
+
+  // Signal 2: any arg references the deleted mcp-entry.js script.
+  // No other MCP server in the wild ships a file with that exact name,
+  // so this is the most specific fingerprint.
+  if (Array.isArray(entry.args)) {
+    for (const arg of entry.args) {
+      if (typeof arg !== 'string') continue
+      if (arg.endsWith('mcp-entry.js') || arg.includes('out/main/mcp-entry')) {
+        return 'mcp-entry-js-arg'
+      }
+    }
+  }
+
+  // Signal 3: command points at the packaged MemoryLane Electron binary
+  // (covers both 'MemoryLane' and 'MemoryLane Enterprise' editions on
+  // macOS and Windows). Catches entries where args were edited away but
+  // the command itself still references the host app.
+  if (typeof entry.command === 'string' && isPackagedMemoryLaneBinary(entry.command)) {
+    return 'packaged-app-binary'
+  }
+
+  return null
+}
+
+/** Convenience boolean wrapper around `detectStaleSignal`. */
+export function isStaleMcpEntry(entry: McpEntryShape | undefined): boolean {
+  return detectStaleSignal(entry) !== null
+}
+
+/**
+ * Returns true if the entry already points at the new CLI invocation,
+ * so the migration can skip rewriting it on every launch.
+ */
+export function isCurrentCliEntry(entry: McpEntryShape | undefined): boolean {
+  if (!entry || typeof entry !== 'object') return false
+  if (entry.command !== 'npx') return false
+  if (!Array.isArray(entry.args)) return false
+  return entry.args.some(
+    (arg) => typeof arg === 'string' && arg.includes('@deusxmachina-dev/memorylane-cli'),
+  )
+}
+
+function isPackagedMemoryLaneBinary(command: string): boolean {
+  // macOS: .../MemoryLane.app/Contents/MacOS/MemoryLane
+  //        .../MemoryLane Enterprise.app/Contents/MacOS/MemoryLane Enterprise
+  if (command.includes('.app/Contents/MacOS/')) {
+    const tail = command.split('/').pop() ?? ''
+    if (tail === 'MemoryLane' || tail === 'MemoryLane Enterprise') return true
+  }
+  // Windows: ...\MemoryLane.exe or ...\MemoryLane Enterprise.exe
+  const winTail = command.split(/[\\/]/).pop() ?? ''
+  if (winTail === 'MemoryLane.exe' || winTail === 'MemoryLane Enterprise.exe') return true
+  return false
+}


### PR DESCRIPTION
## Summary

- The v0.18 startup migration only matched MCP entries whose `env` block still had `ELECTRON_RUN_AS_NODE=1`. Real-world Claude Desktop / Claude Code / Cursor configs frequently lose that field (UI re-serialization, hand edits), so the broken in-asar `memorylane` entry survives the migration and surfaces as `Server disconnected` after upgrading past v0.18.
- New `migration-utils.ts` detects stale entries via three independent signals — `ELECTRON_RUN_AS_NODE` env, any arg ending in `mcp-entry.js` / containing `out/main/mcp-entry`, or a `command` pointing at the packaged `MemoryLane[ Enterprise].app` binary on macOS / `.exe` on Windows. Any match triggers a rewrite.
- Replaced the silent `catch {}` in all three integrations with branch-by-branch logging (`debug` for skips, `info` for successful migration with the matched signal, `warn` for caught errors), so future failures are diagnosable from the main process log.
- Added 21 unit tests covering the screenshot shape (env stripped), Enterprise edition, Windows paths, env-only entries, idempotency against the current CLI entry, and explicit negatives for unrelated MCP servers.

## Test plan

- [x] `npm test -- --run src/main/integrations/migration-utils.test.ts` → 21/21 passing
- [x] `npm test -- --run src/main/integrations/` → 29/29 passing across all integrations
- [x] `npm run lint` → 0 errors
- [x] Manual repro: drop a stale `memorylane` entry (no env block) into `~/Library/Application Support/Claude/claude_desktop_config.json`, launch the app, confirm the entry is rewritten to the `npx` invocation and the log shows `[Claude Integration] Migrated from Electron MCP to CLI (signal: mcp-entry-js-arg)`
- [ ] Repeat the manual repro for `~/.claude/settings.json` (Claude Code) and `~/.cursor/mcp.json` (Cursor)
- [x] Idempotency: launch a second time, confirm the log shows `memorylane entry already current, nothing to migrate` and the file is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)