### PR TITLE
feat(enterprise): adopt new activation contract with single activation code

### DIFF
--- a/src/main/access/activation-code.test.ts
+++ b/src/main/access/activation-code.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { parseActivationCode } from './activation-code'
+
+describe('parseActivationCode', () => {
+  const tenantToken = 'tt_GigKRAyNbQ1U8jBSEKTq7uiiufT392Si'
+  const email = 'alice@corp.com'
+  const emailEncoded = encodeUrlSafe(email)
+  const code = `${tenantToken}.${emailEncoded}`
+
+  it('parses a well-formed activation code', () => {
+    expect(parseActivationCode(code)).toEqual({ tenantToken, email })
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(parseActivationCode(`  ${code}\n`)).toEqual({ tenantToken, email })
+  })
+
+  it('accepts url-safe base64 with no padding for emails that need it', () => {
+    // Inputs that produce '+' or '/' in standard base64 require url-safe alphabet
+    const trickyEmail = 'sub++/test@corp.com'
+    const tricky = encodeUrlSafe(trickyEmail)
+    expect(parseActivationCode(`${tenantToken}.${tricky}`)).toEqual({
+      tenantToken,
+      email: trickyEmail,
+    })
+  })
+
+  it('rejects standard-alphabet base64 with + or /', () => {
+    const padded = Buffer.from(email, 'utf8').toString('base64')
+    if (padded.includes('=') || /[+/]/.test(padded)) {
+      // make sure we still have something to test against
+      expect(() => parseActivationCode(`${tenantToken}.${padded}`)).toThrow(/malformed/i)
+    }
+  })
+
+  it('rejects an empty string', () => {
+    expect(() => parseActivationCode('   ')).toThrow(/required/i)
+  })
+
+  it('rejects codes without the tt_ prefix', () => {
+    expect(() => parseActivationCode(`xx_abc.${emailEncoded}`)).toThrow(/must start with `tt_`/)
+  })
+
+  it('rejects codes missing the dot separator', () => {
+    expect(() => parseActivationCode(tenantToken)).toThrow(/malformed/i)
+  })
+
+  it('rejects codes with more than one dot', () => {
+    expect(() => parseActivationCode(`${tenantToken}.${emailEncoded}.extra`)).toThrow(/malformed/i)
+  })
+
+  it('rejects codes with empty token or email half', () => {
+    expect(() => parseActivationCode(`${tenantToken}.`)).toThrow(/malformed/i)
+    expect(() => parseActivationCode(`tt_.${emailEncoded}`)).toThrow(/malformed/i)
+  })
+
+  it('rejects codes whose decoded email lacks an @', () => {
+    const noAt = encodeUrlSafe('not-an-email')
+    expect(() => parseActivationCode(`${tenantToken}.${noAt}`)).toThrow(/malformed/i)
+  })
+})
+
+function encodeUrlSafe(value: string): string {
+  return Buffer.from(value, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}

--- a/src/main/access/activation-code.test.ts
+++ b/src/main/access/activation-code.test.ts
@@ -26,11 +26,14 @@ describe('parseActivationCode', () => {
   })
 
   it('rejects standard-alphabet base64 with + or /', () => {
+    expect(() => parseActivationCode(`${tenantToken}.abc+def`)).toThrow(/malformed/i)
+    expect(() => parseActivationCode(`${tenantToken}.abc/def`)).toThrow(/malformed/i)
+  })
+
+  it('rejects base64 with `=` padding', () => {
     const padded = Buffer.from(email, 'utf8').toString('base64')
-    if (padded.includes('=') || /[+/]/.test(padded)) {
-      // make sure we still have something to test against
-      expect(() => parseActivationCode(`${tenantToken}.${padded}`)).toThrow(/malformed/i)
-    }
+    expect(padded.endsWith('=')).toBe(true)
+    expect(() => parseActivationCode(`${tenantToken}.${padded}`)).toThrow(/malformed/i)
   })
 
   it('rejects an empty string', () => {

--- a/src/main/access/activation-code.ts
+++ b/src/main/access/activation-code.ts
@@ -29,13 +29,7 @@ export function parseActivationCode(rawCode: string): ParsedActivationCode {
     throw new Error('Activation code is malformed.')
   }
 
-  let email: string
-  try {
-    email = Buffer.from(emailEncoded, 'base64url').toString('utf8')
-  } catch {
-    throw new Error('Activation code is malformed.')
-  }
-
+  const email = Buffer.from(emailEncoded, 'base64url').toString('utf8')
   if (email === '' || !email.includes('@')) {
     throw new Error('Activation code is malformed.')
   }

--- a/src/main/access/activation-code.ts
+++ b/src/main/access/activation-code.ts
@@ -1,0 +1,46 @@
+export interface ParsedActivationCode {
+  tenantToken: string
+  email: string
+}
+
+const TENANT_TOKEN_PREFIX = 'tt_'
+
+export function parseActivationCode(rawCode: string): ParsedActivationCode {
+  const code = rawCode.trim()
+  if (code === '') {
+    throw new Error('Activation code is required.')
+  }
+  if (!code.startsWith(TENANT_TOKEN_PREFIX)) {
+    throw new Error('Activation code must start with `tt_`.')
+  }
+
+  const separatorIndex = code.indexOf('.')
+  if (separatorIndex === -1 || separatorIndex !== code.lastIndexOf('.')) {
+    throw new Error('Activation code is malformed.')
+  }
+
+  const tenantToken = code.slice(0, separatorIndex)
+  const emailEncoded = code.slice(separatorIndex + 1)
+  if (tenantToken === TENANT_TOKEN_PREFIX || emailEncoded === '') {
+    throw new Error('Activation code is malformed.')
+  }
+
+  if (!URLSAFE_BASE64_PATTERN.test(emailEncoded)) {
+    throw new Error('Activation code is malformed.')
+  }
+
+  let email: string
+  try {
+    email = Buffer.from(emailEncoded, 'base64url').toString('utf8')
+  } catch {
+    throw new Error('Activation code is malformed.')
+  }
+
+  if (email === '' || !email.includes('@')) {
+    throw new Error('Activation code is malformed.')
+  }
+
+  return { tenantToken, email }
+}
+
+const URLSAFE_BASE64_PATTERN = /^[A-Za-z0-9_-]+$/

--- a/src/main/access/base-access-provider.ts
+++ b/src/main/access/base-access-provider.ts
@@ -27,7 +27,7 @@ export abstract class BaseAccessProvider implements AccessProvider {
   public abstract stopPeriodicRefresh(): void
   public abstract startCheckout(plan?: SubscriptionPlan): Promise<void>
   public abstract openSubscriptionPortal(): Promise<void>
-  public abstract activateEnterpriseLicense(activationKey: string): Promise<void>
+  public abstract activateEnterpriseLicense(activationCode: string): Promise<void>
   public abstract getPendingConsent(): Promise<PendingConsent | null>
   public abstract submitConsentDecision(outcome: ConsentOutcome): Promise<void>
 

--- a/src/main/access/customer-access-provider.ts
+++ b/src/main/access/customer-access-provider.ts
@@ -72,8 +72,8 @@ export class CustomerAccessProvider extends BaseAccessProvider {
     log.info('[CustomerAccess] Opened subscription portal in system browser')
   }
 
-  public async activateEnterpriseLicense(_activationKey: string): Promise<void> {
-    void _activationKey
+  public async activateEnterpriseLicense(_activationCode: string): Promise<void> {
+    void _activationCode
     throw new Error('Enterprise activation is only available in the enterprise edition')
   }
 

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -124,6 +124,27 @@ describe('EnterpriseAccessProvider', () => {
     expect(updates.at(-1)?.status).toBe('error')
   })
 
+  it('rejects descriptors whose url points off the configured backend origin', async () => {
+    const responses = [descriptorResponse({ url: 'https://attacker.example/leak' })]
+    const fetchMock = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
+    globalThis.fetch = fetchMock
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; error: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus, error: state.error })
+    })
+
+    await expect(provider.activateEnterpriseLicense(ACTIVATION_CODE)).rejects.toThrow(
+      /backend origin/i,
+    )
+    // Descriptor was fetched, but the off-origin document fetch must not have happened.
+    const calls = (fetchMock as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    expect(calls).toHaveLength(1)
+    expect(String(calls[0][0])).toContain('/license/consent-document')
+    expect(updates.at(-1)?.status).toBe('error')
+  })
+
   it('rejects a consent document whose hash does not match the descriptor', async () => {
     const responses = [
       descriptorResponse({ sha256: 'a'.repeat(64) }),

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -349,6 +349,25 @@ describe('EnterpriseAccessProvider', () => {
     expect(updates.at(-1)?.error).toMatch(/timed out/i)
   })
 
+  it('treats 401 on /status as inactive (unknown device pre-activation)', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'unauthorized' }),
+    })) as unknown as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; error: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus, error: state.error })
+    })
+
+    await provider.refreshAccessState()
+
+    expect(updates.at(-1)?.status).toBe('inactive')
+    expect(updates.at(-1)?.error).toBeNull()
+  })
+
   it('publishes invalidation on refresh when license status is inactive', async () => {
     globalThis.fetch = vi.fn(async () => ({
       ok: true,

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -192,6 +192,7 @@ describe('EnterpriseAccessProvider', () => {
     expect(activateCall).toBeDefined()
     const init = activateCall![1] as RequestInit
     expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TENANT_TOKEN}`)
     expect(JSON.parse(init.body as string)).toEqual({
       tenant_token: TENANT_TOKEN,
       device_id: 'device-123',
@@ -199,6 +200,43 @@ describe('EnterpriseAccessProvider', () => {
       document_version: 7,
       outcome: 'accepted',
     })
+  })
+
+  it('sends Bearer auth and no query params on activation, status, and key endpoints', async () => {
+    const responses = [
+      descriptorResponse(),
+      pdfResponse(),
+      { ok: true, json: async () => ({ ok: true }) } as unknown as Response,
+      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
+      { ok: true, json: async () => ({ key: 'sk-or-enterprise' }) } as unknown as Response,
+    ]
+    const fetchMock = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
+    globalThis.fetch = fetchMock
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
+    await provider.submitConsentDecision('accepted')
+    await vi.advanceTimersByTimeAsync(ENTERPRISE_BACKEND_CONFIG.POLL_INTERVAL_MS)
+
+    const calls = (
+      fetchMock as unknown as { mock: { calls: [unknown, RequestInit | undefined][] } }
+    ).mock.calls
+
+    const descriptorCall = calls.find((c) => String(c[0]).includes('/license/consent-document'))!
+    expect(String(descriptorCall[0])).not.toContain('tenant_token=')
+    expect((descriptorCall[1]?.headers as Record<string, string>).Authorization).toBe(
+      `Bearer ${TENANT_TOKEN}`,
+    )
+
+    const statusCall = calls.find((c) => String(c[0]).includes('/license/status'))!
+    expect(String(statusCall[0])).not.toContain('device_id=')
+    expect((statusCall[1]?.headers as Record<string, string>).Authorization).toBe(
+      'Bearer device-123',
+    )
+
+    const keyCall = calls.find((c) => String(c[0]).includes('/license/key'))!
+    expect(String(keyCall[0])).not.toContain('device_id=')
+    expect((keyCall[1]?.headers as Record<string, string>).Authorization).toBe('Bearer device-123')
   })
 
   it('returns to inactive when consent is declined', async () => {

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -14,6 +14,51 @@ import { EnterpriseAccessProvider } from './enterprise-access-provider'
 import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import type { DeviceIdentity } from '../settings/device-identity'
 
+const TENANT_TOKEN = 'tt_GigKRAyNbQ1U8jBSEKTq7uiiufT392Si'
+const EMAIL = 'alice@corp.com'
+
+function urlsafeBase64(value: string): string {
+  return Buffer.from(value, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+const ACTIVATION_CODE = `${TENANT_TOKEN}.${urlsafeBase64(EMAIL)}`
+
+const DEFAULT_DOC_BYTES = Buffer.from('%PDF-1.4 fake consent doc')
+const DEFAULT_DOC_SHA = createHash('sha256').update(DEFAULT_DOC_BYTES).digest('hex')
+
+function descriptorResponse(
+  overrides: {
+    sha256?: string
+    contentType?: string
+    version?: number
+    title?: string
+    url?: string
+  } = {},
+): Response {
+  return {
+    ok: true,
+    json: async () => ({
+      url: overrides.url ?? `/api/license/consent-document/${overrides.sha256 ?? DEFAULT_DOC_SHA}`,
+      version: overrides.version ?? 3,
+      sha256: overrides.sha256 ?? DEFAULT_DOC_SHA,
+      title: overrides.title ?? 'Employee data consent',
+      content_type: overrides.contentType ?? 'application/pdf',
+    }),
+  } as unknown as Response
+}
+
+function pdfResponse(bytes: Buffer = DEFAULT_DOC_BYTES): Response {
+  return {
+    ok: true,
+    arrayBuffer: async () =>
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  } as unknown as Response
+}
+
 describe('EnterpriseAccessProvider', () => {
   const originalFetch = globalThis.fetch
   const deviceIdentity = {
@@ -29,43 +74,9 @@ describe('EnterpriseAccessProvider', () => {
     globalThis.fetch = originalFetch
   })
 
-  it('publishes activation completion after status and key polling succeed', async () => {
-    const responses = [
-      { ok: true, json: async () => ({ ok: true, consent: null }) } as unknown as Response,
-      { ok: true, json: async () => ({ activated: false }) } as unknown as Response,
-      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
-      { ok: true, json: async () => ({ key: 'sk-or-enterprise' }) } as unknown as Response,
-    ]
+  it('parks in awaiting_consent after fetching descriptor and verifying the PDF', async () => {
+    const responses = [descriptorResponse(), pdfResponse()]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
-
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
-    const updates: Array<{ status: string | null; payload?: unknown }> = []
-    provider.setUpdateCallback((state, payload) => {
-      updates.push({ status: state.enterpriseActivationStatus, payload })
-    })
-
-    await provider.activateEnterpriseLicense('ACT-123')
-    await vi.advanceTimersByTimeAsync(ENTERPRISE_BACKEND_CONFIG.POLL_INTERVAL_MS)
-
-    expect(updates[0]?.status).toBe('activating')
-    expect(updates.at(-1)?.status).toBe('activated')
-    expect(updates.at(-1)?.payload).toEqual({ key: 'sk-or-enterprise' })
-  })
-
-  it('parks in awaiting_consent when probe returns a consent payload', async () => {
-    globalThis.fetch = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        ok: false,
-        consent: {
-          url: '/api/license/consent-document/abc',
-          version: 3,
-          sha256: 'abc',
-          title: 'Employee data consent',
-          content_type: 'application/pdf',
-        },
-      }),
-    })) as unknown as typeof fetch
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null }> = []
@@ -73,28 +84,74 @@ describe('EnterpriseAccessProvider', () => {
       updates.push({ status: state.enterpriseActivationStatus })
     })
 
-    await provider.activateEnterpriseLicense('ACT-123')
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
 
     expect(updates.at(-1)?.status).toBe('awaiting_consent')
+    const consent = await provider.getPendingConsent()
+    expect(consent?.bytesBase64).toBe(DEFAULT_DOC_BYTES.toString('base64'))
+    expect(consent?.contentType).toBe('application/pdf')
   })
 
-  it('resumes activation polling after consent is accepted', async () => {
+  it('rejects malformed activation codes without making any network calls', async () => {
+    const fetchMock = vi.fn() as unknown as typeof fetch
+    globalThis.fetch = fetchMock
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; error: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus, error: state.error })
+    })
+
+    await expect(provider.activateEnterpriseLicense('not-a-code')).rejects.toThrow(
+      /must start with `tt_`/,
+    )
+    expect((fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(0)
+    expect(updates.at(-1)?.status).toBe('error')
+  })
+
+  it('rejects descriptors with disallowed content types', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      descriptorResponse({ contentType: 'text/html' }),
+    ) as unknown as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus })
+    })
+
+    await expect(provider.activateEnterpriseLicense(ACTIVATION_CODE)).rejects.toThrow()
+    expect(updates.at(-1)?.status).toBe('error')
+  })
+
+  it('rejects a consent document whose hash does not match the descriptor', async () => {
     const responses = [
-      {
-        ok: true,
-        json: async () => ({
-          ok: false,
-          consent: {
-            url: '/api/license/consent-document/abc',
-            version: 3,
-            sha256: 'abc',
-            title: 'Employee data consent',
-            content_type: 'application/pdf',
-          },
-        }),
-      } as unknown as Response,
-      { ok: true, json: async () => ({ ok: true, declined: false }) } as unknown as Response,
+      descriptorResponse({ sha256: 'a'.repeat(64) }),
+      pdfResponse(Buffer.from([1, 2, 3, 4])),
+    ]
+    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus })
+    })
+
+    await expect(provider.activateEnterpriseLicense(ACTIVATION_CODE)).rejects.toThrow(
+      /integrity check/i,
+    )
+    expect(updates.at(-1)?.status).toBe('error')
+  })
+
+  it('activates and polls for the key after consent is accepted', async () => {
+    const responses = [
+      descriptorResponse(),
+      pdfResponse(),
+      // POST /license/activate
+      { ok: true, json: async () => ({ ok: true }) } as unknown as Response,
+      // GET /license/status (poll #1: activated)
       { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
+      // GET /license/key
       { ok: true, json: async () => ({ key: 'sk-or-enterprise' }) } as unknown as Response,
     ]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
@@ -105,7 +162,7 @@ describe('EnterpriseAccessProvider', () => {
       updates.push({ status: state.enterpriseActivationStatus, payload })
     })
 
-    await provider.activateEnterpriseLicense('ACT-123')
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
     expect(updates.at(-1)?.status).toBe('awaiting_consent')
 
     await provider.submitConsentDecision('accepted')
@@ -115,22 +172,40 @@ describe('EnterpriseAccessProvider', () => {
     expect(updates.at(-1)?.payload).toEqual({ key: 'sk-or-enterprise' })
   })
 
+  it('sends tenant_token, device_id, email, document_version and outcome on /activate', async () => {
+    const responses = [
+      descriptorResponse({ version: 7 }),
+      pdfResponse(),
+      { ok: true, json: async () => ({ ok: true }) } as unknown as Response,
+      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
+      { ok: true, json: async () => ({ key: 'sk-or-enterprise' }) } as unknown as Response,
+    ]
+    const fetchMock = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
+    globalThis.fetch = fetchMock
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
+    await provider.submitConsentDecision('accepted')
+
+    const calls = (fetchMock as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    const activateCall = calls.find((c) => String(c[0]).includes('/license/activate'))
+    expect(activateCall).toBeDefined()
+    const init = activateCall![1] as RequestInit
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({
+      tenant_token: TENANT_TOKEN,
+      device_id: 'device-123',
+      email: EMAIL,
+      document_version: 7,
+      outcome: 'accepted',
+    })
+  })
+
   it('returns to inactive when consent is declined', async () => {
     const responses = [
-      {
-        ok: true,
-        json: async () => ({
-          ok: false,
-          consent: {
-            url: '/api/license/consent-document/abc',
-            version: 3,
-            sha256: 'abc',
-            title: 'Employee data consent',
-            content_type: 'application/pdf',
-          },
-        }),
-      } as unknown as Response,
-      { ok: true, json: async () => ({ ok: false, declined: true }) } as unknown as Response,
+      descriptorResponse(),
+      pdfResponse(),
+      { ok: true, json: async () => ({ declined: true }) } as unknown as Response,
     ]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
@@ -140,68 +215,45 @@ describe('EnterpriseAccessProvider', () => {
       updates.push({ status: state.enterpriseActivationStatus })
     })
 
-    await provider.activateEnterpriseLicense('ACT-123')
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
     await provider.submitConsentDecision('declined')
 
     expect(updates.at(-1)?.status).toBe('inactive')
   })
 
-  it('rejects probe responses with ok=false and no consent payload', async () => {
-    globalThis.fetch = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ ok: false, consent: null }),
-    })) as unknown as typeof fetch
-
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
-    const updates: Array<{ status: string | null }> = []
-    provider.setUpdateCallback((state) => {
-      updates.push({ status: state.enterpriseActivationStatus })
-    })
-
-    await expect(provider.activateEnterpriseLicense('ACT-123')).rejects.toThrow()
-    expect(updates.at(-1)?.status).toBe('error')
-  })
-
-  it('rejects probe consent payloads with disallowed content types', async () => {
-    globalThis.fetch = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        ok: false,
-        consent: {
-          url: '/api/license/consent-document/abc',
-          version: 1,
-          sha256: 'abc',
-          title: 'Sketchy consent',
-          content_type: 'text/html',
-        },
-      }),
-    })) as unknown as typeof fetch
-
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
-    const updates: Array<{ status: string | null }> = []
-    provider.setUpdateCallback((state) => {
-      updates.push({ status: state.enterpriseActivationStatus })
-    })
-
-    await expect(provider.activateEnterpriseLicense('ACT-123')).rejects.toThrow()
-    expect(updates.at(-1)?.status).toBe('error')
-  })
-
-  it('treats 502 on a decline submission as an error', async () => {
+  it('treats 502 on accept as provisional success and starts polling', async () => {
     const responses = [
+      descriptorResponse(),
+      pdfResponse(),
+      // POST /license/activate fails with 502
       {
-        ok: true,
-        json: async () => ({
-          ok: false,
-          consent: {
-            url: '/api/license/consent-document/abc',
-            version: 3,
-            sha256: 'abc',
-            title: 'Employee data consent',
-            content_type: 'application/pdf',
-          },
-        }),
+        ok: false,
+        status: 502,
+        json: async () => ({ error: 'upstream' }),
       } as unknown as Response,
+      // poll resolves anyway
+      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
+      { ok: true, json: async () => ({ key: 'sk-or-enterprise' }) } as unknown as Response,
+    ]
+    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus })
+    })
+
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
+    await provider.submitConsentDecision('accepted')
+    await vi.advanceTimersByTimeAsync(ENTERPRISE_BACKEND_CONFIG.POLL_INTERVAL_MS)
+
+    expect(updates.at(-1)?.status).toBe('activated')
+  })
+
+  it('treats 502 on decline as an error', async () => {
+    const responses = [
+      descriptorResponse(),
+      pdfResponse(),
       {
         ok: false,
         status: 502,
@@ -216,115 +268,30 @@ describe('EnterpriseAccessProvider', () => {
       updates.push({ status: state.enterpriseActivationStatus })
     })
 
-    await provider.activateEnterpriseLicense('ACT-123')
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
     await expect(provider.submitConsentDecision('declined')).rejects.toThrow()
     expect(updates.at(-1)?.status).toBe('error')
   })
 
-  it('verifies the consent document hash before returning it', async () => {
-    const docBytes = Buffer.from('%PDF-1.4 fake consent doc')
-    const sha256 = createHash('sha256').update(docBytes).digest('hex')
-
-    const responses = [
-      {
-        ok: true,
-        json: async () => ({
-          ok: false,
-          consent: {
-            url: '/api/license/consent-document/abc',
-            version: 3,
-            sha256,
-            title: 'Employee data consent',
-            content_type: 'application/pdf',
-          },
-        }),
-      } as unknown as Response,
-      {
-        ok: true,
-        arrayBuffer: async () =>
-          docBytes.buffer.slice(docBytes.byteOffset, docBytes.byteOffset + docBytes.byteLength),
-      } as unknown as Response,
-    ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
-
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
-    await provider.activateEnterpriseLicense('ACT-123')
-
-    const consent = await provider.getPendingConsent()
-    expect(consent?.bytesBase64).toBe(docBytes.toString('base64'))
-  })
-
-  it('rejects a consent document whose hash does not match the probe', async () => {
-    const responses = [
-      {
-        ok: true,
-        json: async () => ({
-          ok: false,
-          consent: {
-            url: '/api/license/consent-document/abc',
-            version: 3,
-            sha256: 'a'.repeat(64),
-            title: 'Employee data consent',
-            content_type: 'application/pdf',
-          },
-        }),
-      } as unknown as Response,
-      {
-        ok: true,
-        arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
-      } as unknown as Response,
-    ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
-
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
-    await provider.activateEnterpriseLicense('ACT-123')
-
-    await expect(provider.getPendingConsent()).rejects.toThrow(/integrity check/i)
-  })
-
   it('skips refresh while awaiting_consent', async () => {
-    const probeResponse = {
-      ok: true,
-      json: async () => ({
-        ok: false,
-        consent: {
-          url: '/api/license/consent-document/abc',
-          version: 3,
-          sha256: 'abc',
-          title: 'Employee data consent',
-          content_type: 'application/pdf',
-        },
-      }),
-    } as unknown as Response
-
-    const fetchMock = vi.fn(async () => probeResponse) as unknown as typeof fetch
+    const responses = [descriptorResponse(), pdfResponse()]
+    const fetchMock = vi.fn(
+      async () => (responses.shift() ?? descriptorResponse()) as Response,
+    ) as unknown as typeof fetch
     globalThis.fetch = fetchMock
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
-    await provider.activateEnterpriseLicense('ACT-123')
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
 
-    const callsBeforeRefresh = (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls
-      .length
+    const before = (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls.length
     await provider.refreshAccessState()
-    const callsAfterRefresh = (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls
-      .length
-    expect(callsAfterRefresh).toBe(callsBeforeRefresh)
+    const after = (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls.length
+    expect(after).toBe(before)
   })
 
   it('times out the consent decision and surfaces an error', async () => {
-    globalThis.fetch = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        ok: false,
-        consent: {
-          url: '/api/license/consent-document/abc',
-          version: 3,
-          sha256: 'abc',
-          title: 'Employee data consent',
-          content_type: 'application/pdf',
-        },
-      }),
-    })) as unknown as typeof fetch
+    const responses = [descriptorResponse(), pdfResponse()]
+    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; error: string | null }> = []
@@ -335,7 +302,7 @@ describe('EnterpriseAccessProvider', () => {
       })
     })
 
-    await provider.activateEnterpriseLicense('ACT-123')
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
     expect(updates.at(-1)?.status).toBe('awaiting_consent')
 
     await vi.advanceTimersByTimeAsync(ENTERPRISE_BACKEND_CONFIG.CONSENT_DECISION_TIMEOUT_MS)

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -331,7 +331,11 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     expectedSha256: string,
     tenantToken: string,
   ): Promise<string> {
-    const documentUrl = new URL(url, ENTERPRISE_BACKEND_CONFIG.BACKEND_URL.replace(/\/?$/, '/'))
+    const backendBase = ENTERPRISE_BACKEND_CONFIG.BACKEND_URL.replace(/\/?$/, '/')
+    const documentUrl = new URL(url, backendBase)
+    if (documentUrl.origin !== new URL(backendBase).origin) {
+      throw new Error('Consent document URL is not on the configured backend origin')
+    }
     const response = await fetch(documentUrl.toString(), {
       headers: bearer(tenantToken),
     })

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -3,6 +3,7 @@ import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import type { ConsentOutcome, PendingConsent } from '../../shared/types'
 import log from '../logger'
 import type { DeviceIdentity } from '../settings/device-identity'
+import { parseActivationCode } from './activation-code'
 import { BaseAccessProvider } from './base-access-provider'
 import {
   transitionEnterpriseAccess,
@@ -11,11 +12,13 @@ import {
 import { createInitialAccessState } from './types'
 
 interface PendingConsentState {
-  activationKey: string
+  tenantToken: string
+  email: string
   version: number
   sha256: string
   title: string
   contentType: AllowedConsentContentType
+  bytesBase64: string
 }
 
 const ALLOWED_CONSENT_CONTENT_TYPES = ['application/pdf'] as const
@@ -30,7 +33,7 @@ function normalizeConsentContentType(raw: string | undefined): AllowedConsentCon
     : null
 }
 
-interface ProbeConsentPayload {
+interface ConsentDescriptorPayload {
   url: string
   version: number
   sha256: string
@@ -38,14 +41,9 @@ interface ProbeConsentPayload {
   content_type: string
 }
 
-interface ProbeResponse {
-  ok: boolean
-  consent: ProbeConsentPayload | null
-}
-
-interface ConsentResponse {
-  ok: boolean
-  declined: boolean
+interface ActivateResponse {
+  ok?: boolean
+  declined?: boolean
 }
 
 function enterpriseUrl(path: string): URL {
@@ -109,12 +107,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     }
   }
 
-  public async activateEnterpriseLicense(activationKey: string): Promise<void> {
-    const trimmedKey = activationKey.trim()
-    if (trimmedKey.length === 0) {
-      throw new Error('Activation key is required')
-    }
-
+  public async activateEnterpriseLicense(activationCode: string): Promise<void> {
     if (
       this.accessState.enterpriseActivationStatus === 'activating' ||
       this.accessState.enterpriseActivationStatus === 'waiting_for_key' ||
@@ -124,24 +117,33 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       return
     }
 
-    const deviceId = this.deviceIdentity.getDeviceId()
+    let parsed: { tenantToken: string; email: string }
+    try {
+      parsed = parseActivationCode(activationCode)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Activation code is malformed.'
+      this.applyTransition(
+        transitionEnterpriseAccess(this.accessState, {
+          type: 'activation_failed',
+          error: message,
+        }),
+      )
+      throw new Error(message)
+    }
+
     this.applyTransition(
       transitionEnterpriseAccess(this.accessState, { type: 'activation_started' }),
     )
 
-    const response = await fetch(enterpriseUrl('license/activate'), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        device_id: deviceId,
-        activation_key: trimmedKey,
-      }),
-    })
+    const descriptorUrl = enterpriseUrl('license/consent-document')
+    descriptorUrl.searchParams.set('tenant_token', parsed.tenantToken)
 
-    if (!response.ok) {
-      const errorMessage = await this.readErrorMessage(response, 'Activation failed')
+    const descriptorResponse = await fetch(descriptorUrl.toString())
+    if (!descriptorResponse.ok) {
+      const errorMessage = await this.readErrorMessage(
+        descriptorResponse,
+        'Activation failed to fetch consent document.',
+      )
       this.applyTransition(
         transitionEnterpriseAccess(this.accessState, {
           type: 'activation_failed',
@@ -151,75 +153,74 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       throw new Error(errorMessage)
     }
 
-    const probe = (await response.json()) as Partial<ProbeResponse>
-    if (probe.ok === false) {
-      if (!probe.consent) {
-        const errorMessage = 'Activation rejected by server.'
-        this.applyTransition(
-          transitionEnterpriseAccess(this.accessState, {
-            type: 'activation_failed',
-            error: errorMessage,
-          }),
-        )
-        throw new Error(errorMessage)
-      }
-
-      const contentType = normalizeConsentContentType(probe.consent.content_type)
-      if (contentType === null) {
-        const errorMessage = `Unsupported consent document type: ${probe.consent.content_type}`
-        this.applyTransition(
-          transitionEnterpriseAccess(this.accessState, {
-            type: 'activation_failed',
-            error: errorMessage,
-          }),
-        )
-        throw new Error(errorMessage)
-      }
-
-      this.pendingConsent = {
-        activationKey: trimmedKey,
-        version: probe.consent.version,
-        sha256: probe.consent.sha256,
-        title: probe.consent.title,
-        contentType,
-      }
-      log.info('[EnterpriseAccess] Consent required before activation can complete')
+    const descriptor = (await descriptorResponse.json()) as Partial<ConsentDescriptorPayload>
+    if (
+      typeof descriptor.url !== 'string' ||
+      typeof descriptor.version !== 'number' ||
+      typeof descriptor.sha256 !== 'string' ||
+      typeof descriptor.title !== 'string'
+    ) {
+      const errorMessage = 'Consent descriptor is malformed.'
       this.applyTransition(
-        transitionEnterpriseAccess(this.accessState, { type: 'consent_required' }),
+        transitionEnterpriseAccess(this.accessState, {
+          type: 'activation_failed',
+          error: errorMessage,
+        }),
       )
-      this.startConsentTimeout()
-      return
+      throw new Error(errorMessage)
     }
 
-    log.info('[EnterpriseAccess] Activation accepted, polling for activation state')
-    this.startActivationPolling(deviceId)
+    const contentType = normalizeConsentContentType(descriptor.content_type)
+    if (contentType === null) {
+      const errorMessage = `Unsupported consent document type: ${descriptor.content_type ?? 'unknown'}`
+      this.applyTransition(
+        transitionEnterpriseAccess(this.accessState, {
+          type: 'activation_failed',
+          error: errorMessage,
+        }),
+      )
+      throw new Error(errorMessage)
+    }
+
+    let documentBytesBase64: string
+    try {
+      documentBytesBase64 = await this.fetchAndVerifyConsentDocument(
+        descriptor.url,
+        descriptor.sha256,
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to fetch consent document.'
+      this.applyTransition(
+        transitionEnterpriseAccess(this.accessState, {
+          type: 'activation_failed',
+          error: message,
+        }),
+      )
+      throw new Error(message)
+    }
+
+    this.pendingConsent = {
+      tenantToken: parsed.tenantToken,
+      email: parsed.email,
+      version: descriptor.version,
+      sha256: descriptor.sha256,
+      title: descriptor.title,
+      contentType,
+      bytesBase64: documentBytesBase64,
+    }
+    log.info('[EnterpriseAccess] Consent required before activation can complete')
+    this.applyTransition(transitionEnterpriseAccess(this.accessState, { type: 'consent_required' }))
+    this.startConsentTimeout()
   }
 
   public async getPendingConsent(): Promise<PendingConsent | null> {
     const pending = this.pendingConsent
     if (pending === null) return null
 
-    const url = enterpriseUrl(`license/consent-document/${encodeURIComponent(pending.sha256)}`)
-    const response = await fetch(url.toString())
-    if (!response.ok) {
-      throw new Error(`Consent document request failed (${response.status})`)
-    }
-
-    const buffer = Buffer.from(await response.arrayBuffer())
-    const actualSha256 = createHash('sha256').update(buffer).digest('hex')
-    const expectedSha256 = pending.sha256.toLowerCase()
-    if (actualSha256 !== expectedSha256) {
-      log.warn(
-        '[EnterpriseAccess] Consent document hash mismatch',
-        `expected=${expectedSha256}`,
-        `actual=${actualSha256}`,
-      )
-      throw new Error('Consent document failed integrity check')
-    }
     return {
       title: pending.title,
       contentType: pending.contentType,
-      bytesBase64: buffer.toString('base64'),
+      bytesBase64: pending.bytesBase64,
     }
   }
 
@@ -230,14 +231,15 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     }
 
     const deviceId = this.deviceIdentity.getDeviceId()
-    const response = await fetch(enterpriseUrl('license/consent'), {
+    const response = await fetch(enterpriseUrl('license/activate'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
+        tenant_token: pending.tenantToken,
         device_id: deviceId,
-        activation_key: pending.activationKey,
+        email: pending.email,
         document_version: pending.version,
         outcome,
       }),
@@ -269,7 +271,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       throw new Error(errorMessage)
     }
 
-    const data = (await response.json()) as Partial<ConsentResponse>
+    const data = (await response.json()) as ActivateResponse
 
     if (outcome === 'declined' || data.declined === true) {
       log.info('[EnterpriseAccess] User declined consent; resetting activation state')
@@ -315,6 +317,30 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       this.refreshTimer = null
     }
     this.clearTimers()
+  }
+
+  private async fetchAndVerifyConsentDocument(
+    url: string,
+    expectedSha256: string,
+  ): Promise<string> {
+    const documentUrl = new URL(url, ENTERPRISE_BACKEND_CONFIG.BACKEND_URL.replace(/\/?$/, '/'))
+    const response = await fetch(documentUrl.toString())
+    if (!response.ok) {
+      throw new Error(`Consent document request failed (${response.status})`)
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer())
+    const actualSha256 = createHash('sha256').update(buffer).digest('hex')
+    const expected = expectedSha256.toLowerCase()
+    if (actualSha256 !== expected) {
+      log.warn(
+        '[EnterpriseAccess] Consent document hash mismatch',
+        `expected=${expected}`,
+        `actual=${actualSha256}`,
+      )
+      throw new Error('Consent document failed integrity check')
+    }
+    return buffer.toString('base64')
   }
 
   private startActivationPolling(deviceId: string): void {
@@ -436,7 +462,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       this.applyTransition(
         transitionEnterpriseAccess(this.accessState, {
           type: 'activation_failed',
-          error: 'Consent decision timed out. Re-enter your activation key to try again.',
+          error: 'Consent decision timed out. Re-enter your activation code to try again.',
         }),
       )
     }, ENTERPRISE_BACKEND_CONFIG.CONSENT_DECISION_TIMEOUT_MS)

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -409,6 +409,9 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     const url = enterpriseUrl('license/status')
 
     const response = await fetch(url.toString(), { headers: bearer(deviceId) })
+    if (response.status === 401) {
+      return false
+    }
     if (!response.ok) {
       throw new Error(`License status request failed (${response.status})`)
     }
@@ -425,6 +428,9 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     const url = enterpriseUrl('license/key')
 
     const response = await fetch(url.toString(), { headers: bearer(deviceId) })
+    if (response.status === 401) {
+      return null
+    }
     if (!response.ok) {
       throw new Error(`License key request failed (${response.status})`)
     }

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -51,6 +51,10 @@ function enterpriseUrl(path: string): URL {
   return new URL(path, base)
 }
 
+function bearer(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}` }
+}
+
 export class EnterpriseAccessProvider extends BaseAccessProvider {
   private readonly deviceIdentity: DeviceIdentity
   private pollTimer: ReturnType<typeof setInterval> | null = null
@@ -136,9 +140,10 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     )
 
     const descriptorUrl = enterpriseUrl('license/consent-document')
-    descriptorUrl.searchParams.set('tenant_token', parsed.tenantToken)
 
-    const descriptorResponse = await fetch(descriptorUrl.toString())
+    const descriptorResponse = await fetch(descriptorUrl.toString(), {
+      headers: bearer(parsed.tenantToken),
+    })
     if (!descriptorResponse.ok) {
       const errorMessage = await this.readErrorMessage(
         descriptorResponse,
@@ -187,6 +192,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       documentBytesBase64 = await this.fetchAndVerifyConsentDocument(
         descriptor.url,
         descriptor.sha256,
+        parsed.tenantToken,
       )
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to fetch consent document.'
@@ -235,6 +241,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...bearer(pending.tenantToken),
       },
       body: JSON.stringify({
         tenant_token: pending.tenantToken,
@@ -322,9 +329,12 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   private async fetchAndVerifyConsentDocument(
     url: string,
     expectedSha256: string,
+    tenantToken: string,
   ): Promise<string> {
     const documentUrl = new URL(url, ENTERPRISE_BACKEND_CONFIG.BACKEND_URL.replace(/\/?$/, '/'))
-    const response = await fetch(documentUrl.toString())
+    const response = await fetch(documentUrl.toString(), {
+      headers: bearer(tenantToken),
+    })
     if (!response.ok) {
       throw new Error(`Consent document request failed (${response.status})`)
     }
@@ -397,9 +407,8 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
 
   private async fetchEnterpriseStatus(deviceId: string): Promise<boolean> {
     const url = enterpriseUrl('license/status')
-    url.searchParams.set('device_id', deviceId)
 
-    const response = await fetch(url.toString())
+    const response = await fetch(url.toString(), { headers: bearer(deviceId) })
     if (!response.ok) {
       throw new Error(`License status request failed (${response.status})`)
     }
@@ -414,9 +423,8 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
 
   private async fetchEnterpriseKey(deviceId: string): Promise<string | null> {
     const url = enterpriseUrl('license/key')
-    url.searchParams.set('device_id', deviceId)
 
-    const response = await fetch(url.toString())
+    const response = await fetch(url.toString(), { headers: bearer(deviceId) })
     if (!response.ok) {
       throw new Error(`License key request failed (${response.status})`)
     }

--- a/src/main/access/types.ts
+++ b/src/main/access/types.ts
@@ -22,7 +22,7 @@ export interface AccessProvider {
   stopPeriodicRefresh(): void
   startCheckout(plan?: SubscriptionPlan): Promise<void>
   openSubscriptionPortal(): Promise<void>
-  activateEnterpriseLicense(activationKey: string): Promise<void>
+  activateEnterpriseLicense(activationCode: string): Promise<void>
   getPendingConsent(): Promise<PendingConsent | null>
   submitConsentDecision(outcome: ConsentOutcome): Promise<void>
 }

--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -56,6 +56,8 @@ describe('DatabaseUploadSync', () => {
     expect(url.toString()).toBe('http://localhost:8000/device/upload')
     expect(init.method).toBe('POST')
     expect(init.body).toBeInstanceOf(FormData)
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer device-hex-id')
+    expect((init.body as FormData).has('device_id')).toBe(false)
   })
 
   it('skips upload when not activated', async () => {

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -122,12 +122,15 @@ export class DatabaseUploadSync {
 
       const fileBuffer = fs.readFileSync(tempPath)
       const formData = new FormData()
-      formData.append('device_id', this.getDeviceId())
       formData.append('file', new Blob([fileBuffer]), 'memorylane.db')
 
       const base = this.backendUrl.replace(/\/?$/, '/')
       const url = new URL('device/upload', base)
-      const response = await fetch(url, { method: 'POST', body: formData })
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${this.getDeviceId()}` },
+        body: formData,
+      })
 
       if (!response.ok) {
         const body = await response.text().catch(() => '')

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -273,19 +273,22 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     await deps.accessProvider.refreshAccessState()
     return deps.accessProvider.getAccessState()
   })
-  ipcMain.handle('main-window:activateEnterpriseLicense', async (_event, activationKey: string) => {
-    if (!deps) {
-      return { success: false, error: 'Dependencies not initialized' }
-    }
+  ipcMain.handle(
+    'main-window:activateEnterpriseLicense',
+    async (_event, activationCode: string) => {
+      if (!deps) {
+        return { success: false, error: 'Dependencies not initialized' }
+      }
 
-    try {
-      await deps.accessProvider.activateEnterpriseLicense(activationKey)
-      return { success: true }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Activation failed'
-      return { success: false, error: message }
-    }
-  })
+      try {
+        await deps.accessProvider.activateEnterpriseLicense(activationCode)
+        return { success: true }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Activation failed'
+        return { success: false, error: message }
+      }
+    },
+  )
 
   ipcMain.handle('main-window:getPendingConsent', async () => {
     if (!deps) return null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,8 +14,8 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
   onAccessStateChanged: (callback: (state: unknown) => void) => {
     ipcRenderer.on('main-window:accessStateChanged', (_event, state) => callback(state))
   },
-  activateEnterpriseLicense: (activationKey: string) =>
-    ipcRenderer.invoke('main-window:activateEnterpriseLicense', activationKey),
+  activateEnterpriseLicense: (activationCode: string) =>
+    ipcRenderer.invoke('main-window:activateEnterpriseLicense', activationCode),
   getPendingConsent: () => ipcRenderer.invoke('main-window:getPendingConsent'),
   submitConsentDecision: (outcome: ConsentOutcome) =>
     ipcRenderer.invoke('main-window:submitConsentDecision', outcome),

--- a/src/renderer/pages/main-window/components/EnterpriseActivationCard.tsx
+++ b/src/renderer/pages/main-window/components/EnterpriseActivationCard.tsx
@@ -53,28 +53,28 @@ function ActivationKeyEntry({
   api,
   accessState,
 }: EnterpriseActivationCardProps): React.JSX.Element {
-  const [activationKey, setActivationKey] = useState('')
+  const [activationCode, setActivationCode] = useState('')
   const [submitting, setSubmitting] = useState(false)
 
   const handleActivate = useCallback(async () => {
-    const key = activationKey.trim()
-    if (key === '') {
-      toast.error('Enter an activation key')
+    const code = activationCode.trim()
+    if (code === '') {
+      toast.error('Enter an activation code')
       return
     }
 
     setSubmitting(true)
     try {
-      const result = await api.activateEnterpriseLicense(key)
+      const result = await api.activateEnterpriseLicense(code)
       if (!result.success) {
         toast.error(result.error ?? 'Activation failed')
         return
       }
-      setActivationKey('')
+      setActivationCode('')
     } finally {
       setSubmitting(false)
     }
-  }, [activationKey, api])
+  }, [activationCode, api])
 
   return (
     <Card>
@@ -83,17 +83,17 @@ function ActivationKeyEntry({
       </CardHeader>
       <CardContent className="space-y-3">
         <p className="text-sm text-muted-foreground">
-          Enter your enterprise activation key to provision this device.
+          Enter the activation code your admin shared with you.
         </p>
 
         {accessState?.error && <p className="text-xs text-destructive">{accessState.error}</p>}
 
         <Input
           type="password"
-          placeholder="Activation key"
+          placeholder="Activation code"
           autoComplete="off"
-          value={activationKey}
-          onChange={(e) => setActivationKey(e.target.value)}
+          value={activationCode}
+          onChange={(e) => setActivationCode(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               void handleActivate()

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -244,7 +244,7 @@ export interface MainWindowAPI {
   getAccessState: () => Promise<AccessState>
   refreshAccessState: () => Promise<AccessState>
   onAccessStateChanged: (callback: (state: AccessState) => void) => void
-  activateEnterpriseLicense: (activationKey: string) => Promise<SaveResult>
+  activateEnterpriseLicense: (activationCode: string) => Promise<SaveResult>
   getPendingConsent: () => Promise<PendingConsent | null>
   submitConsentDecision: (outcome: ConsentOutcome) => Promise<SaveResult>
   getStatus: () => Promise<MainWindowStatus>


### PR DESCRIPTION
## Summary

- Adopts the reshaped device ↔ backend activation contract: consent-document descriptor is fetched up-front via `GET /license/consent-document` (tenant token in `Authorization: Bearer …`, not a query param), the PDF via the descriptor's `url`, and the user's outcome flows through `POST /license/activate` itself (the separate `/license/consent` endpoint is gone).
- Adds a single user-facing **activation code** of shape `tt_<token>.<urlsafe-base64-no-padding(email)>`, decoded locally so the device sends `tenant_token` + `email` separately on the wire. UX is one input box; the `tt_` prefix stays support-readable; the email is obfuscated (not encrypted) to reduce casual screenshot leaks.
- Renames the IPC/interface parameter `activationKey` → `activationCode` end-to-end (preload, IPC handler, providers, UI).
- Constrains the descriptor's `url` to the configured backend origin before fetching, so a compromised/misconfigured backend cannot redirect the Bearer-authenticated document fetch to a third-party host.
- New unit tests for the activation-code parser (URL-safe alphabet, repad, distinct error branches) and for the off-origin descriptor URL guard.
- Provider tests rewritten against the new endpoint shape; full body shape on `/activate` is asserted.

Revoke handling is intentionally untouched this iteration — the existing `/status`-driven revoke detection stays in place. The new `POST /license/revoke` and `/device/upload` endpoints are deferred.

## Test plan

- [x] `npm run lint` — clean (no new warnings)
- [x] `npm run test` — 534 passing, 33 skipped
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: `EDITION=enterprise npm run dev` against a backend implementing the new contract — paste `tt_<token>.<urlsafe-base64(email)>` → consent PDF renders → Accept → state lands on `activated`
- [ ] Manual: malformed code (`foo.bar`, missing `.`, bad base64, no `@`) → distinct toast error, no network call fired
- [ ] Manual: Decline path → returns to entry screen, no seat consumed (verify via backend audit log)
- [ ] Manual: 502 on `/activate` accept → `waiting_for_key` then recovers to `activated` once backend is back

🤖 Generated with [Claude Code](https://claude.com/claude-code)