### PR TITLE
fix(mcp): remove top-level electron import from edition.ts

### DIFF
--- a/src/main/edition.ts
+++ b/src/main/edition.ts
@@ -1,4 +1,3 @@
-import { app } from 'electron'
 import fs from 'node:fs'
 import path from 'node:path'
 import {
@@ -7,6 +6,7 @@ import {
   type AppEdition,
   type AppEditionConfig,
 } from '../shared/edition'
+import { isPackagedElectronExecutable } from './paths'
 import log from './logger'
 
 type RawEditionConfig = Partial<AppEditionConfig>
@@ -17,8 +17,26 @@ interface LoadedEditionConfig {
   source: 'dev' | 'packaged'
 }
 
+// Electron's `app` is only available when running as a real Electron app.
+// Under ELECTRON_RUN_AS_NODE=1 (MCP entry) require('electron') throws, so
+// we read it lazily and fall back to pure-Node detection.
+function getElectronApp(): { isPackaged?: boolean; getAppPath?: () => string } | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const electron = require('electron')
+    if (typeof electron === 'object' && electron !== null && 'app' in electron) {
+      return (electron as { app: { isPackaged?: boolean; getAppPath?: () => string } }).app
+    }
+  } catch {
+    // ELECTRON_RUN_AS_NODE — electron module unavailable
+  }
+  return null
+}
+
 function getDevEditionConfigPath(edition: AppEdition): string {
-  return path.join(app.getAppPath(), 'config', 'editions', `${edition}.json`)
+  const electronApp = getElectronApp()
+  const appPath = electronApp?.getAppPath?.() ?? process.cwd()
+  return path.join(appPath, 'config', 'editions', `${edition}.json`)
 }
 
 function getPackagedEditionConfigPath(): string {
@@ -51,7 +69,10 @@ function loadAndValidateEditionConfig(
 }
 
 function resolveEditionConfig(): LoadedEditionConfig {
-  if (!app.isPackaged) {
+  const electronApp = getElectronApp()
+  const isPackaged = electronApp?.isPackaged ?? isPackagedElectronExecutable(process.execPath)
+
+  if (!isPackaged) {
     const requestedEdition = parseEdition(process.env.EDITION)
     return {
       config: loadAndValidateEditionConfig(

--- a/src/main/edition.ts
+++ b/src/main/edition.ts
@@ -6,7 +6,7 @@ import {
   type AppEdition,
   type AppEditionConfig,
 } from '../shared/edition'
-import { isPackagedElectronExecutable } from './paths'
+import { getElectronAppOrNull, isPackagedElectronExecutable } from './paths'
 import log from './logger'
 
 type RawEditionConfig = Partial<AppEditionConfig>
@@ -17,24 +17,8 @@ interface LoadedEditionConfig {
   source: 'dev' | 'packaged'
 }
 
-// Electron's `app` is only available when running as a real Electron app.
-// Under ELECTRON_RUN_AS_NODE=1 (MCP entry) require('electron') throws, so
-// we read it lazily and fall back to pure-Node detection.
-function getElectronApp(): { isPackaged?: boolean; getAppPath?: () => string } | null {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const electron = require('electron')
-    if (typeof electron === 'object' && electron !== null && 'app' in electron) {
-      return (electron as { app: { isPackaged?: boolean; getAppPath?: () => string } }).app
-    }
-  } catch {
-    // ELECTRON_RUN_AS_NODE — electron module unavailable
-  }
-  return null
-}
-
 function getDevEditionConfigPath(edition: AppEdition): string {
-  const electronApp = getElectronApp()
+  const electronApp = getElectronAppOrNull()
   const appPath = electronApp?.getAppPath?.() ?? process.cwd()
   return path.join(appPath, 'config', 'editions', `${edition}.json`)
 }
@@ -69,7 +53,7 @@ function loadAndValidateEditionConfig(
 }
 
 function resolveEditionConfig(): LoadedEditionConfig {
-  const electronApp = getElectronApp()
+  const electronApp = getElectronAppOrNull()
   const isPackaged = electronApp?.isPackaged ?? isPackagedElectronExecutable(process.execPath)
 
   if (!isPackaged) {

--- a/src/main/mcp-entry-isolation.test.ts
+++ b/src/main/mcp-entry-isolation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import * as ts from 'typescript'
 
 /**
  * Guard: the MCP entry point runs under ELECTRON_RUN_AS_NODE=1, so the
@@ -10,47 +11,58 @@ import * as path from 'node:path'
  * would crash the MCP process before `main()` runs.
  *
  * Electron APIs may still be consulted lazily via `require('electron')`
- * inside a try/catch — see `getElectronApp()` in `src/main/edition.ts` and
- * `getBundledModelPath()` in `src/main/paths.ts`.
+ * inside a try/catch — see `getElectronAppOrNull()` in `src/main/paths.ts`.
  *
  * This test reproduces the class of regression from the bug where
  * `edition.ts` had `import { app } from 'electron'`, which Rollup placed in
  * a shared chunk that the MCP entry transitively required.
+ *
+ * Implementation notes:
+ * - Uses the TypeScript compiler API (not a regex) so multi-line imports,
+ *   inline `{ type X }` bindings, and comments are all handled correctly.
+ * - Only follows relative import specifiers. `src/main` uses relative
+ *   imports throughout; path aliases (`@/…`, `@components/…`) are not
+ *   traversed. This is an audit, not a proof: if `src/main` ever adopts
+ *   aliased imports, extend `extractRelativeImportSpecifiers` to resolve
+ *   them via the `tsconfig.node.json` `paths` map.
  */
 
 const PROJECT_ROOT = findProjectRoot(__dirname)
 const MAIN_DIR = path.join(PROJECT_ROOT, 'src', 'main')
 const MCP_ENTRY = path.join(MAIN_DIR, 'mcp-entry.ts')
 
-// Matches ES imports like `import ... from 'electron'` and side-effect
-// `import 'electron'`, but NOT `import type ... from 'electron'` — type
-// imports are stripped by the TS compiler and emit no runtime require.
-const FORBIDDEN_IMPORT_RE = /^\s*import\s+(?!type\b)(?:[^'"]*\s+from\s+)?['"]electron['"]\s*;?\s*$/
-
 describe('MCP entry electron isolation', () => {
-  it('FORBIDDEN_IMPORT_RE matches the patterns it is meant to catch', () => {
-    // Self-check: if this regex regresses, the main test below would
+  it('fileImportsElectronAtRuntime classifies all relevant import forms', () => {
+    // Self-check: if this helper regresses, the main test below would
     // silently pass even when offenders exist. Pin the behaviour.
-    const shouldMatch = [
-      `import { app } from 'electron'`,
-      `import { app, BrowserWindow } from "electron"`,
-      `import * as electron from 'electron'`,
-      `import electron from 'electron'`,
-      `import 'electron'`,
-      `  import { app } from 'electron';`,
+    const shouldFlag: Array<[string, string]> = [
+      ['named value import', `import { app } from 'electron'`],
+      ['multiple named value imports', `import { app, BrowserWindow } from "electron"`],
+      ['namespace import', `import * as electron from 'electron'`],
+      ['default import', `import electron from 'electron'`],
+      ['side-effect import', `import 'electron'`],
+      [
+        'multi-line named import',
+        `import {
+           app,
+           BrowserWindow,
+         } from 'electron'`,
+      ],
+      ['mixed type + value named import', `import { app, type App } from 'electron'`],
     ]
-    const shouldNotMatch = [
-      `import type { App } from 'electron'`,
-      `import type { App, BrowserWindow } from 'electron'`,
-      `import { something } from './electron-helpers'`,
-      `// import { app } from 'electron' — historical note`,
-      `const electron = require('electron')`,
+    const shouldNotFlag: Array<[string, string]> = [
+      ['type-only import', `import type { App } from 'electron'`],
+      ['type-only multi-named', `import type { App, BrowserWindow } from 'electron'`],
+      ['all-inline-type named import', `import { type App, type BrowserWindow } from 'electron'`],
+      ['similarly-named relative import', `import { something } from './electron-helpers'`],
+      ['commented-out import', `// import { app } from 'electron' — historical note`],
+      ['lazy require in expression', `const electron = require('electron')`],
     ]
-    for (const line of shouldMatch) {
-      expect(FORBIDDEN_IMPORT_RE.test(line), `should match: ${line}`).toBe(true)
+    for (const [label, source] of shouldFlag) {
+      expect(fileImportsElectronAtRuntime(source), `should flag: ${label}`).toBe(true)
     }
-    for (const line of shouldNotMatch) {
-      expect(FORBIDDEN_IMPORT_RE.test(line), `should not match: ${line}`).toBe(false)
+    for (const [label, source] of shouldNotFlag) {
+      expect(fileImportsElectronAtRuntime(source), `should not flag: ${label}`).toBe(false)
     }
   })
 
@@ -63,15 +75,20 @@ describe('MCP entry electron isolation', () => {
       visited.add(file)
 
       const source = fs.readFileSync(file, 'utf-8')
-      const lines = source.split('\n')
+      const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true)
 
-      lines.forEach((text, idx) => {
-        if (FORBIDDEN_IMPORT_RE.test(text)) {
-          offenders.push({ file, line: idx + 1, text: text.trim() })
-        }
-      })
+      for (const stmt of sf.statements) {
+        if (!ts.isImportDeclaration(stmt)) continue
+        if (!importsElectronAtRuntime(stmt)) continue
+        const { line } = sf.getLineAndCharacterOfPosition(stmt.getStart(sf))
+        offenders.push({
+          file,
+          line: line + 1,
+          text: stmt.getText(sf).replace(/\s+/g, ' ').trim(),
+        })
+      }
 
-      for (const spec of extractRelativeImportSpecifiers(source)) {
+      for (const spec of extractRelativeImportSpecifiers(sf)) {
         const resolved = resolveRelativeImport(file, spec)
         if (resolved) visit(resolved)
       }
@@ -93,16 +110,50 @@ describe('MCP entry electron isolation', () => {
   })
 })
 
-function extractRelativeImportSpecifiers(source: string): string[] {
-  // Match `import ... from './foo'` / `import ... from '../foo'` and
-  // side-effect `import './foo'`. Non-relative specifiers (npm packages,
-  // path aliases) are ignored — we only follow relative imports within
-  // src/main, which is where the regression surface lives.
+/**
+ * Returns true iff the source contains a top-level ES import from `'electron'`
+ * that will emit a runtime `require('electron')`. Type-only imports (either at
+ * the declaration level — `import type …` — or entirely via inline
+ * `{ type X }` specifiers) are stripped by the TS compiler and are safe.
+ */
+function fileImportsElectronAtRuntime(source: string): boolean {
+  const sf = ts.createSourceFile('probe.ts', source, ts.ScriptTarget.Latest, true)
+  return sf.statements.some(
+    (stmt) => ts.isImportDeclaration(stmt) && importsElectronAtRuntime(stmt),
+  )
+}
+
+function importsElectronAtRuntime(stmt: ts.ImportDeclaration): boolean {
+  const spec = stmt.moduleSpecifier
+  if (!ts.isStringLiteral(spec) || spec.text !== 'electron') return false
+
+  const clause = stmt.importClause
+  // Side-effect import: `import 'electron'` — always runtime.
+  if (!clause) return true
+  // `import type { … } from 'electron'`
+  if (clause.isTypeOnly) return false
+
+  const hasDefault = !!clause.name
+  const bindings = clause.namedBindings
+  if (bindings && ts.isNamespaceImport(bindings)) return true
+  if (bindings && ts.isNamedImports(bindings)) {
+    const hasRuntimeNamed = bindings.elements.some((el) => !el.isTypeOnly)
+    if (hasRuntimeNamed) return true
+    // All named bindings are inline-type-only.
+    return hasDefault
+  }
+  return hasDefault
+}
+
+function extractRelativeImportSpecifiers(sf: ts.SourceFile): string[] {
   const specifiers: string[] = []
-  const importRe = /import\s+(?:[^'"]*?\s+from\s+)?['"](\.\.?\/[^'"]+)['"]/g
-  let match: RegExpExecArray | null
-  while ((match = importRe.exec(source)) !== null) {
-    specifiers.push(match[1])
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue
+    const spec = stmt.moduleSpecifier
+    if (!ts.isStringLiteral(spec)) continue
+    if (spec.text.startsWith('./') || spec.text.startsWith('../')) {
+      specifiers.push(spec.text)
+    }
   }
   return specifiers
 }

--- a/src/main/mcp-entry-isolation.test.ts
+++ b/src/main/mcp-entry-isolation.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/**
+ * Guard: the MCP entry point runs under ELECTRON_RUN_AS_NODE=1, so the
+ * `electron` module is not resolvable at require time. No file in the static
+ * import graph starting at `src/main/mcp-entry.ts` may contain a top-level
+ * (non-type) import from `'electron'`, because ES imports are hoisted and
+ * would crash the MCP process before `main()` runs.
+ *
+ * Electron APIs may still be consulted lazily via `require('electron')`
+ * inside a try/catch — see `getElectronApp()` in `src/main/edition.ts` and
+ * `getBundledModelPath()` in `src/main/paths.ts`.
+ *
+ * This test reproduces the class of regression from the bug where
+ * `edition.ts` had `import { app } from 'electron'`, which Rollup placed in
+ * a shared chunk that the MCP entry transitively required.
+ */
+
+const PROJECT_ROOT = findProjectRoot(__dirname)
+const MAIN_DIR = path.join(PROJECT_ROOT, 'src', 'main')
+const MCP_ENTRY = path.join(MAIN_DIR, 'mcp-entry.ts')
+
+// Matches ES imports like `import ... from 'electron'` and side-effect
+// `import 'electron'`, but NOT `import type ... from 'electron'` — type
+// imports are stripped by the TS compiler and emit no runtime require.
+const FORBIDDEN_IMPORT_RE = /^\s*import\s+(?!type\b)(?:[^'"]*\s+from\s+)?['"]electron['"]\s*;?\s*$/
+
+describe('MCP entry electron isolation', () => {
+  it('FORBIDDEN_IMPORT_RE matches the patterns it is meant to catch', () => {
+    // Self-check: if this regex regresses, the main test below would
+    // silently pass even when offenders exist. Pin the behaviour.
+    const shouldMatch = [
+      `import { app } from 'electron'`,
+      `import { app, BrowserWindow } from "electron"`,
+      `import * as electron from 'electron'`,
+      `import electron from 'electron'`,
+      `import 'electron'`,
+      `  import { app } from 'electron';`,
+    ]
+    const shouldNotMatch = [
+      `import type { App } from 'electron'`,
+      `import type { App, BrowserWindow } from 'electron'`,
+      `import { something } from './electron-helpers'`,
+      `// import { app } from 'electron' — historical note`,
+      `const electron = require('electron')`,
+    ]
+    for (const line of shouldMatch) {
+      expect(FORBIDDEN_IMPORT_RE.test(line), `should match: ${line}`).toBe(true)
+    }
+    for (const line of shouldNotMatch) {
+      expect(FORBIDDEN_IMPORT_RE.test(line), `should not match: ${line}`).toBe(false)
+    }
+  })
+
+  it('no file in the mcp-entry import graph statically imports electron', () => {
+    const visited = new Set<string>()
+    const offenders: Array<{ file: string; line: number; text: string }> = []
+
+    function visit(file: string): void {
+      if (visited.has(file)) return
+      visited.add(file)
+
+      const source = fs.readFileSync(file, 'utf-8')
+      const lines = source.split('\n')
+
+      lines.forEach((text, idx) => {
+        if (FORBIDDEN_IMPORT_RE.test(text)) {
+          offenders.push({ file, line: idx + 1, text: text.trim() })
+        }
+      })
+
+      for (const spec of extractRelativeImportSpecifiers(source)) {
+        const resolved = resolveRelativeImport(file, spec)
+        if (resolved) visit(resolved)
+      }
+    }
+
+    visit(MCP_ENTRY)
+
+    if (offenders.length > 0) {
+      const report = offenders
+        .map((o) => `  ${path.relative(PROJECT_ROOT, o.file)}:${o.line} — ${o.text}`)
+        .join('\n')
+      throw new Error(
+        `MCP entry chain must not statically import 'electron' (the MCP process runs under ` +
+          `ELECTRON_RUN_AS_NODE=1, where the module is unresolvable). Use a lazy ` +
+          `try/require('electron') pattern instead. Offenders:\n${report}`,
+      )
+    }
+    expect(offenders).toEqual([])
+  })
+})
+
+function extractRelativeImportSpecifiers(source: string): string[] {
+  // Match `import ... from './foo'` / `import ... from '../foo'` and
+  // side-effect `import './foo'`. Non-relative specifiers (npm packages,
+  // path aliases) are ignored — we only follow relative imports within
+  // src/main, which is where the regression surface lives.
+  const specifiers: string[] = []
+  const importRe = /import\s+(?:[^'"]*?\s+from\s+)?['"](\.\.?\/[^'"]+)['"]/g
+  let match: RegExpExecArray | null
+  while ((match = importRe.exec(source)) !== null) {
+    specifiers.push(match[1])
+  }
+  return specifiers
+}
+
+function resolveRelativeImport(fromFile: string, specifier: string): string | null {
+  const base = path.resolve(path.dirname(fromFile), specifier)
+  const candidates = [
+    base + '.ts',
+    base + '.tsx',
+    path.join(base, 'index.ts'),
+    path.join(base, 'index.tsx'),
+  ]
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate
+  }
+  return null
+}
+
+function findProjectRoot(startDir: string): string {
+  let dir = startDir
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) return dir
+    dir = path.dirname(dir)
+  }
+  throw new Error('Could not find project root')
+}

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -76,26 +76,39 @@ export function getModelCacheDir(): string {
   return path.join(getAppDataPath(), 'models')
 }
 
-export function getBundledModelPath(): string | null {
-  if (!process.versions.electron) return null
-
-  let isPackaged: boolean | null = null
+/**
+ * Returns Electron's `app` object if available, otherwise null.
+ *
+ * Lazy `require('electron')` inside try/catch so this is safe to call from
+ * code paths that may run under `ELECTRON_RUN_AS_NODE=1` (e.g. the MCP entry),
+ * where the `electron` module is unresolvable. A top-level
+ * `import { app } from 'electron'` would crash the MCP process at module init,
+ * before `main()` runs — see `mcp-entry-isolation.test.ts`.
+ */
+export function getElectronAppOrNull(): {
+  isPackaged?: boolean
+  getAppPath?: () => string
+} | null {
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const electron = require('electron')
     if (typeof electron === 'object' && electron !== null && 'app' in electron) {
-      const app = (electron as { app?: { isPackaged?: boolean } }).app
-      if (typeof app?.isPackaged === 'boolean') {
-        isPackaged = app.isPackaged
-      }
+      return (electron as { app: { isPackaged?: boolean; getAppPath?: () => string } }).app
     }
   } catch {
-    // Running under ELECTRON_RUN_AS_NODE can make require('electron') unavailable
+    // ELECTRON_RUN_AS_NODE — electron module unavailable
   }
+  return null
+}
 
-  if (isPackaged === null) {
-    isPackaged = isPackagedElectronExecutable(process.execPath)
-  }
+export function getBundledModelPath(): string | null {
+  if (!process.versions.electron) return null
+
+  const app = getElectronAppOrNull()
+  const isPackaged =
+    typeof app?.isPackaged === 'boolean'
+      ? app.isPackaged
+      : isPackagedElectronExecutable(process.execPath)
   if (!isPackaged) return null
 
   const bundled = path.join(process.resourcesPath, 'models')


### PR DESCRIPTION
## Summary

- `src/main/edition.ts` had `import { app } from 'electron'` at the top level. Rollup code-split it into a shared chunk (`chunks/edition-*.js`) that both `index.ts` and `mcp-entry.ts` depended on. When Claude Desktop launched the packaged MCP entry under `ELECTRON_RUN_AS_NODE=1`, the `electron` module was unresolvable and the process crashed with `Cannot find module 'electron'` before `main()` ran.
- Switch to the lazy `try/require('electron')` pattern already used by `getBundledModelPath()` in `paths.ts`. Falls back to `isPackagedElectronExecutable(process.execPath)` for the packaged check and `process.cwd()` for the dev `getAppPath` — both correct for the packaged MCP entry.
- Add `src/main/mcp-entry-isolation.test.ts`: walks the import graph from `mcp-entry.ts` and fails if any file contains a top-level ES `import ... from 'electron'`. Includes a regex self-check so a silent regex regression can't let real offenders slip through.

## Error this fixes

```
Error: Cannot find module 'electron'
Require stack:
- /Applications/MemoryLane.app/.../out/main/chunks/edition-*.js
- /Applications/MemoryLane.app/.../out/main/mcp-entry.js
```

## Test plan

- [x] `npm test -- src/main/mcp` — all 49 MCP-adjacent tests pass
- [x] `npm run build` — new `chunks/edition-*.js` no longer has a top-level `require('electron')`; both remaining requires are inside try/catch
- [x] `npm run lint` — clean
- [ ] Package the app (`npm run make:mac`), replace `/Applications/MemoryLane.app`, `Cmd+R` in Claude Desktop, confirm the `memorylane` MCP server attaches and tools are listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)