### PR TITLE
feat(enterprise): skip consent UI when backend reports already_approved

### DIFF
--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -164,6 +164,64 @@ describe('EnterpriseAccessProvider', () => {
     expect(updates.at(-1)?.status).toBe('error')
   })
 
+  it('skips consent UI and binds via external consent when backend returns already_approved', async () => {
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = []
+    const responses = [
+      // GET /license/consent-document -> already_approved sentinel
+      {
+        ok: true,
+        json: async () => ({ state: 'already_approved', version: 0 }),
+      } as unknown as Response,
+      // POST /license/activate (outcome=accepted, no document_version)
+      { ok: true, json: async () => ({ ok: true }) } as unknown as Response,
+      // GET /license/status (poll #1: activated)
+      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
+      // GET /license/inference-config
+      {
+        ok: true,
+        json: async () => ({
+          provider: 'openrouter',
+          apiKey: 'sk-or-enterprise',
+          project: null,
+          location: null,
+          expiresAt: null,
+        }),
+      } as unknown as Response,
+    ]
+    globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), init })
+      return responses.shift() as Response
+    }) as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; payload?: unknown }> = []
+    provider.setUpdateCallback((state, payload) => {
+      updates.push({ status: state.enterpriseActivationStatus, payload })
+    })
+
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
+    await vi.advanceTimersByTimeAsync(ENTERPRISE_BACKEND_CONFIG.POLL_INTERVAL_MS)
+
+    expect(updates.some((u) => u.status === 'awaiting_consent')).toBe(false)
+    expect(await provider.getPendingConsent()).toBeNull()
+
+    const activateCall = fetchCalls.find((c) => c.url.includes('/license/activate'))
+    expect(activateCall).toBeDefined()
+    const activateBody = JSON.parse(String(activateCall?.init?.body)) as Record<string, unknown>
+    expect(activateBody).toMatchObject({
+      tenant_token: TENANT_TOKEN,
+      device_id: 'device-123',
+      email: EMAIL,
+      outcome: 'accepted',
+    })
+    expect(activateBody).not.toHaveProperty('document_version')
+
+    expect(updates.at(-1)?.status).toBe('activated')
+    expect(updates.at(-1)?.payload).toEqual({
+      config: { provider: 'openrouter', apiKey: 'sk-or-enterprise' },
+    })
+  })
+
   it('activates and polls for the key after consent is accepted', async () => {
     const responses = [
       descriptorResponse(),

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -222,6 +222,63 @@ describe('EnterpriseAccessProvider', () => {
     })
   })
 
+  it('treats 502 on external-consent bind as provisional success and starts polling', async () => {
+    const responses = [
+      // GET /license/consent-document -> already_approved sentinel
+      {
+        ok: true,
+        json: async () => ({ state: 'already_approved' }),
+      } as unknown as Response,
+      // POST /license/activate fails with 502
+      {
+        ok: false,
+        status: 502,
+        json: async () => ({ error: 'upstream' }),
+      } as unknown as Response,
+      // poll resolves anyway
+      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
+      {
+        ok: true,
+        json: async () => ({
+          provider: 'openrouter',
+          apiKey: 'sk-or-enterprise',
+          project: null,
+          location: null,
+          expiresAt: null,
+        }),
+      } as unknown as Response,
+    ]
+    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus })
+    })
+
+    await provider.activateEnterpriseLicense(ACTIVATION_CODE)
+    await vi.advanceTimersByTimeAsync(ENTERPRISE_BACKEND_CONFIG.POLL_INTERVAL_MS)
+
+    expect(updates.some((u) => u.status === 'awaiting_consent')).toBe(false)
+    expect(updates.at(-1)?.status).toBe('activated')
+  })
+
+  it('rejects descriptors with an unknown state value as malformed', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ state: 'pending_review' }),
+    })) as unknown as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; error: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus, error: state.error })
+    })
+
+    await expect(provider.activateEnterpriseLicense(ACTIVATION_CODE)).rejects.toThrow(/malformed/i)
+    expect(updates.at(-1)?.status).toBe('error')
+  })
+
   it('activates and polls for the key after consent is accepted', async () => {
     const responses = [
       descriptorResponse(),

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -37,13 +37,19 @@ function normalizeConsentContentType(raw: string | undefined): AllowedConsentCon
     : null
 }
 
-interface ConsentDescriptorPayload {
-  url: string
-  version: number
-  sha256: string
-  title: string
-  content_type: string
-}
+type ConsentDescriptorPayload =
+  | {
+      state?: 'required'
+      url: string
+      version: number
+      sha256: string
+      title: string
+      content_type: string
+    }
+  | {
+      state: 'already_approved'
+      version: 0
+    }
 
 interface ActivateResponse {
   ok?: boolean
@@ -169,8 +175,19 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       throw new Error(errorMessage)
     }
 
-    const descriptor = (await descriptorResponse.json()) as Partial<ConsentDescriptorPayload>
+    const descriptor = (await descriptorResponse.json()) as
+      | (Partial<ConsentDescriptorPayload> & { state?: string })
+      | null
+
+    if (descriptor !== null && descriptor.state === 'already_approved') {
+      log.info('[EnterpriseAccess] Consent pre-approved by backend; skipping consent UI')
+      await this.bindWithExternalConsent(parsed.tenantToken, parsed.email)
+      return
+    }
+
     if (
+      descriptor === null ||
+      (descriptor.state !== undefined && descriptor.state !== 'required') ||
       typeof descriptor.url !== 'string' ||
       typeof descriptor.version !== 'number' ||
       typeof descriptor.sha256 !== 'string' ||
@@ -307,6 +324,48 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     this.applyTransition(
       transitionEnterpriseAccess(this.accessState, { type: 'consent_decision_accepted' }),
     )
+    this.startActivationPolling(deviceId)
+  }
+
+  private async bindWithExternalConsent(tenantToken: string, email: string): Promise<void> {
+    const deviceId = this.deviceIdentity.getDeviceId()
+    const response = await fetch(this.enterpriseUrl('api/license/activate'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...bearer(tenantToken),
+      },
+      body: JSON.stringify({
+        tenant_token: tenantToken,
+        device_id: deviceId,
+        email,
+        outcome: 'accepted',
+      }),
+    })
+
+    if (response.status === 502) {
+      log.warn(
+        '[EnterpriseAccess] External-consent bind reported downstream provisioning failure; polling',
+      )
+      this.startActivationPolling(deviceId)
+      return
+    }
+
+    if (!response.ok) {
+      const errorMessage = await this.readErrorMessage(
+        response,
+        'Activation failed during external-consent bind',
+      )
+      this.applyTransition(
+        transitionEnterpriseAccess(this.accessState, {
+          type: 'activation_failed',
+          error: errorMessage,
+        }),
+      )
+      throw new Error(errorMessage)
+    }
+
+    log.info('[EnterpriseAccess] External-consent bind succeeded; polling for activation state')
     this.startActivationPolling(deviceId)
   }
 

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -37,24 +37,61 @@ function normalizeConsentContentType(raw: string | undefined): AllowedConsentCon
     : null
 }
 
