### PR TITLE
feat: periodic database upload sync for enterprise

### DIFF
--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -10,7 +10,7 @@ vi.mock('../logger', () => ({
 }))
 
 import { EnterpriseAccessProvider } from './enterprise-access-provider'
-import { ENTERPRISE_LICENSE_CONFIG } from '../../shared/constants'
+import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import type { DeviceIdentity } from '../settings/device-identity'
 
 describe('EnterpriseAccessProvider', () => {
@@ -44,7 +44,7 @@ describe('EnterpriseAccessProvider', () => {
     })
 
     await provider.activateEnterpriseLicense('ACT-123')
-    await vi.advanceTimersByTimeAsync(ENTERPRISE_LICENSE_CONFIG.POLL_INTERVAL_MS)
+    await vi.advanceTimersByTimeAsync(ENTERPRISE_BACKEND_CONFIG.POLL_INTERVAL_MS)
 
     expect(updates[0]?.status).toBe('activating')
     expect(updates.at(-1)?.status).toBe('activated')

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -1,4 +1,4 @@
-import { ENTERPRISE_LICENSE_CONFIG } from '../../shared/constants'
+import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import log from '../logger'
 import type { DeviceIdentity } from '../settings/device-identity'
 import { BaseAccessProvider } from './base-access-provider'
@@ -79,7 +79,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     )
 
     const response = await fetch(
-      new URL('/license/activate', ENTERPRISE_LICENSE_CONFIG.BACKEND_URL),
+      new URL('/license/activate', ENTERPRISE_BACKEND_CONFIG.BACKEND_URL),
       {
         method: 'POST',
         headers: {
@@ -122,7 +122,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
 
     this.refreshTimer = setInterval(() => {
       void this.refreshAccessState()
-    }, ENTERPRISE_LICENSE_CONFIG.STATUS_REFRESH_INTERVAL_MS)
+    }, ENTERPRISE_BACKEND_CONFIG.STATUS_REFRESH_INTERVAL_MS)
     this.refreshTimer.unref?.()
   }
 
@@ -140,7 +140,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
 
     this.pollTimer = setInterval(() => {
       void this.pollForActivation(deviceId)
-    }, ENTERPRISE_LICENSE_CONFIG.POLL_INTERVAL_MS)
+    }, ENTERPRISE_BACKEND_CONFIG.POLL_INTERVAL_MS)
 
     this.timeoutTimer = setTimeout(() => {
       log.warn('[EnterpriseAccess] Activation polling timed out')
@@ -151,7 +151,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
           error: 'Activation timed out while waiting for key provisioning.',
         }),
       )
