### PR TITLE
fix(semantic): skip client rebuild when updateApiKey gets the same key

### DIFF
--- a/src/main/activity-semantic-service.test.ts
+++ b/src/main/activity-semantic-service.test.ts
@@ -475,6 +475,23 @@ describe('ActivitySemanticService', () => {
     })
   })
 
+  it('does not rebuild the OpenRouter client or reset health when updateApiKey gets the same key', async () => {
+    mockSend.mockResolvedValueOnce(response('OK'))
+
+    const service = new ActivitySemanticService('test-key', {
+      usageTracker: { recordUsage: vi.fn() },
+    })
+
+    await service.testConnection()
+    expect(service.getLlmHealthStatus().state).toBe('active')
+    expect(OpenRouter).toHaveBeenCalledTimes(1)
+
+    service.updateApiKey('test-key')
+
+    expect(OpenRouter).toHaveBeenCalledTimes(1)
+    expect(service.getLlmHealthStatus().state).toBe('active')
+  })
+
   it('marks LLM failing after a failed connection test', async () => {
     const service = new ActivitySemanticService(undefined, {
       client: { chat: { send: vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')) } },

--- a/src/main/semantic/service.ts
+++ b/src/main/semantic/service.ts
@@ -172,6 +172,14 @@ export class ActivitySemanticService implements SemanticServiceContract {
     }
 
     const normalizedKey = apiKey && apiKey.trim().length > 0 ? apiKey : null
+
+    if (
+      normalizedKey === this.openRouterApiKey &&
+      (normalizedKey === null || this.client !== null)
+    ) {
+      return
+    }
+
     this.openRouterApiKey = normalizedKey
 
     if (normalizedKey) {


### PR DESCRIPTION
## Summary

- Stops the every-5-minute Mistral Small \"Reply with OK\" probe seen in OpenRouter logs on enterprise builds.
- `EnterpriseAccessProvider` polls `/license/status` + `/license/key` every 5 minutes and re-pushes the (unchanged) managed key into `ActivitySemanticService.updateApiKey`. That call unconditionally rebuilt the OpenRouter client and reset health to `unknown`, which the renderer's `useLlmHealth` hook then resolved by firing `testConnection()` — a probe to the first snapshot model (Mistral Small).
- Fix: short-circuit `updateApiKey` when the normalized key matches the one already in use and the client exists. No client churn, no health reset, no probe.

Out of scope (intentionally): the 5-minute `/license/status` poll itself, redundant `apiKeyManager.saveApiKey` disk writes, and a similar idempotency guard for `updateEndpoint` (custom-endpoint path is not on the periodic timer).

## Test plan

- [x] `npx vitest run src/main/activity-semantic-service.test.ts` — 39/39 passing, including new `does not rebuild the OpenRouter client or reset health when updateApiKey gets the same key`.
- [ ] Manual: run enterprise dev build, leave main window on home page for 10–15 min, confirm OpenRouter dashboard shows no new 7-in/3-out Mistral Small rows and main-process log no longer prints `[ActivitySemanticService] Connection test succeeded` every 5 min.
- [ ] Manual regression: change the API key in settings; connection test should still fire once and health should cycle `unknown → active`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)