### PR TITLE
feat(enterprise): tri-state remote sync toggle (Off / Summary / Detailed)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -156,7 +156,11 @@ app.on('ready', async () => {
       storage: runtime.storage,
       getDeviceId: () => deviceIdentity.getDeviceId(),
       isActivated: () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false,
-      getStripOptions: () => ({ detailLevel: captureSettingsManager.get().uploadDetailLevel }),
+      isSyncEnabled: () => captureSettingsManager.get().uploadDetailLevel !== 'off',
+      getStripOptions: () => {
+        const level = captureSettingsManager.get().uploadDetailLevel
+        return { detailLevel: level === 'detailed' ? 'detailed' : 'summary' }
+      },
       backendUrl: ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
     })
     databaseUploadSync.start()

--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -39,6 +39,7 @@ describe('DatabaseUploadSync', () => {
       storage: { backupToFile },
       getDeviceId: () => 'device-hex-id',
       isActivated: () => true,
+      isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       backendUrl: 'http://localhost:8000/',
     })
@@ -69,6 +70,7 @@ describe('DatabaseUploadSync', () => {
       storage: { backupToFile },
       getDeviceId: () => 'device-hex-id',
       isActivated: () => false,
+      isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       backendUrl: 'http://localhost:8000/',
     })
@@ -94,6 +96,7 @@ describe('DatabaseUploadSync', () => {
       storage: { backupToFile },
       getDeviceId: () => 'device-hex-id',
       isActivated: () => true,
+      isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       backendUrl: 'http://localhost:8000/',
     })
@@ -118,6 +121,7 @@ describe('DatabaseUploadSync', () => {
       storage: { backupToFile },
       getDeviceId: () => 'device-hex-id',
       isActivated: () => true,
+      isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       backendUrl: 'http://localhost:8000/',
     })
@@ -145,6 +149,8 @@ describe('DatabaseUploadSync', () => {
       storage: { backupToFile },
       getDeviceId: () => 'device-hex-id',
       isActivated: () => true,
+      isSyncEnabled: () => true,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
       backendUrl: 'http://localhost:8000/',
       intervalMs: 1000,
     })