-type ConsentDescriptorPayload =
+type ParsedConsentDescriptor =
+  | { kind: 'already_approved' }
   | {
-      state?: 'required'
+      kind: 'required'
       url: string
       version: number
       sha256: string
       title: string
-      content_type: string
+      contentType: AllowedConsentContentType
     }
-  | {
-      state: 'already_approved'
-      version: 0
-    }
+
+function parseConsentDescriptor(raw: unknown): ParsedConsentDescriptor {
+  if (raw === null || typeof raw !== 'object') {
+    throw new Error('Consent descriptor is malformed.')
+  }
+  const obj = raw as Record<string, unknown>
+
+  if (obj.state === 'already_approved') {
+    return { kind: 'already_approved' }
+  }
+  if (obj.state !== undefined && obj.state !== 'required') {
+    throw new Error('Consent descriptor is malformed.')
+  }
+  if (
+    typeof obj.url !== 'string' ||
+    typeof obj.version !== 'number' ||
+    typeof obj.sha256 !== 'string' ||
+    typeof obj.title !== 'string'
+  ) {
+    throw new Error('Consent descriptor is malformed.')
+  }
+  const rawContentType = typeof obj.content_type === 'string' ? obj.content_type : undefined
+  const contentType = normalizeConsentContentType(rawContentType)
+  if (contentType === null) {
+    throw new Error(`Unsupported consent document type: ${rawContentType ?? 'unknown'}`)
+  }
+  return {
+    kind: 'required',
+    url: obj.url,
+    version: obj.version,
+    sha256: obj.sha256,
+    title: obj.title,
+    contentType,
+  }
+}
 
 interface ActivateResponse {
   ok?: boolean
   declined?: boolean
 }
