### PR TITLE
chore(deps): bump electron 40.1.0 → 40.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "@typescript-eslint/parser": "^8.54.0",
         "@vitejs/plugin-react": "^5.1.3",
         "cross-env": "^10.1.0",
-        "electron": "40.1.0",
+        "electron": "40.9.2",
         "electron-builder": "^26.7.0",
         "electron-vite": "^5.0.0",
         "eslint": "^8.57.1",
@@ -8504,9 +8504,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.1.0.tgz",
-      "integrity": "sha512-2j/kvw7uF0H1PnzYBzw2k2Q6q16J8ToKrtQzZfsAoXbbMY0l5gQi2DLOauIZLzwp4O01n8Wt/74JhSRwG0yj9A==",
+      "version": "40.9.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-40.9.2.tgz",
+      "integrity": "sha512-gTLLTlfMyORZDj+03tkxsstQOQlmu6dYl0X8cwlmFb+gMmCM9Gc+rmBGSaCb5KI11IMUWHu4hvKA/spP8oJe+w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@typescript-eslint/parser": "^8.54.0",
     "@vitejs/plugin-react": "^5.1.3",
     "cross-env": "^10.1.0",
-    "electron": "40.1.0",
+    "electron": "40.9.2",
     "electron-builder": "^26.7.0",
     "electron-vite": "^5.0.0",
     "eslint": "^8.57.1",


### PR DESCRIPTION
## Summary
- Bumps `electron` from `40.1.0` to `40.9.2` (same major; patch range).
- Picks up fixes for multiple high-severity advisories flagged by `npm audit`: context isolation bypass via `VideoFrame` transfer, AppleScript injection in `moveToApplicationsFolder`, service-worker IPC reply spoofing, several use-after-frees, HTTP header injection in custom protocol handlers, and more.
- Extracted from #130, where it was accidentally bundled with the LLM refactor.

## Test plan
- [ ] `npm install` succeeds; native modules rebuild cleanly for the new Electron ABI
- [ ] `npm run dev` boots the tray app and basic capture works
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)