### PR TITLE
fix(privacy): resolve .lnk targets for Windows installed-apps

### DIFF
--- a/src/main/apps/installed-apps.test.ts
+++ b/src/main/apps/installed-apps.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Dirent } from 'fs'
+
+vi.mock('fs/promises', () => ({ readdir: vi.fn() }))
+vi.mock('child_process', () => ({ execFile: vi.fn() }))
+vi.mock('../logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+function dirent(name: string, isDir: boolean): Dirent {
+  return {
+    name,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isSymbolicLink: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+  } as unknown as Dirent
+}
+
+async function setupReaddir(tree: Record<string, Array<[string, boolean]>>): Promise<void> {
+  const fsp = await import('fs/promises')
+  vi.mocked(fsp.readdir).mockImplementation((async (dir: string) => {
+    const entries = tree[dir.replace(/\\/g, '/')]
+    if (!entries) return []
+    return entries.map(([n, d]) => dirent(n, d))
+  }) as unknown as typeof fsp.readdir)
+}
+
+async function setupPowershellOutput(lines: string[]): Promise<void> {
+  const cp = await import('child_process')
+  vi.mocked(cp.execFile).mockImplementation(((...args: unknown[]) => {
+    const cb = args[args.length - 1]
+    if (typeof cb === 'function') {
+      ;(cb as (e: Error | null, out: string, err: string) => void)(null, lines.join('\n'), '')
+    }
+    return {} as ReturnType<typeof cp.execFile>
+  }) as unknown as typeof cp.execFile)
+}
+
+async function setupPowershellFailure(): Promise<void> {
+  const cp = await import('child_process')
+  vi.mocked(cp.execFile).mockImplementation(((...args: unknown[]) => {
+    const cb = args[args.length - 1]
+    if (typeof cb === 'function') {
+      ;(cb as (e: Error | null, out: string, err: string) => void)(
+        new Error('powershell crashed'),
+        '',
+        '',
+      )
+    }
+    return {} as ReturnType<typeof cp.execFile>
+  }) as unknown as typeof cp.execFile)
+}
+
+describe('listInstalledApps (windows)', () => {
+  const ORIGINAL_PLATFORM = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+  beforeEach(() => {
+    vi.resetModules()
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    process.env.ProgramData = 'C:/ProgramData'
+    process.env.APPDATA = 'C:/AppData'
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', ORIGINAL_PLATFORM)
+  })
+
+  it('keeps only shortcuts whose target is an .exe and uses the exe stem as matchToken', async () => {
+    const programsA = 'C:/ProgramData/Microsoft/Windows/Start Menu/Programs'
+    const programsB = 'C:/AppData/Microsoft/Windows/Start Menu/Programs'
+    await setupReaddir({
+      [programsA]: [
+        ['Google Chrome.lnk', false],
+        ['Event Viewer.lnk', false],
+        ['Git Release Notes.lnk', false],
+        ['Uninstall Node.js.lnk', false],
+        ['Subfolder', true],
+      ],
+      [`${programsA}/Subfolder`]: [['Wordpad.lnk', false]],
+      [programsB]: [['Warp.lnk', false]],
+    })
+    await setupPowershellOutput([
+      `${programsA}/Google Chrome.lnk\tC:/Program Files/Google/Chrome/Application/chrome.exe`,
+      `${programsA}/Event Viewer.lnk\tC:/Windows/system32/eventvwr.msc`,
+      `${programsA}/Git Release Notes.lnk\tC:/Program Files/Git/ReleaseNotes.html`,
+      `${programsA}/Subfolder/Wordpad.lnk\tC:/Program Files/Windows NT/Accessories/wordpad.exe`,
+      `${programsB}/Warp.lnk\tC:/Users/u/AppData/Local/Warp/Warp.exe`,
+    ])
+
+    const { listInstalledApps } = await import('./installed-apps')
+    const apps = await listInstalledApps()
+
+    expect(apps).toEqual([
+      { displayName: 'Google Chrome', matchToken: 'chrome' },
+      { displayName: 'Warp', matchToken: 'warp' },
+      { displayName: 'Wordpad', matchToken: 'wordpad' },
+    ])
+  })
+
+  it('returns empty list when powershell resolver fails', async () => {
+    const programs = 'C:/ProgramData/Microsoft/Windows/Start Menu/Programs'
+    await setupReaddir({
+      [programs]: [['Google Chrome.lnk', false]],
+      'C:/AppData/Microsoft/Windows/Start Menu/Programs': [],
+    })
+    await setupPowershellFailure()
+
+    const { listInstalledApps } = await import('./installed-apps')
+    const apps = await listInstalledApps()
+    expect(apps).toEqual([])
+  })
+
+  it('dedupes multiple shortcuts pointing to the same exe', async () => {
+    const programs = 'C:/ProgramData/Microsoft/Windows/Start Menu/Programs'
+    await setupReaddir({
+      [programs]: [
+        ['Python 3.14 (64-bit).lnk', false],
+        ['Python 3.14.lnk', false],
+      ],
+      'C:/AppData/Microsoft/Windows/Start Menu/Programs': [],
+    })
+    await setupPowershellOutput([
+      `${programs}/Python 3.14 (64-bit).lnk\tC:/Python314/python.exe`,
+      `${programs}/Python 3.14.lnk\tC:/Python314/python.exe`,
+    ])
+
+    const { listInstalledApps } = await import('./installed-apps')
+    const apps = await listInstalledApps()
+    expect(apps.map((a) => a.matchToken)).toEqual(['python'])
+  })
+})