+
+type ActivateResult =
+  | { status: 'ok'; data: ActivateResponse }
+  | { status: 'provisioning_pending'; message: string }
+  | { status: 'error'; message: string }
 
 function bearer(token: string): Record<string, string> {
   return { Authorization: `Bearer ${token}` }
@@ -175,44 +212,25 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       throw new Error(errorMessage)
     }
 
-    const descriptor = (await descriptorResponse.json()) as
-      | (Partial<ConsentDescriptorPayload> & { state?: string })
-      | null
+    let descriptor: ParsedConsentDescriptor
+    try {
+      descriptor = parseConsentDescriptor(await descriptorResponse.json())
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Consent descriptor is malformed.'
+      this.applyTransition(
+        transitionEnterpriseAccess(this.accessState, {
+          type: 'activation_failed',
+          error: errorMessage,
+        }),
+      )
+      throw new Error(errorMessage)
+    }
 
-    if (descriptor !== null && descriptor.state === 'already_approved') {
+    if (descriptor.kind === 'already_approved') {
       log.info('[EnterpriseAccess] Consent pre-approved by backend; skipping consent UI')
       await this.bindWithExternalConsent(parsed.tenantToken, parsed.email)
       return
-    }
-
-    if (
-      descriptor === null ||
-      (descriptor.state !== undefined && descriptor.state !== 'required') ||
-      typeof descriptor.url !== 'string' ||
-      typeof descriptor.version !== 'number' ||
-      typeof descriptor.sha256 !== 'string' ||
-      typeof descriptor.title !== 'string'
-    ) {
-      const errorMessage = 'Consent descriptor is malformed.'
-      this.applyTransition(
-        transitionEnterpriseAccess(this.accessState, {
-          type: 'activation_failed',
-          error: errorMessage,
-        }),
-      )
-      throw new Error(errorMessage)
-    }
-
-    const contentType = normalizeConsentContentType(descriptor.content_type)
-    if (contentType === null) {
-      const errorMessage = `Unsupported consent document type: ${descriptor.content_type ?? 'unknown'}`
-      this.applyTransition(
-        transitionEnterpriseAccess(this.accessState, {
-          type: 'activation_failed',
-          error: errorMessage,
-        }),
-      )
-      throw new Error(errorMessage)
     }
 
     let documentBytesBase64: string
@@ -239,7 +257,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       version: descriptor.version,
       sha256: descriptor.sha256,
       title: descriptor.title,
-      contentType,
+      contentType: descriptor.contentType,
       bytesBase64: documentBytesBase64,
     }
     log.info('[EnterpriseAccess] Consent required before activation can complete')
@@ -265,22 +283,19 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     }
 
     const deviceId = this.deviceIdentity.getDeviceId()
-    const response = await fetch(this.enterpriseUrl('api/license/activate'), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...bearer(pending.tenantToken),
-      },
-      body: JSON.stringify({
+    const result = await this.postActivate(
+      {
         tenant_token: pending.tenantToken,
         device_id: deviceId,
         email: pending.email,
         document_version: pending.version,
         outcome,
-      }),
-    })
+      },
+      pending.tenantToken,
+      'Consent request failed',
+    )
 