-    }, ENTERPRISE_LICENSE_CONFIG.ACTIVATION_TIMEOUT_MS)
+    }, ENTERPRISE_BACKEND_CONFIG.ACTIVATION_TIMEOUT_MS)
   }
 
   private async pollForActivation(deviceId: string): Promise<void> {
@@ -187,7 +187,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   }
 
   private async fetchEnterpriseStatus(deviceId: string): Promise<boolean> {
-    const url = new URL('/license/status', ENTERPRISE_LICENSE_CONFIG.BACKEND_URL)
+    const url = new URL('/license/status', ENTERPRISE_BACKEND_CONFIG.BACKEND_URL)
     url.searchParams.set('device_id', deviceId)
 
     const response = await fetch(url.toString())
@@ -204,7 +204,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   }
 
   private async fetchEnterpriseKey(deviceId: string): Promise<string | null> {
-    const url = new URL('/license/key', ENTERPRISE_LICENSE_CONFIG.BACKEND_URL)
+    const url = new URL('/license/key', ENTERPRISE_BACKEND_CONFIG.BACKEND_URL)
     url.searchParams.set('device_id', deviceId)
 
     const response = await fetch(url.toString())

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,9 +28,11 @@ import { SlackSemanticLayer } from './integrations/slack/semantic'
 import { PatternDetector } from './services/pattern-detector'
 import { UserContextBuilder } from './services/user-context-builder'
 import { RawDatabaseExportSync } from './services/raw-database-export-sync'
+import { DatabaseUploadSync } from './services/database-upload-sync'
 import { createMainRuntime, type MainRuntime } from './runtime'
 import { getAppDirectoryName } from './paths'
 import { loadAppEditionConfig } from './edition'
+import { ENTERPRISE_BACKEND_CONFIG } from '../shared/constants'
 
 // Keep single-instance behavior in packaged app, but allow dev to run
 // alongside production for local debugging.
@@ -70,6 +72,7 @@ let userContextBuilder: UserContextBuilder | null = null
 let patternDetector: PatternDetector | null = null
 let slackIntegrationService: SlackIntegrationService | null = null
 let rawDatabaseExportSync: RawDatabaseExportSync | null = null
+let databaseUploadSync: DatabaseUploadSync | null = null
 
 app.on('before-quit', () => {
   runtime?.accessProvider.stopPeriodicRefresh()
@@ -77,6 +80,7 @@ app.on('before-quit', () => {
     runtime?.dispose(),
     slackIntegrationService?.stop(),
     rawDatabaseExportSync?.stop(),
+    databaseUploadSync?.stop(),
   ])
 })
 
@@ -151,6 +155,16 @@ app.on('ready', async () => {
     getInstallationId: () => deviceIdentity.getPublicInstallationId(),
   })
   rawDatabaseExportSync.start()
+
+  if (editionConfig.edition === 'enterprise') {
+    databaseUploadSync = new DatabaseUploadSync({
+      storage: runtime.storage,
+      getDeviceId: () => deviceIdentity.getDeviceId(),
+      isActivated: () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false,
+      backendUrl: ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
+    })
+    databaseUploadSync.start()
+  }
 
   slackIntegrationService = new SlackIntegrationService(
     slackSettingsManager,

--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -1,0 +1,153 @@
+import * as fs from 'fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DatabaseUploadSync } from './database-upload-sync'
+
+function mockFetchResponse(status: number, body: object | string) {
+  return vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => (typeof body === 'object' ? body : JSON.parse(body)),
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  }))
+}
+
+describe('DatabaseUploadSync', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    globalThis.fetch = originalFetch
+  })
+
+  it('uploads database when activated', async () => {
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_123',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      backendUrl: 'http://localhost:8000/',
+    })
+
+    sync.start()
+    await vi.advanceTimersByTimeAsync?.(0).catch(() => undefined)
+    // Wait for the in-flight promise to settle
+    await sync.stop()
+
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url.toString()).toBe('http://localhost:8000/api/device/upload')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBeInstanceOf(FormData)
+  })
+
+  it('skips upload when not activated', async () => {
+    const fetchMock = mockFetchResponse(201, { ok: true })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => false,
+      backendUrl: 'http://localhost:8000/',
+    })
+
+    sync.start()
+    await sync.stop()
+
+    expect(backupToFile).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('cleans up temp file on upload failure', async () => {
+    const fetchMock = mockFetchResponse(500, 'server error')
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const tempFiles: string[] = []
+    const backupToFile = vi.fn(async (dest: string) => {
+      tempFiles.push(dest)
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      backendUrl: 'http://localhost:8000/',
+    })
+
+    sync.start()
+    await sync.stop()
+
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+    expect(tempFiles.length).toBe(1)
+    expect(fs.existsSync(tempFiles[0])).toBe(false)
+  })
+
+  it('cleans up temp file on backup failure', async () => {
+    const fetchMock = mockFetchResponse(201, { ok: true })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async () => {
+      throw new Error('backup failed')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      backendUrl: 'http://localhost:8000/',
+    })
+
+    sync.start()
+    await sync.stop()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('uploads on startup and on interval', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_1',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      backendUrl: 'http://localhost:8000/',
+      intervalMs: 1000,
+    })
+
+    sync.start()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(backupToFile).toHaveBeenCalledTimes(2)
+
+    await sync.stop()
+  })
+})

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -1,0 +1,126 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import log from '../logger'
+
+const DEFAULT_UPLOAD_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+export interface DatabaseUploadStorage {
+  backupToFile(destinationPath: string): Promise<void>
+}
+
+export interface DatabaseUploadSyncParams {
+  storage: DatabaseUploadStorage
+  getDeviceId: () => string
+  isActivated: () => boolean
+  backendUrl: string
+  intervalMs?: number
+}
+
+export class DatabaseUploadSync {
+  private readonly storage: DatabaseUploadStorage
+  private readonly getDeviceId: () => string
+  private readonly isActivated: () => boolean
+  private readonly backendUrl: string
+  private readonly intervalMs: number
+  private timer: ReturnType<typeof setInterval> | null = null
+  private uploadRunning = false
+  private rerunRequested = false
+  private inFlight: Promise<void> = Promise.resolve()
+
+  constructor(params: DatabaseUploadSyncParams) {
+    this.storage = params.storage
+    this.getDeviceId = params.getDeviceId
+    this.isActivated = params.isActivated
+    this.backendUrl = params.backendUrl
+    this.intervalMs = params.intervalMs ?? DEFAULT_UPLOAD_INTERVAL_MS
+  }
+
+  public start(): void {
+    if (this.timer !== null) {
+      return
+    }
+
+    this.timer = setInterval(() => {
+      void this.queueUpload('interval')
+    }, this.intervalMs)
+    this.timer.unref?.()
+
+    void this.queueUpload('startup')
+  }
+
+  public async stop(): Promise<void> {
+    if (this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+
+    await this.inFlight.catch(() => undefined)
+  }
+
+  private async queueUpload(reason: string): Promise<void> {
+    if (this.uploadRunning) {
+      this.rerunRequested = true
+      return this.inFlight
+    }
+
+    this.uploadRunning = true
+    let nextReason = reason
+    this.inFlight = (async () => {
+      do {
+        this.rerunRequested = false
+        await this.uploadOnce(nextReason)
+        nextReason = 'coalesced'
+      } while (this.rerunRequested)
+    })()
+      .catch((error) => {
+        log.error(`[DatabaseUploadSync] Upload failed (${reason}):`, error)
+      })
+      .finally(() => {
+        this.uploadRunning = false
+      })
+
+    return this.inFlight
+  }
+
+  private async uploadOnce(reason: string): Promise<void> {
+    if (!this.isActivated()) {
+      log.debug('[DatabaseUploadSync] Skipping upload — device not activated')
+      return
+    }
+
+    const tempPath = path.join(os.tmpdir(), `.memorylane-upload-${process.pid}.${Date.now()}.tmp`)
+
+    try {
+      await this.storage.backupToFile(tempPath)
+
+      const fileBuffer = fs.readFileSync(tempPath)
+      const formData = new FormData()
+      formData.append('device_id', this.getDeviceId())
+      formData.append('file', new Blob([fileBuffer]), 'memorylane.db')
+
+      const url = new URL('/api/device/upload', this.backendUrl)
+      const response = await fetch(url, { method: 'POST', body: formData })
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '')
+        throw new Error(`Upload failed (${response.status}): ${body}`)
+      }
+
+      const data = (await response.json()) as {
+        ok: boolean
+        upload_id: string
+        checksum_sha256: string
+      }
+      log.info(
+        `[DatabaseUploadSync] Upload succeeded (${reason}): upload_id=${data.upload_id} checksum=${data.checksum_sha256}`,
+      )
+    } finally {
+      try {
+        fs.rmSync(tempPath, { force: true })
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -89,7 +89,7 @@ export const MANAGED_KEY_CONFIG = {
   KEY_REFRESH_INTERVAL_MS: 24 * 60 * 60 * 1000, // 24 hours
 }
 
-export const ENTERPRISE_LICENSE_CONFIG = {
+export const ENTERPRISE_BACKEND_CONFIG = {
   BACKEND_URL:
     process.env.NODE_ENV === 'development'
       ? 'http://localhost:8000/'


### PR DESCRIPTION
## Summary

- Add `DatabaseUploadSync` service that periodically (24h) backs up the SQLite DB and uploads it via multipart `POST /api/device/upload`, authenticated by `device_id`
- Enterprise-only: created and started only when `edition === 'enterprise'`, skips upload cycles when device is not yet activated
- Rename `ENTERPRISE_LICENSE_CONFIG` → `ENTERPRISE_BACKEND_CONFIG` since the constant now serves more than licensing

## Test plan

- [x] 5 unit tests pass (upload success, skip when inactive, temp cleanup on upload/backup failure, startup + interval)
- [x] Existing enterprise access provider tests pass after rename
- [x] Lint clean, build succeeds
- [ ] Manual: run with `EDITION=enterprise` against local backend, verify upload logged on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)