### PR TITLE
feat(enterprise): embed backend URL in activation code

### DIFF
--- a/src/main/access/activation-code.test.ts
+++ b/src/main/access/activation-code.test.ts
@@ -116,6 +116,15 @@ describe('parseActivationCode', () => {
     it('rejects an empty third segment', () => {
       expect(() => parseActivationCode(`${code}.`)).toThrow(/malformed/i)
     })
+
+    it('strips query string and fragment from the URL', () => {
+      const encoded = encodeUrlSafe('https://acme.trymemorylane.com/api?foo=bar#x')
+      expect(parseActivationCode(`${code}.${encoded}`)).toEqual({
+        tenantToken,
+        email,
+        backendUrl: 'https://acme.trymemorylane.com/api/',
+      })
+    })
   })
 })
 

--- a/src/main/access/activation-code.test.ts
+++ b/src/main/access/activation-code.test.ts
@@ -8,11 +8,11 @@ describe('parseActivationCode', () => {
   const code = `${tenantToken}.${emailEncoded}`
 
   it('parses a well-formed activation code', () => {
-    expect(parseActivationCode(code)).toEqual({ tenantToken, email })
+    expect(parseActivationCode(code)).toEqual({ tenantToken, email, backendUrl: null })
   })
 
   it('trims surrounding whitespace', () => {
-    expect(parseActivationCode(`  ${code}\n`)).toEqual({ tenantToken, email })
+    expect(parseActivationCode(`  ${code}\n`)).toEqual({ tenantToken, email, backendUrl: null })
   })
 
   it('accepts url-safe base64 with no padding for emails that need it', () => {
@@ -22,6 +22,7 @@ describe('parseActivationCode', () => {
     expect(parseActivationCode(`${tenantToken}.${tricky}`)).toEqual({
       tenantToken,
       email: trickyEmail,
+      backendUrl: null,
     })
   })
 
@@ -48,8 +49,12 @@ describe('parseActivationCode', () => {
     expect(() => parseActivationCode(tenantToken)).toThrow(/malformed/i)
   })
 
-  it('rejects codes with more than one dot', () => {
-    expect(() => parseActivationCode(`${tenantToken}.${emailEncoded}.extra`)).toThrow(/malformed/i)
+  it('rejects codes with more than two dots', () => {
+    expect(() =>
+      parseActivationCode(
+        `${tenantToken}.${emailEncoded}.${encodeUrlSafe('https://x.com/')}.extra`,
+      ),
+    ).toThrow(/malformed/i)
   })
 
   it('rejects codes with empty token or email half', () => {
@@ -60,6 +65,57 @@ describe('parseActivationCode', () => {
   it('rejects codes whose decoded email lacks an @', () => {
     const noAt = encodeUrlSafe('not-an-email')
     expect(() => parseActivationCode(`${tenantToken}.${noAt}`)).toThrow(/malformed/i)
+  })
+
+  describe('with embedded backend URL', () => {
+    it('parses an https URL', () => {
+      const url = 'https://acme.trymemorylane.com/api/'
+      const encoded = encodeUrlSafe(url)
+      expect(parseActivationCode(`${code}.${encoded}`)).toEqual({
+        tenantToken,
+        email,
+        backendUrl: url,
+      })
+    })
+
+    it('normalizes a missing trailing slash on the path', () => {
+      const url = 'https://acme.trymemorylane.com/api'
+      const encoded = encodeUrlSafe(url)
+      expect(parseActivationCode(`${code}.${encoded}`)).toEqual({
+        tenantToken,
+        email,
+        backendUrl: 'https://acme.trymemorylane.com/api/',
+      })
+    })
+
+    it('allows http for localhost', () => {
+      const url = 'http://localhost:8000/api/'
+      const encoded = encodeUrlSafe(url)
+      expect(parseActivationCode(`${code}.${encoded}`)).toEqual({
+        tenantToken,
+        email,
+        backendUrl: url,
+      })
+    })
+
+    it('rejects http for non-localhost hosts', () => {
+      const encoded = encodeUrlSafe('http://acme.example.com/api/')
+      expect(() => parseActivationCode(`${code}.${encoded}`)).toThrow(/malformed/i)
+    })
+
+    it('rejects an unparseable URL', () => {
+      const encoded = encodeUrlSafe('not a url')
+      expect(() => parseActivationCode(`${code}.${encoded}`)).toThrow(/malformed/i)
+    })
+
+    it('rejects a non-base64url third segment', () => {
+      expect(() => parseActivationCode(`${code}.has spaces`)).toThrow(/malformed/i)
+      expect(() => parseActivationCode(`${code}.abc+def`)).toThrow(/malformed/i)
+    })
+
+    it('rejects an empty third segment', () => {
+      expect(() => parseActivationCode(`${code}.`)).toThrow(/malformed/i)
+    })
   })
 })
 

--- a/src/main/access/activation-code.ts
+++ b/src/main/access/activation-code.ts
@@ -42,32 +42,40 @@ export function parseActivationCode(rawCode: string): ParsedActivationCode {
     if (backendEncoded === '' || !URLSAFE_BASE64_PATTERN.test(backendEncoded)) {
       throw new Error('Activation code is malformed.')
     }
-    backendUrl = decodeAndValidateBackendUrl(backendEncoded)
+    const decoded = Buffer.from(backendEncoded, 'base64url').toString('utf8')
+    backendUrl = normalizeBackendUrl(decoded)
+    if (backendUrl === null) {
+      throw new Error('Activation code is malformed.')
+    }
   }
 
   return { tenantToken, email, backendUrl }
 }
 
-function decodeAndValidateBackendUrl(encoded: string): string {
-  const decoded = Buffer.from(encoded, 'base64url').toString('utf8')
-  if (decoded === '') {
-    throw new Error('Activation code is malformed.')
-  }
+/**
+ * Validate and normalize a decoded backend URL. Returns the normalized URL
+ * (with a guaranteed trailing slash on the path so it composes with
+ * `new URL(path, base)`), or `null` if the URL is unparseable, uses a
+ * disallowed scheme, or otherwise fails validation.
+ *
+ * Shared between activation-code parsing and `EnterpriseLicenseConfig.load`
+ * so persisted state goes through the same checks as fresh activation input.
+ */
+export function normalizeBackendUrl(decoded: string): string | null {
+  if (decoded === '') return null
 
   let parsed: URL
   try {
     parsed = new URL(decoded)
   } catch {
-    throw new Error('Activation code is malformed.')
+    return null
   }
 
   const isLocalhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1'
   if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLocalhost)) {
-    throw new Error('Activation code is malformed.')
+    return null
   }
 
-  // Normalize trailing slash so it composes correctly with `new URL(path, base)`
-  // in the access provider (see enterprise-access-provider.ts).
   return parsed.pathname.endsWith('/') ? parsed.toString() : `${parsed.toString()}/`
 }
 

--- a/src/main/access/activation-code.ts
+++ b/src/main/access/activation-code.ts
@@ -1,6 +1,7 @@
 export interface ParsedActivationCode {
   tenantToken: string
   email: string
+  backendUrl: string | null
 }
 
 const TENANT_TOKEN_PREFIX = 'tt_'
@@ -14,13 +15,15 @@ export function parseActivationCode(rawCode: string): ParsedActivationCode {
     throw new Error('Activation code must start with `tt_`.')
   }
 
-  const separatorIndex = code.indexOf('.')
-  if (separatorIndex === -1 || separatorIndex !== code.lastIndexOf('.')) {
+  const parts = code.split('.')
+  if (parts.length < 2 || parts.length > 3) {
     throw new Error('Activation code is malformed.')
   }
 
-  const tenantToken = code.slice(0, separatorIndex)
-  const emailEncoded = code.slice(separatorIndex + 1)
+  const tenantToken = parts[0]
+  const emailEncoded = parts[1]
+  const backendEncoded = parts[2]
+
   if (tenantToken === TENANT_TOKEN_PREFIX || emailEncoded === '') {
     throw new Error('Activation code is malformed.')
   }
@@ -34,7 +37,38 @@ export function parseActivationCode(rawCode: string): ParsedActivationCode {
     throw new Error('Activation code is malformed.')
   }
 
-  return { tenantToken, email }
+  let backendUrl: string | null = null
+  if (backendEncoded !== undefined) {
+    if (backendEncoded === '' || !URLSAFE_BASE64_PATTERN.test(backendEncoded)) {
+      throw new Error('Activation code is malformed.')
+    }
+    backendUrl = decodeAndValidateBackendUrl(backendEncoded)
+  }
+
+  return { tenantToken, email, backendUrl }
+}
+
+function decodeAndValidateBackendUrl(encoded: string): string {
+  const decoded = Buffer.from(encoded, 'base64url').toString('utf8')
+  if (decoded === '') {
+    throw new Error('Activation code is malformed.')
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(decoded)
+  } catch {
+    throw new Error('Activation code is malformed.')
+  }
+
+  const isLocalhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1'
+  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLocalhost)) {
+    throw new Error('Activation code is malformed.')
+  }
+
+  // Normalize trailing slash so it composes correctly with `new URL(path, base)`
+  // in the access provider (see enterprise-access-provider.ts).
+  return parsed.pathname.endsWith('/') ? parsed.toString() : `${parsed.toString()}/`
 }
 
 const URLSAFE_BASE64_PATTERN = /^[A-Za-z0-9_-]+$/

--- a/src/main/access/activation-code.ts
+++ b/src/main/access/activation-code.ts
@@ -76,6 +76,8 @@ export function normalizeBackendUrl(decoded: string): string | null {
     return null
   }
 
+  parsed.search = ''
+  parsed.hash = ''
   return parsed.pathname.endsWith('/') ? parsed.toString() : `${parsed.toString()}/`
 }
 

--- a/src/main/access/create-access-provider.ts
+++ b/src/main/access/create-access-provider.ts
@@ -1,5 +1,6 @@
 import type { AppEdition } from '../../shared/edition'
 import type { DeviceIdentity } from '../settings/device-identity'
+import type { EnterpriseLicenseConfig } from '../settings/enterprise-license-config'
 import { CustomerAccessProvider } from './customer-access-provider'
 import { EnterpriseAccessProvider } from './enterprise-access-provider'
 import type { AccessProvider } from './types'
@@ -7,8 +8,9 @@ import type { AccessProvider } from './types'
 export function createAccessProvider(
   edition: AppEdition,
   deviceIdentity: DeviceIdentity,
+  licenseConfig?: EnterpriseLicenseConfig,
 ): AccessProvider {
   return edition === 'enterprise'
-    ? new EnterpriseAccessProvider(deviceIdentity)
+    ? new EnterpriseAccessProvider(deviceIdentity, licenseConfig)
     : new CustomerAccessProvider(deviceIdentity)
 }

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -3,12 +3,14 @@ import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import type { ConsentOutcome, PendingConsent } from '../../shared/types'
 import log from '../logger'
 import type { DeviceIdentity } from '../settings/device-identity'
+import type { EnterpriseLicenseConfig } from '../settings/enterprise-license-config'
 import { parseActivationCode } from './activation-code'
 import { BaseAccessProvider } from './base-access-provider'
 import {
   transitionEnterpriseAccess,
   type EnterpriseAccessTransition,
- ManagedInferenceConfig } from './enterprise-access-machine'
+  ManagedInferenceConfig,
+} from './enterprise-access-machine'
 import { createInitialAccessState } from './types'
 
 const TOKEN_REFRESH_LEAD_MS = 60_000
@@ -60,6 +62,7 @@ function bearer(token: string): Record<string, string> {
 
 export class EnterpriseAccessProvider extends BaseAccessProvider {
   private readonly deviceIdentity: DeviceIdentity
+  private readonly licenseConfig: EnterpriseLicenseConfig | null
   private pollTimer: ReturnType<typeof setInterval> | null = null
   private timeoutTimer: ReturnType<typeof setTimeout> | null = null
   private refreshTimer: ReturnType<typeof setInterval> | null = null
@@ -67,9 +70,10 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   private tokenRefreshTimer: ReturnType<typeof setTimeout> | null = null
   private pendingConsent: PendingConsentState | null = null
 
-  constructor(deviceIdentity: DeviceIdentity) {
+  constructor(deviceIdentity: DeviceIdentity, licenseConfig?: EnterpriseLicenseConfig) {
     super(createInitialAccessState('enterprise'))
     this.deviceIdentity = deviceIdentity
+    this.licenseConfig = licenseConfig ?? null
   }
 
   public async refreshAccessState(): Promise<void> {
@@ -128,7 +132,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       return
     }
 
-    let parsed: { tenantToken: string; email: string }
+    let parsed: { tenantToken: string; email: string; backendUrl: string | null }
     try {
       parsed = parseActivationCode(activationCode)
     } catch (error) {
@@ -140,6 +144,10 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
         }),
       )
       throw new Error(message)
+    }
+
+    if (parsed.backendUrl !== null && this.licenseConfig !== null) {
+      this.licenseConfig.setBackendUrl(parsed.backendUrl)
     }
 
     this.applyTransition(

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -51,11 +51,6 @@ interface ActivateResponse {
   declined?: boolean
 }
 
-function enterpriseUrl(path: string): URL {
-  const base = ENTERPRISE_BACKEND_CONFIG.BACKEND_URL.replace(/\/?$/, '/')
-  return new URL(path, base)
-}
-
 function bearer(token: string): Record<string, string> {
   return { Authorization: `Bearer ${token}` }
 }
@@ -74,6 +69,15 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     super(createInitialAccessState('enterprise'))
     this.deviceIdentity = deviceIdentity
     this.licenseConfig = licenseConfig ?? null
+  }
+
+  private resolveBackendBase(): string {
+    const url = this.licenseConfig?.getBackendUrl() ?? ENTERPRISE_BACKEND_CONFIG.BACKEND_URL
+    return url.replace(/\/?$/, '/')
+  }
+
+  private enterpriseUrl(path: string): URL {
+    return new URL(path, this.resolveBackendBase())
   }
 
   public async refreshAccessState(): Promise<void> {
@@ -154,7 +158,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       transitionEnterpriseAccess(this.accessState, { type: 'activation_started' }),
     )
 
-    const descriptorUrl = enterpriseUrl('license/consent-document')
+    const descriptorUrl = this.enterpriseUrl('license/consent-document')
 
     const descriptorResponse = await fetch(descriptorUrl.toString(), {
       headers: bearer(parsed.tenantToken),
@@ -252,7 +256,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     }
 
     const deviceId = this.deviceIdentity.getDeviceId()
-    const response = await fetch(enterpriseUrl('license/activate'), {
+    const response = await fetch(this.enterpriseUrl('license/activate'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -347,7 +351,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     expectedSha256: string,
     tenantToken: string,
   ): Promise<string> {
-    const backendBase = ENTERPRISE_BACKEND_CONFIG.BACKEND_URL.replace(/\/?$/, '/')
+    const backendBase = this.resolveBackendBase()
     const documentUrl = new URL(url, backendBase)
     if (documentUrl.origin !== new URL(backendBase).origin) {
       throw new Error('Consent document URL is not on the configured backend origin')
@@ -427,7 +431,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   }
 
   private async fetchEnterpriseStatus(deviceId: string): Promise<boolean> {
-    const url = enterpriseUrl('license/status')
+    const url = this.enterpriseUrl('license/status')
 
     const response = await fetch(url.toString(), { headers: bearer(deviceId) })
     if (response.status === 401) {
@@ -446,7 +450,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   }
 
   private async fetchInferenceConfig(deviceId: string): Promise<ManagedInferenceConfig | null> {
-    const url = enterpriseUrl('license/inference-config')
+    const url = this.enterpriseUrl('license/inference-config')
 
     const response = await fetch(url.toString(), { headers: bearer(deviceId) })
     if (response.status === 401) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,10 +36,7 @@ import { createMainRuntime, type MainRuntime } from './runtime'
 import { createObservationController, type ObservationController } from './observation-controller'
 import { getAppDirectoryName } from './paths'
 import { loadAppEditionConfig } from './edition'
-import {
-  ENTERPRISE_BACKEND_CONFIG,
-  registerEnterpriseBackendUrlAccessor,
-} from '../shared/constants'
+import { ENTERPRISE_BACKEND_CONFIG } from '../shared/constants'
 
 // Keep single-instance behavior in packaged app, but allow dev to run
 // alongside production for local debugging.
@@ -164,7 +161,6 @@ app.on('ready', async () => {
   const deviceIdentity = new DeviceIdentity()
   const licenseConfig = new EnterpriseLicenseConfig()
   licenseConfig.load()
-  registerEnterpriseBackendUrlAccessor(() => licenseConfig.getBackendUrl())
   captureSettingsManager.applyToConstants()
   const initialCaptureSettings = captureSettingsManager.get()
 
@@ -215,7 +211,7 @@ app.on('ready', async () => {
         const level = captureSettingsManager.get().uploadDetailLevel
         return { detailLevel: level === 'detailed' ? 'detailed' : 'summary' }
       },
-      getBackendUrl: () => ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
+      getBackendUrl: () => licenseConfig.getBackendUrl() ?? ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
     })
     databaseUploadSync.start()
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,7 @@ import { startPowerMonitoring, shouldPause } from './power-monitor'
 import { CaptureStateManager } from './settings/capture-state-manager'
 import { CaptureSettingsManager } from './settings/capture-settings-manager'
 import { DeviceIdentity } from './settings/device-identity'
+import { EnterpriseLicenseConfig } from './settings/enterprise-license-config'
 import { VendorCredentialsManager } from './settings/vendor-credentials-manager'
 import { PatternDetector } from './services/pattern-detector'
 import { UserContextBuilder } from './services/user-context-builder'
@@ -35,7 +36,10 @@ import { createMainRuntime, type MainRuntime } from './runtime'
 import { createObservationController, type ObservationController } from './observation-controller'
 import { getAppDirectoryName } from './paths'
 import { loadAppEditionConfig } from './edition'
-import { ENTERPRISE_BACKEND_CONFIG } from '../shared/constants'
+import {
+  ENTERPRISE_BACKEND_CONFIG,
+  registerEnterpriseBackendUrlAccessor,
+} from '../shared/constants'
 
 // Keep single-instance behavior in packaged app, but allow dev to run
 // alongside production for local debugging.
@@ -158,6 +162,9 @@ app.on('ready', async () => {
   }
   const captureStateManager = new CaptureStateManager()
   const deviceIdentity = new DeviceIdentity()
+  const licenseConfig = new EnterpriseLicenseConfig()
+  licenseConfig.load()
+  registerEnterpriseBackendUrlAccessor(() => licenseConfig.getBackendUrl())
   captureSettingsManager.applyToConstants()
   const initialCaptureSettings = captureSettingsManager.get()
 
@@ -184,6 +191,7 @@ app.on('ready', async () => {
     excludedUrlPatterns: initialCaptureSettings.excludedUrlPatterns,
     excludePrivateBrowsing: initialCaptureSettings.excludePrivateBrowsing,
     deviceIdentity,
+    licenseConfig,
     vendorCredentials: vendorCredentialsManager,
     getActiveVendor: () => captureSettingsManager.get().activeVendor,
     initialVideoModel: initialCaptureSettings.semanticVideoModel,
@@ -207,7 +215,7 @@ app.on('ready', async () => {
         const level = captureSettingsManager.get().uploadDetailLevel
         return { detailLevel: level === 'detailed' ? 'detailed' : 'summary' }
       },
-      backendUrl: ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
+      getBackendUrl: () => ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
     })
     databaseUploadSync.start()
   }

--- a/src/main/llm/inference-provider.ts
+++ b/src/main/llm/inference-provider.ts
@@ -81,6 +81,7 @@ export class InferenceProviderImpl implements InferenceProvider {
     }
     const sdkProvider = createSdkProvider(vendor, creds, { fetch: this.customFetch })
     this.sdkCache.set(vendor, { signature, sdkProvider })
+    log.info(`[InferenceProvider] built provider ${describeRoute(vendor, creds)}`)
     return sdkProvider.languageModel(modelId)
   }
 
@@ -89,15 +90,20 @@ export class InferenceProviderImpl implements InferenceProvider {
     if (!vendorSupportsRawHttp(vendor)) return null
     const creds = this.credentials.getCredentials(vendor)
     if (!creds) return null
+    const baseURL = rawHttpBaseURL(vendor, creds)
+    log.info(`[InferenceProvider] route snapshot vendor=${vendor} baseURL=${baseURL}`)
     return {
       vendor,
-      baseURL: rawHttpBaseURL(vendor, creds),
+      baseURL,
       apiKey: creds.apiKey,
     }
   }
 
   notifyConfigChanged(): void {
     this.sdkCache.clear()
+    log.info(
+      `[InferenceProvider] config changed; sdk cache cleared; active vendor=${this.getActiveVendor()}`,
+    )
     for (const listener of this.listeners) {
       try {
         listener()
@@ -117,4 +123,13 @@ export class InferenceProviderImpl implements InferenceProvider {
 
 function signatureFor(creds: VendorCredentials): string {
   return `${creds.baseURL ?? ''}|${creds.project ?? ''}|${creds.location ?? ''}|${creds.apiKey}`
+}
+
+function describeRoute(vendor: Vendor, creds: VendorCredentials): string {
+  const apiKeyTail = creds.apiKey.length >= 4 ? creds.apiKey.slice(-4) : '****'
+  const apiKey = `apiKey=…${apiKeyTail}`
+  if (vendor === 'google') {
+    return `vendor=${vendor} project=${creds.project ?? '?'} location=${creds.location ?? '?'} ${apiKey}`
+  }
+  return `vendor=${vendor} baseURL=${creds.baseURL ?? '(default)'} ${apiKey}`
 }

--- a/src/main/llm/inference-provider.ts
+++ b/src/main/llm/inference-provider.ts
@@ -52,6 +52,7 @@ export class InferenceProviderImpl implements InferenceProvider {
   private readonly getActiveVendorAccessor: () => Vendor
   private readonly customFetch: typeof globalThis.fetch | undefined
   private readonly sdkCache = new Map<Vendor, CacheEntry>()
+  private readonly loggedRouteSnapshots = new Set<string>()
   private readonly listeners = new Set<() => void>()
 
   constructor(options: InferenceProviderOptions) {
@@ -91,7 +92,11 @@ export class InferenceProviderImpl implements InferenceProvider {
     const creds = this.credentials.getCredentials(vendor)
     if (!creds) return null
     const baseURL = rawHttpBaseURL(vendor, creds)
-    log.info(`[InferenceProvider] route snapshot vendor=${vendor} baseURL=${baseURL}`)
+    const routeKey = `${vendor}|${baseURL}`
+    if (!this.loggedRouteSnapshots.has(routeKey)) {
+      this.loggedRouteSnapshots.add(routeKey)
+      log.info(`[InferenceProvider] route snapshot vendor=${vendor} baseURL=${baseURL}`)
+    }
     return {
       vendor,
       baseURL,
@@ -101,6 +106,7 @@ export class InferenceProviderImpl implements InferenceProvider {
 
   notifyConfigChanged(): void {
     this.sdkCache.clear()
+    this.loggedRouteSnapshots.clear()
     log.info(
       `[InferenceProvider] config changed; sdk cache cleared; active vendor=${this.getActiveVendor()}`,
     )

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -4,6 +4,7 @@ import { app } from 'electron'
 import log from './logger'
 import { VendorCredentialsManager } from './settings/vendor-credentials-manager'
 import { DeviceIdentity } from './settings/device-identity'
+import type { EnterpriseLicenseConfig } from './settings/enterprise-license-config'
 import { createAccessProvider, type AccessProvider } from './access'
 import type { AppEdition } from '../shared/edition'
 import { StorageService } from './storage'
@@ -54,6 +55,7 @@ export async function createMainRuntime(params: {
   excludedUrlPatterns?: string[]
   excludePrivateBrowsing?: boolean
   deviceIdentity?: DeviceIdentity
+  licenseConfig?: EnterpriseLicenseConfig
   edition: AppEdition
   vendorCredentials: VendorCredentialsManager
   getActiveVendor: () => Vendor
@@ -171,7 +173,7 @@ export async function createMainRuntime(params: {
   interactionMonitor.onInteraction(interactionHandler)
 
   const deviceIdentity = params.deviceIdentity ?? new DeviceIdentity()
-  const accessProvider = createAccessProvider(params.edition, deviceIdentity)
+  const accessProvider = createAccessProvider(params.edition, deviceIdentity, params.licenseConfig)
 
   let disposePromise: Promise<void> | null = null
 

--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -41,7 +41,7 @@ describe('DatabaseUploadSync', () => {
       isActivated: () => true,
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
-      backendUrl: 'http://localhost:8000/',
+      getBackendUrl: () => 'http://localhost:8000/',
     })
 
     sync.start()
@@ -74,7 +74,7 @@ describe('DatabaseUploadSync', () => {
       isActivated: () => false,
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
-      backendUrl: 'http://localhost:8000/',
+      getBackendUrl: () => 'http://localhost:8000/',
     })
 
     sync.start()
@@ -100,7 +100,7 @@ describe('DatabaseUploadSync', () => {
       isActivated: () => true,
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
-      backendUrl: 'http://localhost:8000/',
+      getBackendUrl: () => 'http://localhost:8000/',
     })
 
     sync.start()
@@ -125,7 +125,7 @@ describe('DatabaseUploadSync', () => {
       isActivated: () => true,
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
-      backendUrl: 'http://localhost:8000/',
+      getBackendUrl: () => 'http://localhost:8000/',
     })
 
     sync.start()
@@ -153,7 +153,7 @@ describe('DatabaseUploadSync', () => {
       isActivated: () => true,
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
-      backendUrl: 'http://localhost:8000/',
+      getBackendUrl: () => 'http://localhost:8000/',
       intervalMs: 1000,
     })
 
@@ -181,7 +181,7 @@ describe('DatabaseUploadSync', () => {
       isActivated: () => true,
       isSyncEnabled: () => false,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
-      backendUrl: 'http://localhost:8000/',
+      getBackendUrl: () => 'http://localhost:8000/',
     })
 
     sync.start()
@@ -205,7 +205,7 @@ describe('DatabaseUploadSync', () => {
       isActivated: () => true,
       isSyncEnabled: () => false,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
-      backendUrl: 'http://localhost:8000/',
+      getBackendUrl: () => 'http://localhost:8000/',
     })
 
     const result = await sync.triggerUpload()
@@ -236,7 +236,7 @@ describe('DatabaseUploadSync', () => {
       isActivated: () => true,
       isSyncEnabled: () => syncOn,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
-      backendUrl: 'http://localhost:8000/',
+      getBackendUrl: () => 'http://localhost:8000/',
       intervalMs: 1000,
     })
 
@@ -281,7 +281,7 @@ describe('DatabaseUploadSync', () => {
       isActivated: () => true,
       isSyncEnabled: () => syncOn,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
-      backendUrl: 'http://localhost:8000/',
+      getBackendUrl: () => 'http://localhost:8000/',
       intervalMs: 1000,
     })
 

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -16,7 +16,7 @@ export interface DatabaseUploadSyncParams {
   isActivated: () => boolean
   isSyncEnabled: () => boolean
   getStripOptions: () => StripOptions
-  backendUrl: string
+  getBackendUrl: () => string
   intervalMs?: number
 }
 
@@ -26,7 +26,7 @@ export class DatabaseUploadSync {
   private readonly isActivated: () => boolean
   private readonly isSyncEnabled: () => boolean
   private readonly getStripOptions: () => StripOptions
-  private readonly backendUrl: string
+  private readonly getBackendUrl: () => string
   private readonly intervalMs: number
   private timer: ReturnType<typeof setInterval> | null = null
   private uploadRunning = false
@@ -39,7 +39,7 @@ export class DatabaseUploadSync {
     this.isActivated = params.isActivated
     this.isSyncEnabled = params.isSyncEnabled
     this.getStripOptions = params.getStripOptions
-    this.backendUrl = params.backendUrl
+    this.getBackendUrl = params.getBackendUrl
     this.intervalMs = params.intervalMs ?? DEFAULT_UPLOAD_INTERVAL_MS
   }
 
@@ -124,7 +124,7 @@ export class DatabaseUploadSync {
       const formData = new FormData()
       formData.append('file', new Blob([fileBuffer]), 'memorylane.db')
 
-      const base = this.backendUrl.replace(/\/?$/, '/')
+      const base = this.getBackendUrl().replace(/\/?$/, '/')
       const url = new URL('device/upload', base)
       const response = await fetch(url, {
         method: 'POST',

--- a/src/main/settings/enterprise-license-config.ts
+++ b/src/main/settings/enterprise-license-config.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron'
 import * as fs from 'fs'
 import * as path from 'path'
+import { normalizeBackendUrl } from '../access/activation-code'
 import log from '../logger'
 
 interface PersistedShape {
@@ -26,8 +27,15 @@ export class EnterpriseLicenseConfig {
       const data = fs.readFileSync(this.configPath, 'utf-8')
       const parsed = JSON.parse(data) as PersistedShape
       if (typeof parsed.backendUrl === 'string' && parsed.backendUrl !== '') {
-        this.backendUrl = parsed.backendUrl
-        log.info(`[EnterpriseLicenseConfig] Loaded backend URL: ${this.backendUrl}`)
+        const normalized = normalizeBackendUrl(parsed.backendUrl)
+        if (normalized === null) {
+          log.error(
+            `[EnterpriseLicenseConfig] Persisted backend URL failed validation; ignoring: ${parsed.backendUrl}`,
+          )
+        } else {
+          this.backendUrl = normalized
+          log.info(`[EnterpriseLicenseConfig] Loaded backend URL: ${this.backendUrl}`)
+        }
       }
     } catch (error) {
       log.error('[EnterpriseLicenseConfig] Failed to read config:', error)

--- a/src/main/settings/enterprise-license-config.ts
+++ b/src/main/settings/enterprise-license-config.ts
@@ -1,0 +1,53 @@
+import { app } from 'electron'
+import * as fs from 'fs'
+import * as path from 'path'
+import log from '../logger'
+
+interface PersistedShape {
+  backendUrl?: string | null
+}
+
+export class EnterpriseLicenseConfig {
+  private readonly configPath: string
+  private backendUrl: string | null = null
+  private loaded = false
+
+  constructor() {
+    this.configPath = path.join(app.getPath('userData'), 'enterprise-license.json')
+  }
+
+  public load(): void {
+    if (this.loaded) return
+    this.loaded = true
+
+    if (!fs.existsSync(this.configPath)) return
+
+    try {
+      const data = fs.readFileSync(this.configPath, 'utf-8')
+      const parsed = JSON.parse(data) as PersistedShape
+      if (typeof parsed.backendUrl === 'string' && parsed.backendUrl !== '') {
+        this.backendUrl = parsed.backendUrl
+        log.info(`[EnterpriseLicenseConfig] Loaded backend URL: ${this.backendUrl}`)
+      }
+    } catch (error) {
+      log.error('[EnterpriseLicenseConfig] Failed to read config:', error)
+    }
+  }
+
+  public getBackendUrl(): string | null {
+    return this.backendUrl
+  }
+
+  public setBackendUrl(url: string | null): void {
+    this.backendUrl = url
+    this.persist()
+    log.info(`[EnterpriseLicenseConfig] Backend URL set to ${url ?? '(cleared)'}`)
+  }
+
+  private persist(): void {
+    const payload: PersistedShape = { backendUrl: this.backendUrl }
+    const tmp = `${this.configPath}.tmp`
+    fs.writeFileSync(tmp, JSON.stringify(payload, null, 2))
+    fs.renameSync(tmp, this.configPath)
+  }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -89,16 +89,9 @@ export const MANAGED_KEY_CONFIG = {
   KEY_REFRESH_INTERVAL_MS: 24 * 60 * 60 * 1000, // 24 hours
 }
 
-let backendUrlAccessor: () => string | null = () => null
-
-export function registerEnterpriseBackendUrlAccessor(fn: () => string | null): void {
-  backendUrlAccessor = fn
-}
-
 export const ENTERPRISE_BACKEND_CONFIG = {
   get BACKEND_URL(): string {
     return (
-      backendUrlAccessor() ??
       process.env.MEMORYLANE_BACKEND_URL ??
       (process.env.NODE_ENV === 'development'
         ? 'http://localhost:8000/api'

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -89,9 +89,16 @@ export const MANAGED_KEY_CONFIG = {
   KEY_REFRESH_INTERVAL_MS: 24 * 60 * 60 * 1000, // 24 hours
 }
 
+let backendUrlAccessor: () => string | null = () => null
+
+export function registerEnterpriseBackendUrlAccessor(fn: () => string | null): void {
+  backendUrlAccessor = fn
+}
+
 export const ENTERPRISE_BACKEND_CONFIG = {
   get BACKEND_URL(): string {
     return (
+      backendUrlAccessor() ??
       process.env.MEMORYLANE_BACKEND_URL ??
       (process.env.NODE_ENV === 'development'
         ? 'http://localhost:8000/api'


### PR DESCRIPTION
## Summary
- Activation code gains an optional third base64url-encoded segment carrying a per-tenant enterprise backend URL: `tt_<token>.<base64url-email>[.<base64url-url>]`. Two-segment codes still parse and fall back to env / build defaults.
- New `EnterpriseLicenseConfig` persists the URL to `enterprise-license.json` in userData. Bootstrap registers it as the top-priority accessor for `ENTERPRISE_BACKEND_CONFIG.BACKEND_URL`, so all `enterpriseUrl()` call sites pick it up without per-site changes.
- `DatabaseUploadSync` now reads `getBackendUrl()` per upload instead of holding a snapshot, so post-activation URL changes take effect without restart.
- Three `log.info` lines in `InferenceProvider` (SDK build, route snapshot, config-changed) make the active LLM route visible. apiKey is masked to last 4.

URL validation: must parse as `URL`, must be `https:` (or `http:` only for localhost / 127.0.0.1 — keeps dev against `http://localhost:8000/api` working). Trailing slash on the path is normalized.

## Test plan
- [ ] `npm run test` — 570 pass locally
- [ ] `npm run lint` clean (only pre-existing warnings)
- [ ] `npx tsc --noEmit` clean
- [ ] Mint a 3-segment code with `http://localhost:9999/api/` and activate; confirm `[EnterpriseLicenseConfig] Backend URL set` and that `[EnterpriseAccess]` requests hit `:9999`.
- [ ] Restart the app and confirm license/status polls continue against the persisted URL.
- [ ] Activate with an existing 2-segment code and confirm fetches go to the env / build default.
- [ ] Activate with a non-localhost `http://` URL and confirm the UI shows "malformed".
- [ ] Trigger an LLM call (e.g. user-context build) and verify the three new `[InferenceProvider]` log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)