### PR TITLE
fix(windows): kill native helpers on quit to unbreak MSI upgrades

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,6 +33,7 @@ import { RawDatabaseExportSync } from './services/raw-database-export-sync'
 import { DatabaseUploadSync } from './services/database-upload-sync'
 import { createMainRuntime, type MainRuntime } from './runtime'
 import { createObservationController } from './observation-controller'
+import { forceStopAppWatcherBackend } from './recorder/app-watcher'
 import { getAppDirectoryName } from './paths'
 import { loadAppEditionConfig } from './edition'
 import { ENTERPRISE_BACKEND_CONFIG } from '../shared/constants'
@@ -76,9 +77,28 @@ let patternDetector: PatternDetector | null = null
 let rawDatabaseExportSync: RawDatabaseExportSync | null = null
 let databaseUploadSync: DatabaseUploadSync | null = null
 
-app.on('before-quit', () => {
+let shutdownCompleted = false
+app.on('before-quit', (event) => {
+  if (shutdownCompleted) return
+  event.preventDefault()
+
+  // Kill the native app-watcher helper synchronously before we proceed.
+  // On Windows, MSI upgrade uses RestartManager to close the main Electron
+  // process, but the Rust helper exe is not registered with RestartManager
+  // and would keep holding resources\rust\app-watcher-windows.exe, forcing
+  // MSI to defer replacement to a reboot (return code 3010) and leaving a
+  // partially-installed app that fails with a V8 snapshot FATAL on launch.
+  forceStopAppWatcherBackend()
+
   runtime?.accessProvider.stopPeriodicRefresh()
-  void Promise.all([runtime?.dispose(), rawDatabaseExportSync?.stop(), databaseUploadSync?.stop()])
+  void Promise.allSettled([
+    runtime?.dispose(),
+    rawDatabaseExportSync?.stop(),
+    databaseUploadSync?.stop(),
+  ]).finally(() => {
+    shutdownCompleted = true
+    app.quit()
+  })
 })
 
 app.on('will-quit', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,8 +32,7 @@ import { UserContextBuilder } from './services/user-context-builder'
 import { RawDatabaseExportSync } from './services/raw-database-export-sync'
 import { DatabaseUploadSync } from './services/database-upload-sync'
 import { createMainRuntime, type MainRuntime } from './runtime'
-import { createObservationController } from './observation-controller'
-import { forceStopAppWatcherBackend } from './recorder/app-watcher'
+import { createObservationController, type ObservationController } from './observation-controller'
 import { getAppDirectoryName } from './paths'
 import { loadAppEditionConfig } from './edition'
 import { ENTERPRISE_BACKEND_CONFIG } from '../shared/constants'
@@ -76,21 +75,23 @@ let userContextBuilder: UserContextBuilder | null = null
 let patternDetector: PatternDetector | null = null
 let rawDatabaseExportSync: RawDatabaseExportSync | null = null
 let databaseUploadSync: DatabaseUploadSync | null = null
+let observation: ObservationController | null = null
 
+// Blocks `app.quit()` until all subscribers to native helpers have released
+// them. Critical on Windows MSI upgrades: Electron's process is closed by
+// RestartManager, but Rust helpers (app-watcher-windows.exe) aren't registered
+// with it. If Electron exits before the observation controller and runtime
+// release their app-watcher subscriptions, the helper outlives the main
+// process, keeps an open handle on resources\rust\app-watcher-windows.exe,
+// and MSI has to defer replacement to a reboot (return code 3010).
 let shutdownCompleted = false
 app.on('before-quit', (event) => {
   if (shutdownCompleted) return
   event.preventDefault()
 
-  // Kill the native app-watcher helper synchronously before we proceed.
-  // On Windows, MSI upgrade uses RestartManager to close the main Electron
-  // process, but the Rust helper exe is not registered with RestartManager
-  // and would keep holding resources\rust\app-watcher-windows.exe, forcing
-  // MSI to defer replacement to a reboot (return code 3010) and leaving a
-  // partially-installed app that fails with a V8 snapshot FATAL on launch.
-  forceStopAppWatcherBackend()
-
   runtime?.accessProvider.stopPeriodicRefresh()
+  observation?.dispose()
+
   void Promise.allSettled([
     runtime?.dispose(),
     rawDatabaseExportSync?.stop(),
@@ -239,7 +240,7 @@ app.on('ready', async () => {
 
   const { sendObservationUpdate } = await import('./ui/main-window')
 
-  const observation = createObservationController({
+  observation = createObservationController({
     captureControl: runtime.capture,
     onUpdate: (state) => sendObservationUpdate(state),
     onSettingsPatch: ({ apps, urls }) => {

--- a/src/main/observation-controller.ts
+++ b/src/main/observation-controller.ts
@@ -20,6 +20,7 @@ export interface ObservationController {
   start(durationMs: number): ObservationState
   stop(reason: 'user' | 'timer'): ObservationState
   getState(): ObservationState
+  dispose(): void
 }
 
 interface ControllerParams {
@@ -203,9 +204,27 @@ export function createObservationController(params: ControllerParams): Observati
     return getState()
   }
 
+  const dispose = (): void => {
+    if (endTimer) {
+      clearTimeout(endTimer)
+      endTimer = null
+    }
+    if (unsubscribe) {
+      try {
+        unsubscribe()
+      } catch (error) {
+        log.error('[Observation] app-watcher unsubscribe threw during dispose:', error)
+      }
+      unsubscribe = null
+    }
+    phase = 'idle'
+    endsAt = null
+  }
+
   return {
     start,
     stop,
     getState,
+    dispose,
   }
 }

--- a/src/main/recorder/app-watcher.ts
+++ b/src/main/recorder/app-watcher.ts
@@ -95,3 +95,13 @@ export function isAppWatcherRunning(): boolean {
   const backend = PLATFORM_APP_WATCHER_BACKENDS[process.platform]
   return backend?.isRunning() ?? false
 }
+
+// Forcibly stops the native backend process regardless of listener count.
+// Used during app shutdown so the native helper can't outlive the main process
+// (see before-quit handler in main/index.ts).
+export function forceStopAppWatcherBackend(): void {
+  if (!backendStarted) return
+  const backend = PLATFORM_APP_WATCHER_BACKENDS[process.platform]
+  backend?.stop()
+  backendStarted = false
+}

--- a/src/main/recorder/app-watcher.ts
+++ b/src/main/recorder/app-watcher.ts
@@ -95,13 +95,3 @@ export function isAppWatcherRunning(): boolean {
   const backend = PLATFORM_APP_WATCHER_BACKENDS[process.platform]
   return backend?.isRunning() ?? false
 }
-
-// Forcibly stops the native backend process regardless of listener count.
-// Used during app shutdown so the native helper can't outlive the main process
-// (see before-quit handler in main/index.ts).
-export function forceStopAppWatcherBackend(): void {
-  if (!backendStarted) return
-  const backend = PLATFORM_APP_WATCHER_BACKENDS[process.platform]
-  backend?.stop()
-  backendStarted = false
-}


### PR DESCRIPTION
## Summary

- `before-quit` used `void Promise.all(...)` and didn't block Electron from exiting, so `app-watcher-windows.exe` could outlive the main process. On MSI upgrades, Windows RestartManager closes the Electron process but has no record of the orphaned Rust helper — it keeps an open handle on `resources\rust\app-watcher-windows.exe`, MSI falls back to `MOVEFILE_DELAY_UNTIL_REBOOT` (return code 3010), and if the user declines the reboot the install is left partially-replaced. Launching the app then crashes with `FATAL:gin\v8_initializer.cc:699 Error loading V8 startup snapshot file` because `v8_context_snapshot.bin` never got written. Running the installer a second time "fixes" it because the orphan has died by then.
- Rewrote `before-quit` to `preventDefault`, dispose the observation controller synchronously, await the dispose chain (`runtime.dispose()` stops capture and the interaction monitor, which releases its app-watcher subscription), then re-enter quit through a one-shot `shutdownCompleted` guard.
- Added `dispose()` on the observation controller so its app-watcher listener is released during shutdown. With both owners (observation + interaction monitor) now releasing their subscriptions, `maybeStopBackend()` collapses the listener count to zero and the Rust helper is SIGTERM'd before Electron exits.

Note: the first upgrade *from* a currently-broken install will still hit the old bug, because it's the already-installed version that RestartManager talks to. Upgrades from builds that contain this fix forward will be clean.

## Test plan

- [ ] Existing `app-watcher.test.ts` suite still passes (verified locally — 5/5)
- [ ] On Windows: start app, confirm `app-watcher-windows.exe` is running, quit via tray → verify the helper exits with the main process (no orphan in `tasklist`)
- [ ] On Windows: with app running, launch MSI upgrade → confirm no 3010 return in `%TEMP%\MSI*.log`, all files replaced in one pass, app launches successfully
- [ ] Screenshot daemon (`screenshot-capturer-windows.exe`) is still stopped cleanly via `runtime.dispose()` during quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)