--- a/src/main/apps/installed-apps.ts
+++ b/src/main/apps/installed-apps.ts
@@ -9,6 +9,9 @@ import type { InstalledApp } from '../../shared/types'
 
 const execFileAsync = promisify(execFile)
 
+const LNK_RESOLVER_TIMEOUT_MS = 15_000
+const LNK_RESOLVER_BUFFER_BYTES = 2 * 1024 * 1024
+
 let cachedApps: InstalledApp[] | null = null
 let cacheLoadPromise: Promise<InstalledApp[]> | null = null
 let cachedAt = 0
@@ -154,23 +157,48 @@ function decodeXmlEntities(value: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Windows: enumerate .lnk shortcut filenames under Start Menu. The filename is
-// the human-readable display name (e.g. "Google Chrome.lnk"). We don't resolve
-// the .lnk binary — normalizeToken on the display name already yields the same
-// token the capture-exclusion matcher uses.
+// Windows: enumerate .lnk shortcuts under Start Menu, then resolve each one's
+// target via WScript.Shell. Only shortcuts pointing to an .exe become apps —
+// this drops .chm manuals, .url docs, and .msc snap-ins that the app-watcher
+// would never match at runtime (it reports process exe stems, not Start Menu
+// display names).
 // ---------------------------------------------------------------------------
+
+interface WindowsShortcut {
+  path: string
+  displayName: string
+}
 
 async function loadWindowsApps(): Promise<InstalledApp[]> {
   const roots = collectWindowsStartMenuRoots()
-  const all: InstalledApp[] = []
+  const shortcuts: WindowsShortcut[] = []
   for (const root of roots) {
     try {
-      await collectWindowsShortcuts(root, all, 0)
+      await collectWindowsShortcuts(root, shortcuts, 0)
     } catch {
       // Missing / inaccessible — skip.
     }
   }
-  return dedupeAndSort(all.filter((app) => !isWindowsNoise(app.displayName)))
+
+  if (shortcuts.length === 0) return []
+
+  const filtered = shortcuts.filter((s) => !isWindowsNoise(s.displayName))
+  const targets = await resolveWindowsShortcutTargets(filtered.map((s) => s.path))
+  const apps: InstalledApp[] = []
+  for (const shortcut of filtered) {
+    const target = targets.get(normalizePathKey(shortcut.path))
+    if (!target) continue
+    if (!target.toLowerCase().endsWith('.exe')) continue
+    const stem = path.basename(target, path.extname(target))
+    const matchToken = normalizeToken(stem)
+    if (!matchToken) continue
+    apps.push({ displayName: shortcut.displayName, matchToken })
+  }
+  return dedupeAndSort(apps)
+}
+
+function normalizePathKey(p: string): string {
+  return p.replace(/\\/g, '/').toLowerCase()
 }
 
 function collectWindowsStartMenuRoots(): string[] {
@@ -188,7 +216,7 @@ function collectWindowsStartMenuRoots(): string[] {
 
 async function collectWindowsShortcuts(
   dir: string,
-  out: InstalledApp[],
+  out: WindowsShortcut[],
   depth: number,
 ): Promise<void> {
   if (depth > 3) return
@@ -205,9 +233,7 @@ async function collectWindowsShortcuts(
     }
     if (!entry.name.toLowerCase().endsWith('.lnk')) continue
     const displayName = entry.name.slice(0, -4)
-    const matchToken = normalizeToken(displayName)
-    if (!matchToken) continue
-    out.push({ displayName, matchToken })
+    out.push({ path: path.join(dir, entry.name), displayName })
   }
 }
 
@@ -216,4 +242,69 @@ const WINDOWS_NOISE_PATTERNS = ['uninstall', 'readme', 'release notes', 'documen
 function isWindowsNoise(displayName: string): boolean {
   const lowered = displayName.toLowerCase()
   return WINDOWS_NOISE_PATTERNS.some((p) => lowered.includes(p))
+}
+
+function buildShortcutResolverScript(lnkPaths: readonly string[]): string {
+  const literals = lnkPaths.map((p) => `'${p.replace(/'/g, "''")}'`).join(',')
+  return [
+    "$ErrorActionPreference = 'SilentlyContinue'",
+    "$ProgressPreference = 'SilentlyContinue'",
+    '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8',
+    '$shell = New-Object -ComObject WScript.Shell',
+    `$paths = @(${literals})`,
+    'foreach ($p in $paths) {',
+    '  try {',
+    '    $target = $shell.CreateShortcut($p).TargetPath',
+    '    if ($target) {',
+    '      $safePath = [string]$p -replace "`t", " "',
+    '      $safeTarget = [string]$target -replace "`t", " "',
+    '      [Console]::Out.WriteLine("$safePath`t$safeTarget")',
+    '    }',
+    '  } catch {}',
+    '}',
+  ].join('\n')
+}
+
+async function resolveWindowsShortcutTargets(
+  lnkPaths: readonly string[],
+): Promise<Map<string, string>> {
+  if (lnkPaths.length === 0) return new Map()
+  const script = buildShortcutResolverScript(lnkPaths)
+  const encoded = Buffer.from(script, 'utf16le').toString('base64')
+
+  let stdout: string
+  try {
+    stdout = await new Promise<string>((resolve, reject) => {
+      execFile(
+        'powershell.exe',
+        ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', encoded],
+        {
+          encoding: 'utf-8',
+          timeout: LNK_RESOLVER_TIMEOUT_MS,
+          maxBuffer: LNK_RESOLVER_BUFFER_BYTES,
+          windowsHide: true,
+        },
+        (err, out) => {
+          if (err) reject(err)
+          else resolve(typeof out === 'string' ? out : out.toString('utf-8'))
+        },
+      )
+    })
+  } catch (error) {
+    log.warn(`Failed to resolve Windows shortcut targets: ${error}`)
+    return new Map()
+  }
+
+  const map = new Map<string, string>()
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0) continue
+    const tabIndex = trimmed.indexOf('\t')
+    if (tabIndex < 0) continue
+    const lnkPath = trimmed.slice(0, tabIndex)
+    const target = trimmed.slice(tabIndex + 1)
+    if (!lnkPath || !target) continue
+    map.set(normalizePathKey(lnkPath), target)
+  }
+  return map
 }


### PR DESCRIPTION
## Summary
- Start Menu scan was treating every `.lnk` as an app, surfacing rows like "Event Viewer", "Git Release Notes", "Python 3.14 Manuals", and every Administrative Tools snap-in — none of which match what the Rust app-watcher reports at runtime (process exe stems), so toggling them did nothing.
- Resolve each shortcut's `TargetPath` via one batched PowerShell call and keep only shortcuts that point to an `.exe`. The exe's file stem becomes the `matchToken`, so picker entries now line up with what the watcher emits.
- PowerShell output and `path.join` results are normalized to a common separator before lookup, so the mapping is robust regardless of slash direction.

## Test plan
- [x] Added `src/main/apps/installed-apps.test.ts` covering the success path, resolver failure (returns empty), and dedupe across multiple shortcuts pointing at the same exe.
- [x] Dry-run on my own Windows machine: noise entries (.msc, .html, .url targets) are filtered; Chrome / Warp / Wordpad / Python / Git Bash etc. remain with correct exe-stem tokens.
- [ ] Reviewer: verify on a clean Windows install that the picker now only shows real apps, and that blocking one (e.g. Warp) still suppresses capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)