### PR TITLE
feat(enterprise): /api prefix + configurable backend URL

### DIFF
--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -8,6 +8,11 @@ import {
 } from './enterprise-access-machine'
 import { createInitialAccessState } from './types'
 
+function enterpriseUrl(path: string): URL {
+  const base = ENTERPRISE_BACKEND_CONFIG.BACKEND_URL.replace(/\/?$/, '/')
+  return new URL(path, base)
+}
+
 export class EnterpriseAccessProvider extends BaseAccessProvider {
   private readonly deviceIdentity: DeviceIdentity
   private pollTimer: ReturnType<typeof setInterval> | null = null
@@ -78,19 +83,16 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       transitionEnterpriseAccess(this.accessState, { type: 'activation_started' }),
     )
 
-    const response = await fetch(
-      new URL('/license/activate', ENTERPRISE_BACKEND_CONFIG.BACKEND_URL),
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          device_id: deviceId,
-          activation_key: trimmedKey,
-        }),
+    const response = await fetch(enterpriseUrl('license/activate'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
       },
-    )
+      body: JSON.stringify({
+        device_id: deviceId,
+        activation_key: trimmedKey,
+      }),
+    })
 
     if (!response.ok) {
       const errorMessage = await this.readErrorMessage(response, 'Activation failed')
@@ -187,7 +189,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   }
 
   private async fetchEnterpriseStatus(deviceId: string): Promise<boolean> {
-    const url = new URL('/license/status', ENTERPRISE_BACKEND_CONFIG.BACKEND_URL)
+    const url = enterpriseUrl('license/status')
     url.searchParams.set('device_id', deviceId)
 
     const response = await fetch(url.toString())
@@ -204,7 +206,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   }
 
   private async fetchEnterpriseKey(deviceId: string): Promise<string | null> {
-    const url = new URL('/license/key', ENTERPRISE_BACKEND_CONFIG.BACKEND_URL)
+    const url = enterpriseUrl('license/key')
     url.searchParams.set('device_id', deviceId)
 
     const response = await fetch(url.toString())

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -109,7 +109,8 @@ export class DatabaseUploadSync {
       formData.append('device_id', this.getDeviceId())
       formData.append('file', new Blob([fileBuffer]), 'memorylane.db')
 
-      const url = new URL('/device/upload', this.backendUrl)
+      const base = this.backendUrl.replace(/\/?$/, '/')
+      const url = new URL('device/upload', base)
       const response = await fetch(url, { method: 'POST', body: formData })
 
       if (!response.ok) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -95,7 +95,7 @@ export const ENTERPRISE_BACKEND_CONFIG = {
       process.env.MEMORYLANE_BACKEND_URL ??
       (process.env.NODE_ENV === 'development'
         ? 'http://localhost:8000/api'
-        : 'https://api-enterprise.trymemorylane.com/api')
+        : 'https://enterprise.trymemorylane.com/api')
     )
   },
   POLL_INTERVAL_MS: 2_000,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -90,10 +90,14 @@ export const MANAGED_KEY_CONFIG = {
 }
 
 export const ENTERPRISE_BACKEND_CONFIG = {
-  BACKEND_URL:
-    process.env.NODE_ENV === 'development'
-      ? 'http://localhost:8000/'
-      : 'https://api-enterprise.trymemorylane.com/',
+  get BACKEND_URL(): string {
+    return (
+      process.env.MEMORYLANE_BACKEND_URL ??
+      (process.env.NODE_ENV === 'development'
+        ? 'http://localhost:8000/api'
+        : 'https://api-enterprise.trymemorylane.com/api')
+    )
+  },
   POLL_INTERVAL_MS: 2_000,
   ACTIVATION_TIMEOUT_MS: 20_000,
   STATUS_REFRESH_INTERVAL_MS: 5 * 60 * 1000, // 5 minutes


### PR DESCRIPTION
## Summary
- All enterprise endpoints now use `/api` prefix (e.g., `/api/license/activate`)
- Backend URL is configurable via `MEMORYLANE_BACKEND_URL` env var — no rebuild needed for custom deployments
- Sensible defaults: `http://localhost:8000/api` (dev), `https://api-enterprise.trymemorylane.com/api` (prod)

## Test plan
- [x] Existing tests pass (`npm run test`)
- [ ] Dev mode with `EDITION=enterprise` hits `/api/...` endpoints
- [ ] Custom `MEMORYLANE_BACKEND_URL` in `.env` overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)