@@ -157,5 +163,139 @@ describe('DatabaseUploadSync', () => {
     expect(backupToFile).toHaveBeenCalledTimes(2)
 
     await sync.stop()
+  })
+
+  it('skips automatic upload when sync is disabled', async () => {
+    const fetchMock = mockFetchResponse(201, { ok: true })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => false,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      backendUrl: 'http://localhost:8000/',
+    })
+
+    sync.start()
+    await sync.stop()
+
+    expect(backupToFile).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('triggerUpload returns error when sync is disabled', async () => {
+    const fetchMock = mockFetchResponse(201, { ok: true })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => false,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      backendUrl: 'http://localhost:8000/',
+    })
+
+    const result = await sync.triggerUpload()
+
+    expect(result).toEqual({ success: false, error: 'Sharing disabled' })
+    expect(backupToFile).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('re-evaluates the sync gate on each interval tick', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_1',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    let syncOn = false
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => syncOn,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      backendUrl: 'http://localhost:8000/',
+      intervalMs: 1000,
+    })
+
+    sync.start()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(backupToFile).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(backupToFile).not.toHaveBeenCalled()
+
+    syncOn = true
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await sync.stop()
+  })
+
+  it('in-flight upload completes even if the gate flips to false mid-flight', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_1',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    let syncOn = true
+    let resolveBackup!: () => void
+    const backupGate = new Promise<void>((resolve) => {
+      resolveBackup = resolve
+    })
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      await backupGate
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => syncOn,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      backendUrl: 'http://localhost:8000/',
+      intervalMs: 1000,
+    })
+
+    sync.start()
+    // Let the startup upload enter uploadOnce() past the gate check,
+    // then block on the backup promise.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+
+    // Flip the gate off while the first upload is still in flight.
+    syncOn = false
+    resolveBackup()
+
+    await sync.stop()
+
+    // The first upload still completed (fetch fired exactly once).
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -14,6 +14,7 @@ export interface DatabaseUploadSyncParams {
   storage: DatabaseUploadStorage
   getDeviceId: () => string
   isActivated: () => boolean
+  isSyncEnabled: () => boolean
   getStripOptions: () => StripOptions
   backendUrl: string
   intervalMs?: number
@@ -23,6 +24,7 @@ export class DatabaseUploadSync {
   private readonly storage: DatabaseUploadStorage
   private readonly getDeviceId: () => string
   private readonly isActivated: () => boolean
+  private readonly isSyncEnabled: () => boolean
   private readonly getStripOptions: () => StripOptions
   private readonly backendUrl: string
   private readonly intervalMs: number
@@ -35,6 +37,7 @@ export class DatabaseUploadSync {
     this.storage = params.storage
     this.getDeviceId = params.getDeviceId
     this.isActivated = params.isActivated
+    this.isSyncEnabled = params.isSyncEnabled
     this.getStripOptions = params.getStripOptions
     this.backendUrl = params.backendUrl
     this.intervalMs = params.intervalMs ?? DEFAULT_UPLOAD_INTERVAL_MS
@@ -54,6 +57,9 @@ export class DatabaseUploadSync {
   }
 
   public async triggerUpload(): Promise<{ success: boolean; error?: string }> {
+    if (!this.isSyncEnabled()) {
+      return { success: false, error: 'Sharing disabled' }
+    }
     try {
       await this.queueUpload('manual')
       return { success: true }
@@ -98,6 +104,11 @@ export class DatabaseUploadSync {
   }
 
   private async uploadOnce(reason: string): Promise<void> {
+    if (!this.isSyncEnabled()) {
+      log.debug('[DatabaseUploadSync] Skipping upload — sharing disabled')
+      return
+    }
+
     if (!this.isActivated()) {
       log.debug('[DatabaseUploadSync] Skipping upload — device not activated')
       return

--- a/src/main/settings/capture-settings-manager.test.ts
+++ b/src/main/settings/capture-settings-manager.test.ts
@@ -52,6 +52,7 @@ describe('CaptureSettingsManager', () => {
       expect(defaults.excludedApps).toEqual([])
       expect(defaults.excludedWindowTitlePatterns).toEqual([])
       expect(defaults.excludedUrlPatterns).toEqual([])
+      expect(defaults.uploadDetailLevel).toBe('off')
     })
 
     it('get() returns a copy, not the internal reference', () => {
@@ -135,6 +136,29 @@ describe('CaptureSettingsManager', () => {
 
       const reloaded = new CaptureSettingsManager(configPath)
       expect(reloaded.get().excludePrivateBrowsing).toBe(false)
+    })
+
+    it('persists uploadDetailLevel across reloads', () => {
+      for (const level of ['off', 'summary', 'detailed'] as const) {
+        const manager = new CaptureSettingsManager(configPath)
+        manager.save({ uploadDetailLevel: level })
+        const reloaded = new CaptureSettingsManager(configPath)
+        expect(reloaded.get().uploadDetailLevel).toBe(level)
+      }
+    })
+
+    it('preserves pre-existing summary/detailed values on load (backward compat)', () => {
+      for (const level of ['summary', 'detailed'] as const) {
+        fs.writeFileSync(configPath, JSON.stringify({ uploadDetailLevel: level }))
+        const manager = new CaptureSettingsManager(configPath)
+        expect(manager.get().uploadDetailLevel).toBe(level)
+      }
+    })
+
+    it("fresh install (no config file) defaults uploadDetailLevel to 'off'", () => {
+      expect(fs.existsSync(configPath)).toBe(false)
+      const manager = new CaptureSettingsManager(configPath)
+      expect(manager.get().uploadDetailLevel).toBe('off')
     })
 
     it('normalizes blank database export directories to disabled', () => {

--- a/src/main/settings/capture-settings-manager.ts
+++ b/src/main/settings/capture-settings-manager.ts
@@ -38,7 +38,7 @@ const DEFAULTS: CaptureSettings = {
   semanticSnapshotModel: '',
   patternDetectionModel: '',
   patternDetectionEnabled: true,
-  uploadDetailLevel: 'summary',
+  uploadDetailLevel: 'off',
 }
 
 export class CaptureSettingsManager {

--- a/src/renderer/pages/main-window/AdvancedSettingsPage.tsx
+++ b/src/renderer/pages/main-window/AdvancedSettingsPage.tsx
@@ -152,12 +152,14 @@ export function AdvancedSettingsPage({ onBack }: { onBack: () => void }): React.
   }, [])
 
   const setUploadDetailLevel = useCallback(
-    (level: 'summary' | 'detailed'): void => {
+    (level: 'off' | 'summary' | 'detailed'): void => {
       setForm((prev) => (prev ? { ...prev, uploadDetailLevel: level } : prev))
-      save(
-        { uploadDetailLevel: level },
-        level === 'detailed' ? 'Sharing detailed activities' : 'Sharing summary only',
-      )
+      const toastByLevel = {
+        off: 'Sharing disabled',
+        summary: 'Sharing summary only',
+        detailed: 'Sharing detailed activities',
+      } as const
+      save({ uploadDetailLevel: level }, toastByLevel[level])
     },
     [save],
   )

--- a/src/renderer/pages/main-window/components/advanced-settings/ConnectionsDataSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/ConnectionsDataSection.tsx
@@ -18,8 +18,8 @@ interface ConnectionsDataSectionProps {
   onToggle: () => void
   databaseExportDirectory: string
   onDatabaseExportDirectoryChange: (directoryPath: string) => void
-  uploadDetailLevel: 'summary' | 'detailed'
-  onUploadDetailLevelChange: (level: 'summary' | 'detailed') => void
+  uploadDetailLevel: 'off' | 'summary' | 'detailed'
+  onUploadDetailLevelChange: (level: 'off' | 'summary' | 'detailed') => void
 }
 
 export function ConnectionsDataSection({
@@ -85,7 +85,14 @@ export function ConnectionsDataSection({
                   <>
                     <div className="space-y-2">
                       <p className="text-xs font-medium text-muted-foreground">Share with remote</p>
-                      <div className="grid grid-cols-2 gap-2">
+                      <div className="grid grid-cols-3 gap-2">
+                        <Button
+                          variant={uploadDetailLevel === 'off' ? 'default' : 'outline'}
+                          size="sm"
+                          onClick={() => onUploadDetailLevelChange('off')}
+                        >
+                          Off
+                        </Button>
                         <Button
                           variant={uploadDetailLevel === 'summary' ? 'default' : 'outline'}
                           size="sm"
@@ -102,14 +109,17 @@ export function ConnectionsDataSection({
                         </Button>
                       </div>
                       <p className="text-xs text-muted-foreground">
-                        Summary strips OCR text and full-text search index. Both modes strip
-                        personal context and pattern detection runs.
+                        Off disables sharing. Summary strips OCR text and full-text search index.
+                        Both Summary and Detailed strip personal context; pattern detection runs
+                        locally either way.
                       </p>
                     </div>
 
-                    <div className="space-y-2">
-                      <DatabaseSyncSection api={api} />
-                    </div>
+                    {uploadDetailLevel !== 'off' && (
+                      <div className="space-y-2">
+                        <DatabaseSyncSection api={api} />
+                      </div>
+                    )}
                   </>
                 )}
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -178,7 +178,7 @@ export interface CaptureSettings {
   semanticSnapshotModel: string
   patternDetectionModel: string
   patternDetectionEnabled: boolean
-  uploadDetailLevel: 'summary' | 'detailed'
+  uploadDetailLevel: 'off' | 'summary' | 'detailed'
 }
 
 export type McpRegistrationStatus = Record<string, boolean>


### PR DESCRIPTION
## Summary
- Makes remote sync opt-in. Default **Off** for new installs. Existing persisted `'summary'`/`'detailed'` values are preserved on load.
- Merges the on/off control with the detail-level control into a single three-state switch: **Off / Summary / Detailed**.
- When Off, both the periodic 24h upload and the manual "Sync to Remote" button are suppressed (the button is hidden).

## Implementation
- Widened `CaptureSettings.uploadDetailLevel` to `'off' | 'summary' | 'detailed'`.
- Added required `isSyncEnabled` gate to `DatabaseUploadSync`. Checked at the top of `uploadOnce()` (silent skip) and in `triggerUpload()` (returns `{ success: false, error: 'Sharing disabled' }`).
- `start()` is still called unconditionally — the gate makes flipping Off↔Summary/Detailed take effect on the next tick without lifecycle plumbing.
- UI: three-button grid in `ConnectionsDataSection`; `DatabaseSyncSection` is rendered only when mode is not `'off'`.

## Test plan
- [x] `npm run test` — 461 passed, 20 skipped (integration), 0 failed
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] New unit tests covering: disabled-auto skip, disabled-manual error, gate re-evaluated each interval tick, in-flight upload completes when gate flips mid-flight, default `'off'` for new installs, backward-compat for pre-existing `'summary'`/`'detailed'` values
- [ ] Manual smoke (enterprise build, fresh user data dir):
  - [ ] Fresh launch → **Off** active, Sync button hidden
  - [ ] Pick **Detailed** → toast "Sharing detailed activities", Sync button appears, startup upload fires
  - [ ] Pick **Off** → Sync button disappears, logs show `Skipping upload — sharing disabled` at next interval
  - [ ] Quit and relaunch → last selected mode is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)