### PR TITLE
fix(user-context): source model from per-vendor settings

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -217,8 +217,10 @@ app.on('ready', async () => {
   }
 
   userContextBuilder = new UserContextBuilder(runtime.storage, runtime.inferenceProvider)
+  userContextBuilder.updateModel(captureSettingsManager.get().patternDetectionModel)
   patternDetector = new PatternDetector(runtime.storage, runtime.inferenceProvider)
   patternDetector.setEnabled(captureSettingsManager.get().patternDetectionEnabled)
+  patternDetector.updateModel(captureSettingsManager.get().patternDetectionModel)
   const captureCoordinator = createCaptureCoordinator({
     capture: runtime.capture,
     captureStateManager,
@@ -284,6 +286,7 @@ app.on('ready', async () => {
     accessProvider: runtime.accessProvider,
     captureSettingsManager,
     patternDetector: patternDetector ?? undefined,
+    userContextBuilder: userContextBuilder ?? undefined,
     getCaptureHotkeyLabel: hotkeyManager.getLabel,
     reconfigureCaptureHotkey,
     updateExclusions: (exclusions) => runtime?.updateExclusions(exclusions),

--- a/src/main/services/pattern-detector/index.ts
+++ b/src/main/services/pattern-detector/index.ts
@@ -95,7 +95,13 @@ export class PatternDetector {
     config: Partial<PatternDetectorConfig> = {},
     onProgress?: ProgressCallback,
   ): Promise<DetectionRunResult> {
-    return runDetection(provider, this.storage, this.embeddingService, config, onProgress)
+    return runDetection(
+      provider,
+      this.storage,
+      this.embeddingService,
+      { model: this.model, ...config },
+      onProgress,
+    )
   }
 
   private async execute(provider: InferenceProvider): Promise<void> {

--- a/src/main/services/user-context-builder.ts
+++ b/src/main/services/user-context-builder.ts
@@ -235,11 +235,17 @@ function extractContextFromResponse(content: string): ParsedContext | null {
 export class UserContextBuilder {
   private running = false
   private settleTimer: ReturnType<typeof setTimeout> | null = null
+  private model: string = DEFAULT_BUILDER_CONFIG.model
 
   constructor(
     private readonly storage: StorageService,
     private readonly provider?: InferenceProvider,
   ) {}
+
+  updateModel(model: string): void {
+    this.model = model && model.trim().length > 0 ? model.trim() : DEFAULT_BUILDER_CONFIG.model
+    log.info(`[UserContextBuilder] Model updated to: ${this.model}`)
+  }
 
   /**
    * Try to schedule a context update. Call this on screen unlock / wake.
@@ -291,7 +297,7 @@ export class UserContextBuilder {
   private async execute(provider: InferenceProvider): Promise<void> {
     this.running = true
     try {
-      const result = await runUserContextUpdate(provider, this.storage)
+      const result = await runUserContextUpdate(provider, this.storage, { model: this.model })
       log.info(
         `[UserContextBuilder] Run complete, ` +
           `tokens: ${result.tokenUsage.input}in/${result.tokenUsage.output}out`,

--- a/src/main/services/user-context-builder.ts
+++ b/src/main/services/user-context-builder.ts
@@ -291,7 +291,12 @@ export class UserContextBuilder {
     config: Partial<UserContextBuilderConfig> = {},
     onProgress?: ProgressCallback,
   ): Promise<UserContextResult> {
-    return runUserContextUpdate(provider, this.storage, config, onProgress)
+    return runUserContextUpdate(
+      provider,
+      this.storage,
+      { model: this.model, ...config },
+      onProgress,
+    )
   }
 
   private async execute(provider: InferenceProvider): Promise<void> {

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -63,6 +63,10 @@ interface PatternDetectorService {
   setEnabled(enabled: boolean): void
 }
 
+interface UserContextBuilderService {
+  updateModel(model: string): void
+}
+
 interface MainWindowDependencies {
   editionConfig: AppEditionConfig
   capture: {
@@ -83,6 +87,7 @@ interface MainWindowDependencies {
   accessProvider: AccessProvider
   captureSettingsManager: CaptureSettingsManager
   patternDetector?: PatternDetectorService
+  userContextBuilder?: UserContextBuilderService
   getCaptureHotkeyLabel: () => string
   reconfigureCaptureHotkey: (accelerator: string) => { success: boolean; error?: string }
   updateExclusions: (exclusions: {
@@ -818,6 +823,7 @@ function applyModelSettings(
   }
   if (updated.patternDetectionModel !== previous.patternDetectionModel) {
     d.patternDetector?.updateModel(updated.patternDetectionModel)
+    d.userContextBuilder?.updateModel(updated.patternDetectionModel)
   }
   if (updated.patternDetectionEnabled !== previous.patternDetectionEnabled) {
     d.patternDetector?.setEnabled(updated.patternDetectionEnabled)

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -24,8 +24,9 @@ import { integrations } from '../integrations'
 import { listInstalledApps } from '../apps/installed-apps'
 import type { VendorCredentialsManager } from '../settings/vendor-credentials-manager'
 import { VENDORS } from '../../shared/types'
-import { VENDOR_PRESETS, buildModelChain, getVendorDefaults } from '../../shared/vendor-defaults'
+import { VENDOR_PRESETS, getVendorDefaults } from '../../shared/vendor-defaults'
 import { applyVendorSwitch } from './vendor-switch'
+import { applyModelSettings } from './model-settings'
 import type { AccessProvider } from '../access'
 import type {
   AccessState,
@@ -803,29 +804,4 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: false, error: message }
     }
   })
-}
-
-function applyModelSettings(
-  d: MainWindowDependencies,
-  updated: CaptureSettings,
-  previous: CaptureSettings,
-): void {
-  if (
-    updated.semanticVideoModel !== previous.semanticVideoModel ||
-    updated.semanticSnapshotModel !== previous.semanticSnapshotModel ||
-    updated.activeVendor !== previous.activeVendor
-  ) {
-    const presets = VENDOR_PRESETS[updated.activeVendor]
-    d.semanticService.updateModels(
-      buildModelChain(updated.semanticVideoModel, presets.semanticVideo),
-      buildModelChain(updated.semanticSnapshotModel, presets.semanticSnapshot),
-    )
-  }
-  if (updated.patternDetectionModel !== previous.patternDetectionModel) {
-    d.patternDetector?.updateModel(updated.patternDetectionModel)
-    d.userContextBuilder?.updateModel(updated.patternDetectionModel)
-  }
-  if (updated.patternDetectionEnabled !== previous.patternDetectionEnabled) {
-    d.patternDetector?.setEnabled(updated.patternDetectionEnabled)
-  }
 }

--- a/src/main/ui/model-settings.test.ts
+++ b/src/main/ui/model-settings.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest'
+import { applyModelSettings, type ModelSettingsDeps } from './model-settings'
+import type { CaptureSettings } from '../../shared/types'
+import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
+
+function makeDeps(): {
+  deps: ModelSettingsDeps
+  semanticService: { updateModels: ReturnType<typeof vi.fn> }
+  patternDetector: {
+    updateModel: ReturnType<typeof vi.fn>
+    setEnabled: ReturnType<typeof vi.fn>
+  }
+  userContextBuilder: { updateModel: ReturnType<typeof vi.fn> }
+} {
+  const semanticService = { updateModels: vi.fn() }
+  const patternDetector = { updateModel: vi.fn(), setEnabled: vi.fn() }
+  const userContextBuilder = { updateModel: vi.fn() }
+  const deps: ModelSettingsDeps = { semanticService, patternDetector, userContextBuilder }
+  return { deps, semanticService, patternDetector, userContextBuilder }
+}
+
+function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
+  return {
+    autoStartEnabled: true,
+    visualThreshold: 8,
+    typingDebounceMs: 2000,
+    scrollDebounceMs: 2000,
+    clickDebounceMs: 3000,
+    minActivityDurationMs: 3000,
+    maxActivityDurationMs: 300000,
+    maxScreenshotsForLlm: 6,
+    semanticRequestTimeoutMs: 120000,
+    semanticPipelineMode: 'image',
+    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
+    databaseExportDirectory: '',
+    excludePrivateBrowsing: true,
+    excludedApps: [],
+    excludedWindowTitlePatterns: [],
+    excludedUrlPatterns: [],
+    activeVendor: 'openrouter',
+    semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
+    semanticSnapshotModel: VENDOR_PRESETS.openrouter.semanticSnapshot[0].id,
+    patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,
+    patternDetectionEnabled: true,
+    uploadDetailLevel: 'off',
+    ...overrides,
+  }
+}
+
+describe('applyModelSettings', () => {
+  it('propagates a changed patternDetectionModel to both patternDetector and userContextBuilder', () => {
+    const { deps, patternDetector, userContextBuilder } = makeDeps()
+    const previous = makeSettings({ patternDetectionModel: 'old/model' })
+    const updated = makeSettings({ patternDetectionModel: 'new/model' })
+
+    applyModelSettings(deps, updated, previous)
+
+    expect(patternDetector.updateModel).toHaveBeenCalledWith('new/model')
+    expect(userContextBuilder.updateModel).toHaveBeenCalledWith('new/model')
+  })
+
+  it('does not call updateModel when patternDetectionModel is unchanged', () => {
+    const { deps, patternDetector, userContextBuilder } = makeDeps()
+    const settings = makeSettings({ patternDetectionModel: 'same/model' })
+
+    applyModelSettings(deps, settings, settings)
+
+    expect(patternDetector.updateModel).not.toHaveBeenCalled()
+    expect(userContextBuilder.updateModel).not.toHaveBeenCalled()
+  })
+
+  it('skips both updateModel calls without throwing when optional services are absent', () => {
+    const semanticService = { updateModels: vi.fn() }
+    const deps: ModelSettingsDeps = { semanticService }
+    const previous = makeSettings({ patternDetectionModel: 'old/model' })
+    const updated = makeSettings({ patternDetectionModel: 'new/model' })
+
+    expect(() => applyModelSettings(deps, updated, previous)).not.toThrow()
+  })
+
+  it('forwards setEnabled to patternDetector when patternDetectionEnabled flips', () => {
+    const { deps, patternDetector, userContextBuilder } = makeDeps()
+    const previous = makeSettings({ patternDetectionEnabled: true })
+    const updated = makeSettings({ patternDetectionEnabled: false })
+
+    applyModelSettings(deps, updated, previous)
+
+    expect(patternDetector.setEnabled).toHaveBeenCalledWith(false)
+    expect(userContextBuilder.updateModel).not.toHaveBeenCalled()
+  })
+
+  it('refreshes semantic models when video/snapshot model or vendor changes', () => {
+    const { deps, semanticService } = makeDeps()
+    const previous = makeSettings({
+      semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
+    })
+    const newPick = VENDOR_PRESETS.openrouter.semanticVideo[1].id
+    const updated = makeSettings({ semanticVideoModel: newPick })
+
+    applyModelSettings(deps, updated, previous)
+
+    expect(semanticService.updateModels).toHaveBeenCalledTimes(1)
+    const [videoModels] = semanticService.updateModels.mock.calls[0] as [string[], string[]]
+    expect(videoModels[0]).toBe(newPick)
+  })
+
+  it('does not refresh semantic models when nothing model-related changed', () => {
+    const { deps, semanticService } = makeDeps()
+    const settings = makeSettings()
+
+    applyModelSettings(deps, settings, settings)
+
+    expect(semanticService.updateModels).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ui/model-settings.ts
+++ b/src/main/ui/model-settings.ts
@@ -1,0 +1,44 @@
+import type { CaptureSettings } from '../../shared/types'
+import { VENDOR_PRESETS, buildModelChain } from '../../shared/vendor-defaults'
+
+/**
+ * Structural shape of the dependencies that `applyModelSettings` touches.
+ * Defined separately so the helper is unit-testable without a full
+ * `MainWindowDependencies` mock.
+ */
+export interface ModelSettingsDeps {
+  semanticService: {
+    updateModels(videoModels: string[], snapshotModels: string[]): void
+  }
+  patternDetector?: { updateModel(model: string): void; setEnabled(enabled: boolean): void }
+  userContextBuilder?: { updateModel(model: string): void }
+}
+
+/**
+ * Diff `updated` vs `previous` capture settings and push only the changed
+ * model-related fields into the live runtime services.
+ */
+export function applyModelSettings(
+  d: ModelSettingsDeps,
+  updated: CaptureSettings,
+  previous: CaptureSettings,
+): void {
+  if (
+    updated.semanticVideoModel !== previous.semanticVideoModel ||
+    updated.semanticSnapshotModel !== previous.semanticSnapshotModel ||
+    updated.activeVendor !== previous.activeVendor
+  ) {
+    const presets = VENDOR_PRESETS[updated.activeVendor]
+    d.semanticService.updateModels(
+      buildModelChain(updated.semanticVideoModel, presets.semanticVideo),
+      buildModelChain(updated.semanticSnapshotModel, presets.semanticSnapshot),
+    )
+  }
+  if (updated.patternDetectionModel !== previous.patternDetectionModel) {
+    d.patternDetector?.updateModel(updated.patternDetectionModel)
+    d.userContextBuilder?.updateModel(updated.patternDetectionModel)
+  }
+  if (updated.patternDetectionEnabled !== previous.patternDetectionEnabled) {
+    d.patternDetector?.setEnabled(updated.patternDetectionEnabled)
+  }
+}

--- a/src/main/ui/vendor-switch.test.ts
+++ b/src/main/ui/vendor-switch.test.ts
@@ -11,6 +11,7 @@ function makeDeps(): {
     testConnection: ReturnType<typeof vi.fn>
   }
   patternDetector: { updateModel: ReturnType<typeof vi.fn> }
+  userContextBuilder: { updateModel: ReturnType<typeof vi.fn> }
   inferenceProvider: { notifyConfigChanged: ReturnType<typeof vi.fn> }
 } {
   const semanticService = {
@@ -19,13 +20,15 @@ function makeDeps(): {
     testConnection: vi.fn().mockResolvedValue(undefined),
   }
   const patternDetector = { updateModel: vi.fn() }
+  const userContextBuilder = { updateModel: vi.fn() }
   const inferenceProvider = { notifyConfigChanged: vi.fn() }
   const deps: VendorSwitchDeps = {
     semanticService,
     patternDetector,
+    userContextBuilder,
     inferenceProvider,
   }
-  return { deps, semanticService, patternDetector, inferenceProvider }
+  return { deps, semanticService, patternDetector, userContextBuilder, inferenceProvider }
 }
 
 function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
@@ -114,8 +117,8 @@ describe('applyVendorSwitch', () => {
     expect(videoModels).toEqual([])
   })
 
-  it('updates the pattern detector model when present and skips when absent', () => {
-    const { deps, patternDetector } = makeDeps()
+  it('updates the pattern detector and user-context-builder models when present and skips when absent', () => {
+    const { deps, patternDetector, userContextBuilder } = makeDeps()
     const next = makeSettings({
       activeVendor: 'openrouter',
       patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,
@@ -126,14 +129,17 @@ describe('applyVendorSwitch', () => {
     expect(patternDetector.updateModel).toHaveBeenCalledWith(
       VENDOR_PRESETS.openrouter.patternDetection[0].id,
     )
+    expect(userContextBuilder.updateModel).toHaveBeenCalledWith(
+      VENDOR_PRESETS.openrouter.patternDetection[0].id,
+    )
 
-    // No detector → no throw.
+    // No detector or builder → no throw.
     const { deps: bareDeps, semanticService } = makeDeps()
-    const depsWithoutDetector: VendorSwitchDeps = {
+    const depsWithoutOptionals: VendorSwitchDeps = {
       semanticService: bareDeps.semanticService,
       inferenceProvider: bareDeps.inferenceProvider,
     }
-    expect(() => applyVendorSwitch(depsWithoutDetector, next)).not.toThrow()
+    expect(() => applyVendorSwitch(depsWithoutOptionals, next)).not.toThrow()
     expect(semanticService.updatePipelinePreference).toHaveBeenCalled()
   })
 

--- a/src/main/ui/vendor-switch.ts
+++ b/src/main/ui/vendor-switch.ts
@@ -13,6 +13,7 @@ export interface VendorSwitchDeps {
     testConnection(): Promise<void>
   }
   patternDetector?: { updateModel(model: string): void }
+  userContextBuilder?: { updateModel(model: string): void }
   inferenceProvider: { notifyConfigChanged(): void }
 }
 
@@ -33,6 +34,7 @@ export function applyVendorSwitch(d: VendorSwitchDeps, next: CaptureSettings): v
   )
   d.semanticService.updatePipelinePreference(next.semanticPipelineMode)
   d.patternDetector?.updateModel(next.patternDetectionModel)
+  d.userContextBuilder?.updateModel(next.patternDetectionModel)
   d.inferenceProvider.notifyConfigChanged()
   void d.semanticService.testConnection()
 }


### PR DESCRIPTION
## Summary

- `UserContextBuilder` was hardcoded to the OpenRouter-style id `google/gemini-2.5-flash` (`USER_CONTEXT_CONFIG.MODEL`), so on native Google Vertex it hit `AI_APICallError: Not Found` — the bare id is `gemini-2.5-flash`.
- Mirrors `PatternDetector` plumbing: `UserContextBuilder` now holds a live `model` field with `updateModel(...)`, fed by the existing per-vendor `patternDetectionModel` setting through `applyVendorSwitch` and `applyModelSettings`.
- Also syncs `patternDetector.updateModel(...)` on startup — same latent bug for the first scheduled run when the user hadn't switched vendor yet.

Reuses the existing `patternDetectionModel` slot rather than introducing a new `userContextModel` setting; the two services do the same kind of background textual analysis and ship identical defaults today. A dedicated slot can be split out later (DEU-83) if they ever need to diverge.

## Test plan

- [x] `npm run test -- vendor-switch` — extended assertion covers `userContextBuilder.updateModel` propagation.
- [x] `npm run test` — full suite (571 passed).
- [x] `npm run lint` — no new warnings/errors.
- [ ] Manual on Google vendor: `npm run dev`, wait for unlock + 30s, confirm `[UserContextBuilder] Sending aggregated profile to gemini-2.5-flash...` (no `google/` prefix) instead of the prior 404.
- [ ] Regression on OpenRouter: default `patternDetectionModel` is `google/gemini-2.5-flash` — identical to the previous hardcoded value, behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)