-    if (response.status === 502 && outcome === 'accepted') {
+    if (result.status === 'provisioning_pending' && outcome === 'accepted') {
       log.warn(
         '[EnterpriseAccess] Consent accepted but downstream key provisioning failed; polling',
       )
@@ -293,22 +308,19 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       return
     }
 
-    if (!response.ok) {
-      const errorMessage = await this.readErrorMessage(response, 'Consent request failed')
+    if (result.status !== 'ok') {
       this.clearConsentTimeout()
       this.pendingConsent = null
       this.applyTransition(
         transitionEnterpriseAccess(this.accessState, {
           type: 'activation_failed',
-          error: errorMessage,
+          error: result.message,
         }),
       )
-      throw new Error(errorMessage)
+      throw new Error(result.message)
     }
 
-    const data = (await response.json()) as ActivateResponse
-
-    if (outcome === 'declined' || data.declined === true) {
+    if (outcome === 'declined' || result.data.declined === true) {
       log.info('[EnterpriseAccess] User declined consent; resetting activation state')
       this.clearConsentTimeout()
       this.pendingConsent = null
@@ -329,44 +341,56 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
 
   private async bindWithExternalConsent(tenantToken: string, email: string): Promise<void> {
     const deviceId = this.deviceIdentity.getDeviceId()
+    const result = await this.postActivate(
+      { tenant_token: tenantToken, device_id: deviceId, email, outcome: 'accepted' },
+      tenantToken,
+      'Activation failed during external-consent bind',
+    )
+
+    if (result.status === 'error') {
+      this.applyTransition(
+        transitionEnterpriseAccess(this.accessState, {
+          type: 'activation_failed',
+          error: result.message,
+        }),
+      )
+      throw new Error(result.message)
+    }
+
+    if (result.status === 'provisioning_pending') {
+      log.warn(
+        '[EnterpriseAccess] External-consent bind reported downstream provisioning failure; polling',
+      )
+    } else {
+      log.info('[EnterpriseAccess] External-consent bind succeeded; polling for activation state')
+    }
+    this.startActivationPolling(deviceId)
+  }
+
+  private async postActivate(
+    body: Record<string, unknown>,
+    tenantToken: string,
+    errorFallback: string,
+  ): Promise<ActivateResult> {
     const response = await fetch(this.enterpriseUrl('api/license/activate'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         ...bearer(tenantToken),
       },
-      body: JSON.stringify({
-        tenant_token: tenantToken,
-        device_id: deviceId,
-        email,
-        outcome: 'accepted',
-      }),
+      body: JSON.stringify(body),
     })
 
     if (response.status === 502) {
-      log.warn(
-        '[EnterpriseAccess] External-consent bind reported downstream provisioning failure; polling',
-      )
-      this.startActivationPolling(deviceId)
-      return
+      return {
+        status: 'provisioning_pending',
+        message: await this.readErrorMessage(response, errorFallback),
+      }
     }
-
     if (!response.ok) {
-      const errorMessage = await this.readErrorMessage(
-        response,
-        'Activation failed during external-consent bind',
-      )
-      this.applyTransition(
-        transitionEnterpriseAccess(this.accessState, {
-          type: 'activation_failed',
-          error: errorMessage,
-        }),
-      )
-      throw new Error(errorMessage)
+      return { status: 'error', message: await this.readErrorMessage(response, errorFallback) }
     }
-
-    log.info('[EnterpriseAccess] External-consent bind succeeded; polling for activation state')
-    this.startActivationPolling(deviceId)
+    return { status: 'ok', data: (await response.json()) as ActivateResponse }
   }
 
   public async startCheckout(): Promise<void> {


### PR DESCRIPTION
## Summary

- When `tenant.consent_handled_externally` is on, the backend now returns `{state: 'already_approved', version: 0}` from `GET /api/license/consent-document`.
- On that branch the client POSTs `/api/license/activate` with `outcome: 'accepted'` and **no** `document_version`, then polls for the inference key — no consent dialog, no PDF fetch, no SHA-256 verification.
- Backwards-compatible: descriptors with no `state` field are still treated as `required`, so a staged backend rollout doesn't break existing users.
- The `outcome` wire value stays `'accepted'`; the backend records it as `ConsentRecord(outcome=EXTERNAL)` based on the tenant flag.

## Why the activate POST is still required

`/api/license/status` and `/api/license/inference-config` use `DeviceTokenAuth`. Without a prior `/activate` call, no Device row exists and polling 401s indefinitely. The activate POST is what creates the Device + ConsentRecord rows on the auto-accept branch.

## Test plan

- [x] `npm run test -- enterprise-access-provider` — 17/17 pass, including new `already_approved` path test
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new warnings
- [ ] Manual E2E against staging tenant with `consent_handled_externally=true`: enter activation code → no dialog → reaches `activated`
- [ ] Manual E2E against tenant with the flag off: dialog still appears and works as before
- [ ] Toggle the flag mid-session and re-attempt activation: client picks up the new response without restart

## Out of scope

- Custom UX for the 409 `TenantConsentNotConfigured` from `consent-document` (currently surfaces the generic backend error message).
- `POST /api/license/revoke` wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)