### PR TITLE
Onboarding: hide Permissions on Windows + skip flow for existing recordings

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -11,7 +11,7 @@ This document is the source of truth for permission behaviour. Update it wheneve
 | **Accessibility**    | Detect app/window focus changes and typing activity (typing _duration_, not content) so captures can be grouped into distinct tasks. | `systemPreferences.isTrustedAccessibilityClient(false)` |
 | **Screen Recording** | Capture screenshots of the active display(s) so on-device OCR + embeddings can recognise what was on screen.                         | `systemPreferences.getMediaAccessStatus('screen')`      |
 
-Non-macOS platforms (Windows, Linux) report both as `granted` and skip the flow entirely.
+Non-macOS platforms (Windows, Linux) report both as `granted` and skip the flow entirely — the renderer filters the **Permissions** step out of the onboarding stepper based on `api.platform` so it never renders on those platforms.
 
 ## Permission states
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -119,6 +119,8 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
   },
   // App lifecycle
   restartApp: () => ipcRenderer.invoke('main-window:restartApp'),
+  // Host platform — read once at preload time; never changes mid-session.
+  platform: process.platform,
 })
 
 console.log('[Preload] mainWindowAPI exposed to renderer')

--- a/src/renderer/components/ui/checkbox.tsx
+++ b/src/renderer/components/ui/checkbox.tsx
@@ -1,0 +1,26 @@
+import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox'
+
+import { cn } from '@/renderer/lib/utils'
+import { CheckIcon } from '@phosphor-icons/react'
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/renderer/pages/main-window/MainWindowApp.tsx
+++ b/src/renderer/pages/main-window/MainWindowApp.tsx
@@ -19,7 +19,7 @@ import { WelcomeStep } from './components/onboarding/WelcomeStep'
 import {
   LAST_COMPLETED_STEP_INDEX_KEY,
   localStorageAdapter,
-  readOrMigrateLastCompletedIndex,
+  readLastCompletedIndex,
   writeIntFlag,
 } from './onboarding-storage'
 import { impliedCompletedIndex, resolveOnboarding } from './onboarding-state'
@@ -56,7 +56,7 @@ export function MainWindowApp(): React.JSX.Element {
   const [patterns, setPatterns] = useState<PatternInfo[] | null>(null)
   const [initialLoaded, setInitialLoaded] = useState(false)
   const [lastCompletedStepIndex, setLastCompletedStepIndex] = useState<number>(() =>
-    readOrMigrateLastCompletedIndex(localStorageAdapter),
+    readLastCompletedIndex(localStorageAdapter),
   )
   const [permissionStatus, setPermissionStatus] = useState<PermissionStatus | null>(null)
   // Captured synchronously on the first non-null permission status so we can
@@ -184,11 +184,18 @@ export function MainWindowApp(): React.JSX.Element {
     initialScreenRecording !== 'granted' &&
     permissionStatus?.screenRecording === 'granted'
 
+  const platform = api.platform
+  const isMac = platform === 'darwin'
   const anyMcpConnected = mcpStatus !== null && Object.values(mcpStatus).some(Boolean)
   const screenRecordingGranted = permissionStatus?.screenRecording === 'granted'
   const accessibilityGranted = permissionStatus?.accessibility === 'granted'
-  const hasAnyProgress =
-    isConfigured || screenRecordingGranted || accessibilityGranted || anyMcpConnected
+  // On non-darwin, both permissions are hard-coded `granted`, so they aren't a
+  // real "progress" signal — exclude them to avoid auto-completing Welcome for
+  // a brand-new Windows user.
+  const hasAnyProgress = isMac
+    ? isConfigured || screenRecordingGranted || accessibilityGranted || anyMcpConnected
+    : isConfigured || anyMcpConnected
+  const hasExistingActivities = (stats?.activityCount ?? 0) > 0
 
   const resolution = useMemo(
     () =>
@@ -201,6 +208,8 @@ export function MainWindowApp(): React.JSX.Element {
         hasAnyProgress,
         anyMcpConnected,
         viewStepOverride,
+        platform,
+        hasExistingActivities,
       }),
     [
       isEnterprise,
@@ -211,10 +220,13 @@ export function MainWindowApp(): React.JSX.Element {
       hasAnyProgress,
       anyMcpConnected,
       viewStepOverride,
+      platform,
+      hasExistingActivities,
     ],
   )
   const {
     steps: onboardingSteps,
+    displaySteps: onboardingDisplaySteps,
     computedStep,
     computedIndex,
     displayStep,
@@ -231,16 +243,24 @@ export function MainWindowApp(): React.JSX.Element {
   }, [viewStepOverride, overrideValid])
 
   const handleBack = useCallback(() => {
-    if (displayIndex <= 0) return
-    setViewStepOverride(onboardingSteps[displayIndex - 1].id)
-  }, [displayIndex, onboardingSteps])
+    // Navigate against the displayed (filtered) step list so platforms that
+    // hide the Permissions step don't accidentally land on it via override.
+    const displayedIdx = onboardingDisplaySteps.findIndex((s) => s.id === displayStep)
+    if (displayedIdx <= 0) return
+    setViewStepOverride(onboardingDisplaySteps[displayedIdx - 1].id)
+  }, [displayStep, onboardingDisplaySteps])
 
   const handleForward = useCallback(() => {
     // If the user is viewing an earlier step via override, just step the
-    // override forward (displayIndex === overrideIndex when overrideValid).
-    if (overrideValid && displayIndex + 1 < computedIndex) {
-      setViewStepOverride(onboardingSteps[displayIndex + 1].id)
-      return
+    // override forward through the displayed list.
+    if (overrideValid) {
+      const displayedIdx = onboardingDisplaySteps.findIndex((s) => s.id === displayStep)
+      const next = onboardingDisplaySteps[displayedIdx + 1]
+      const nextCanonicalIdx = next ? onboardingSteps.findIndex((s) => s.id === next.id) : -1
+      if (next && nextCanonicalIdx < computedIndex) {
+        setViewStepOverride(next.id)
+        return
+      }
     }
     // Otherwise we're at the leading edge — perform the step's continue
     // action. Every step except `activation` needs an explicit completion
@@ -250,7 +270,15 @@ export function MainWindowApp(): React.JSX.Element {
       markStepCompleted(displayIndex)
     }
     setViewStepOverride(null)
-  }, [overrideValid, computedIndex, onboardingSteps, displayStep, displayIndex, markStepCompleted])
+  }, [
+    overrideValid,
+    computedIndex,
+    onboardingSteps,
+    onboardingDisplaySteps,
+    displayStep,
+    displayIndex,
+    markStepCompleted,
+  ])
 
   useEffect(() => {
     void api.getStatus().then((status) => {
@@ -304,6 +332,8 @@ export function MainWindowApp(): React.JSX.Element {
       hasAnyProgress,
       anyMcpConnected,
       viewStepOverride: null,
+      platform,
+      hasExistingActivities,
     })
     if (implied > lastCompletedStepIndex) {
       markStepCompleted(implied)
@@ -317,6 +347,8 @@ export function MainWindowApp(): React.JSX.Element {
     hasAnyProgress,
     anyMcpConnected,
     lastCompletedStepIndex,
+    platform,
+    hasExistingActivities,
     markStepCompleted,
   ])
 
@@ -480,7 +512,7 @@ export function MainWindowApp(): React.JSX.Element {
           </>
         ) : (
           <OnboardingLayout
-            steps={onboardingSteps}
+            steps={onboardingDisplaySteps}
             currentStep={displayStep as OnboardingStepId}
             onBack={handleBack}
             onForward={handleForward}

--- a/src/renderer/pages/main-window/MainWindowApp.tsx
+++ b/src/renderer/pages/main-window/MainWindowApp.tsx
@@ -22,7 +22,12 @@ import {
   readLastCompletedIndex,
   writeIntFlag,
 } from './onboarding-storage'
-import { impliedCompletedIndex, resolveOnboarding } from './onboarding-state'
+import {
+  impliedCompletedIndex,
+  nextOverrideDisplayStep,
+  previousDisplayStep,
+  resolveOnboarding,
+} from './onboarding-state'
 import type { AppEditionConfig } from '@/shared/edition'
 import type {
   AccessState,
@@ -189,13 +194,19 @@ export function MainWindowApp(): React.JSX.Element {
   const anyMcpConnected = mcpStatus !== null && Object.values(mcpStatus).some(Boolean)
   const screenRecordingGranted = permissionStatus?.screenRecording === 'granted'
   const accessibilityGranted = permissionStatus?.accessibility === 'granted'
+  const hasExistingActivities = (stats?.activityCount ?? 0) > 0
   // On non-darwin, both permissions are hard-coded `granted`, so they aren't a
   // real "progress" signal — exclude them to avoid auto-completing Welcome for
-  // a brand-new Windows user.
+  // a brand-new Windows user. Existing DB activity counts as progress on every
+  // platform so wipe-localStorage users land straight on dashboard instead of
+  // flashing through Welcome before the self-heal effect bumps the index.
   const hasAnyProgress = isMac
-    ? isConfigured || screenRecordingGranted || accessibilityGranted || anyMcpConnected
-    : isConfigured || anyMcpConnected
-  const hasExistingActivities = (stats?.activityCount ?? 0) > 0
+    ? isConfigured ||
+      screenRecordingGranted ||
+      accessibilityGranted ||
+      anyMcpConnected ||
+      hasExistingActivities
+    : isConfigured || anyMcpConnected || hasExistingActivities
 
   const resolution = useMemo(
     () =>
@@ -243,22 +254,23 @@ export function MainWindowApp(): React.JSX.Element {
   }, [viewStepOverride, overrideValid])
 
   const handleBack = useCallback(() => {
-    // Navigate against the displayed (filtered) step list so platforms that
-    // hide the Permissions step don't accidentally land on it via override.
-    const displayedIdx = onboardingDisplaySteps.findIndex((s) => s.id === displayStep)
-    if (displayedIdx <= 0) return
-    setViewStepOverride(onboardingDisplaySteps[displayedIdx - 1].id)
+    const prev = previousDisplayStep(displayStep, onboardingDisplaySteps)
+    if (prev === null) return
+    setViewStepOverride(prev)
   }, [displayStep, onboardingDisplaySteps])
 
   const handleForward = useCallback(() => {
     // If the user is viewing an earlier step via override, just step the
     // override forward through the displayed list.
     if (overrideValid) {
-      const displayedIdx = onboardingDisplaySteps.findIndex((s) => s.id === displayStep)
-      const next = onboardingDisplaySteps[displayedIdx + 1]
-      const nextCanonicalIdx = next ? onboardingSteps.findIndex((s) => s.id === next.id) : -1
-      if (next && nextCanonicalIdx < computedIndex) {
-        setViewStepOverride(next.id)
+      const next = nextOverrideDisplayStep(
+        displayStep,
+        onboardingDisplaySteps,
+        onboardingSteps,
+        computedIndex,
+      )
+      if (next !== null) {
+        setViewStepOverride(next)
         return
       }
     }

--- a/src/renderer/pages/main-window/components/advanced-settings/DataTabPanel.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/DataTabPanel.tsx
@@ -182,7 +182,7 @@ export function DataTabPanel({
                 size="sm"
                 onClick={() => setIsPurgeExpanded(true)}
               >
-                Purge database…
+                Purge database
               </Button>
             }
           />

--- a/src/renderer/pages/main-window/components/onboarding/EnterpriseActivationStep.tsx
+++ b/src/renderer/pages/main-window/components/onboarding/EnterpriseActivationStep.tsx
@@ -2,7 +2,9 @@ import * as React from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@components/ui/button'
+import { Checkbox } from '@components/ui/checkbox'
 import { Input } from '@components/ui/input'
+import { Label } from '@components/ui/label'
 import { OnboardingStep } from './OnboardingStep'
 import type { AccessState, ConsentOutcome, MainWindowAPI, PendingConsent } from '@types'
 
@@ -155,7 +157,7 @@ function ConsentScreen({ api, accessState }: EnterpriseActivationStepProps): Rea
   return (
     <OnboardingStep>
       <OnboardingStep.Header
-        title={consent?.title ?? 'Review and accept'}
+        title={consent?.title?.trim() ? consent.title : 'Review and accept'}
         subtitle="Your employer needs your consent before activating this device. Review the document below before deciding."
       />
 
@@ -174,17 +176,17 @@ function ConsentScreen({ api, accessState }: EnterpriseActivationStepProps): Rea
         loadError === null && <p className="text-xs text-muted-foreground">Loading document...</p>
       )}
 
-      <label className="flex items-center gap-2 text-sm">
-        <input
-          type="checkbox"
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="consent-agree"
           checked={agreed}
-          onChange={(e) => setAgreed(e.target.checked)}
+          onCheckedChange={(value) => setAgreed(value === true)}
           disabled={submitting}
         />
-        <span>I have read and agree to this document.</span>
-      </label>
+        <Label htmlFor="consent-agree">I have read and agree to this document.</Label>
+      </div>
 
-      <div className="flex gap-2 pt-2">
+      <OnboardingStep.Actions>
         <Button
           size="lg"
           variant="outline"
@@ -202,7 +204,7 @@ function ConsentScreen({ api, accessState }: EnterpriseActivationStepProps): Rea
         >
           {submitting ? 'Submitting...' : 'Accept'}
         </Button>
-      </div>
+      </OnboardingStep.Actions>
     </OnboardingStep>
   )
 }

--- a/src/renderer/pages/main-window/components/onboarding/OnboardingStep.tsx
+++ b/src/renderer/pages/main-window/components/onboarding/OnboardingStep.tsx
@@ -39,4 +39,12 @@ function StepButton({ onClick, disabled, children }: StepButtonProps): React.JSX
   )
 }
 
-export const OnboardingStep = Object.assign(OnboardingStepRoot, { Header, Button: StepButton })
+function Actions({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return <div className="flex gap-2 pt-2">{children}</div>
+}
+
+export const OnboardingStep = Object.assign(OnboardingStepRoot, {
+  Header,
+  Button: StepButton,
+  Actions,
+})

--- a/src/renderer/pages/main-window/onboarding-state.test.ts
+++ b/src/renderer/pages/main-window/onboarding-state.test.ts
@@ -22,6 +22,8 @@ function baseInputs(overrides: Partial<OnboardingInputs> = {}): OnboardingInputs
     hasAnyProgress: false,
     anyMcpConnected: false,
     viewStepOverride: null,
+    platform: 'darwin',
+    hasExistingActivities: false,
     ...overrides,
   }
 }
@@ -179,22 +181,6 @@ describe('resolveOnboarding — enterprise', () => {
     expect(r.steps).toHaveLength(5)
   })
 
-  it('enterprise overshoot from legacy migration: lands on dashboard', () => {
-    // Legacy migration may produce lastCompletedStepIndex=5 (consumer capture
-    // index post-shift), but enterprise list has indices 0..4. Overshoot
-    // should resolve to dashboard.
-    const r = resolveOnboarding(
-      baseInputs({
-        isEnterprise: true,
-        lastCompletedStepIndex: 5,
-        permissionStatus: GRANTED,
-        isConfigured: true,
-        hasAnyProgress: true,
-      }),
-    )
-    expect(r.computedStep).toBe('dashboard')
-  })
-
   it('activation auto-completes purely on isConfigured', () => {
     const r = resolveOnboarding(
       baseInputs({
@@ -314,5 +300,132 @@ describe('impliedCompletedIndex', () => {
     expect(
       impliedCompletedIndex(baseInputs({ permissionStatus: PARTIAL, hasAnyProgress: true })),
     ).toBe(0)
+  })
+
+  it('returns last consumer index when hasExistingActivities (re-install scenario)', () => {
+    // User has DB data but blank localStorage — treat as fully onboarded.
+    expect(impliedCompletedIndex(baseInputs({ hasExistingActivities: true }))).toBe(5)
+  })
+
+  it('returns last enterprise index when hasExistingActivities', () => {
+    expect(
+      impliedCompletedIndex(baseInputs({ isEnterprise: true, hasExistingActivities: true })),
+    ).toBe(4)
+  })
+
+  it('does not bump implied past permissions on non-darwin even when granted', () => {
+    // On Windows getPermissionStatus auto-returns granted, but that grant is
+    // trivial and should not imply progress beyond welcome.
+    expect(
+      impliedCompletedIndex(
+        baseInputs({ platform: 'win32', permissionStatus: GRANTED, hasAnyProgress: false }),
+      ),
+    ).toBe(-1)
+  })
+})
+
+describe('resolveOnboarding — non-darwin (Windows/Linux) platform', () => {
+  it('consumer Windows: displaySteps has 5 steps, no permissions', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'win32' }))
+    expect(r.steps.map((s) => s.id)).toContain('permissions') // canonical untouched
+    expect(r.displaySteps.map((s) => s.id)).toEqual([
+      'welcome',
+      'plan',
+      'connect',
+      'blacklist',
+      'capture',
+    ])
+  })
+
+  it('enterprise Windows: displaySteps has 4 steps, no permissions', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'win32', isEnterprise: true }))
+    expect(r.displaySteps.map((s) => s.id)).toEqual([
+      'welcome',
+      'activation',
+      'blacklist',
+      'capture',
+    ])
+  })
+
+  it('consumer macOS: displaySteps still has 6 steps including permissions', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'darwin' }))
+    expect(r.displaySteps.map((s) => s.id)).toEqual([
+      'welcome',
+      'permissions',
+      'plan',
+      'connect',
+      'blacklist',
+      'capture',
+    ])
+  })
+
+  it('enterprise macOS: displaySteps has 5 steps including permissions', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'darwin', isEnterprise: true }))
+    expect(r.displaySteps.map((s) => s.id)).toEqual([
+      'welcome',
+      'permissions',
+      'activation',
+      'blacklist',
+      'capture',
+    ])
+  })
+
+  it('linux is treated like Windows: permissions filtered out', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'linux' }))
+    expect(r.displaySteps.map((s) => s.id)).not.toContain('permissions')
+    expect(r.displaySteps).toHaveLength(5)
+  })
+
+  it('auto-skips Permissions step on Windows: after welcome → plan', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'win32', lastCompletedStepIndex: 0 }))
+    expect(r.computedStep).toBe('plan')
+  })
+
+  it('Windows enterprise: after welcome → activation (skips permissions)', () => {
+    const r = resolveOnboarding(
+      baseInputs({ platform: 'win32', isEnterprise: true, lastCompletedStepIndex: 0 }),
+    )
+    expect(r.computedStep).toBe('activation')
+  })
+
+  it('Windows: existing activities → dashboard', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'win32', hasExistingActivities: true }))
+    // impliedCompletedIndex would push lastCompletedStepIndex to 5 in MainWindowApp,
+    // but resolveOnboarding alone needs both signals to short-circuit.
+    // Simulate post-self-heal state:
+    const r2 = resolveOnboarding(
+      baseInputs({
+        platform: 'win32',
+        hasExistingActivities: true,
+        lastCompletedStepIndex: 5,
+        isConfigured: true,
+      }),
+    )
+    expect(r2.computedStep).toBe('dashboard')
+    // First call (pre-self-heal) still works — every prior step is either
+    // auto-complete (permissions on Windows) or content-only (welcome).
+    expect(r.computedStep).not.toBe('permissions')
+  })
+
+  it('canGoBack from plan on Windows: previous displayed step is welcome', () => {
+    // The renderer-side handleBack uses displaySteps, but resolveOnboarding's
+    // canGoBack still reflects whether any earlier displayed step exists.
+    const r = resolveOnboarding(baseInputs({ platform: 'win32', lastCompletedStepIndex: 0 }))
+    expect(r.displayStep).toBe('plan')
+    expect(r.canGoBack).toBe(true)
+  })
+})
+
+describe('resolveOnboarding — existing activities short-circuit', () => {
+  it('returns dashboard once lastCompletedStepIndex covers all steps', () => {
+    const r = resolveOnboarding(
+      baseInputs({
+        hasExistingActivities: true,
+        lastCompletedStepIndex: 5,
+        permissionStatus: GRANTED,
+        isConfigured: true,
+      }),
+    )
+    expect(r.computedStep).toBe('dashboard')
   })
 })

--- a/src/renderer/pages/main-window/onboarding-state.test.ts
+++ b/src/renderer/pages/main-window/onboarding-state.test.ts
@@ -3,6 +3,8 @@ import {
   arePermissionsGranted,
   getOnboardingSteps,
   impliedCompletedIndex,
+  nextOverrideDisplayStep,
+  previousDisplayStep,
   resolveOnboarding,
   type OnboardingInputs,
 } from './onboarding-state'
@@ -414,6 +416,21 @@ describe('resolveOnboarding — non-darwin (Windows/Linux) platform', () => {
     expect(r.displayStep).toBe('plan')
     expect(r.canGoBack).toBe(true)
   })
+
+  it('rejects a viewStepOverride pointing at a hidden step (permissions on Windows)', () => {
+    // Defense-in-depth: the renderer only sets overrides from displaySteps, but
+    // a stale value must not resolve to a step the stepper UI doesn't render.
+    const r = resolveOnboarding(
+      baseInputs({
+        platform: 'win32',
+        lastCompletedStepIndex: 3,
+        isConfigured: true,
+        viewStepOverride: 'permissions',
+      }),
+    )
+    expect(r.overrideValid).toBe(false)
+    expect(r.displayStep).not.toBe('permissions')
+  })
 })
 
 describe('resolveOnboarding — existing activities short-circuit', () => {
@@ -427,5 +444,82 @@ describe('resolveOnboarding — existing activities short-circuit', () => {
       }),
     )
     expect(r.computedStep).toBe('dashboard')
+  })
+})
+
+describe('canGoBack is anchored to displaySteps', () => {
+  it('Windows at plan (canonical idx 2): canGoBack reflects displayed prev (welcome)', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'win32', lastCompletedStepIndex: 0 }))
+    expect(r.displayStep).toBe('plan')
+    // welcome is at displayedPosition 0 < plan at displayedPosition 1, so back is allowed.
+    expect(r.canGoBack).toBe(true)
+  })
+
+  it('macOS at welcome: canGoBack=false (first displayed step)', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'darwin' }))
+    expect(r.displayStep).toBe('welcome')
+    expect(r.canGoBack).toBe(false)
+  })
+
+  it('Windows at welcome: canGoBack=false even though canonical idx 1 is filtered out', () => {
+    const r = resolveOnboarding(baseInputs({ platform: 'win32' }))
+    expect(r.displayStep).toBe('welcome')
+    expect(r.canGoBack).toBe(false)
+  })
+})
+
+describe('previousDisplayStep', () => {
+  it('returns the prior displayed step', () => {
+    const consumer = getOnboardingSteps(false)
+    expect(previousDisplayStep('plan', consumer)).toBe('permissions')
+  })
+
+  it('skips filtered (Windows) steps — back from plan goes to welcome, not permissions', () => {
+    const consumer = getOnboardingSteps(false)
+    const windowsDisplay = consumer.filter((s) => s.id !== 'permissions')
+    expect(previousDisplayStep('plan', windowsDisplay)).toBe('welcome')
+  })
+
+  it('returns null at the first displayed step', () => {
+    const consumer = getOnboardingSteps(false)
+    expect(previousDisplayStep('welcome', consumer)).toBeNull()
+  })
+
+  it('returns null when displayStep is not in the displayed list (e.g. dashboard)', () => {
+    const consumer = getOnboardingSteps(false)
+    expect(previousDisplayStep('dashboard', consumer)).toBeNull()
+  })
+})
+
+describe('nextOverrideDisplayStep', () => {
+  it('advances through the displayed list, skipping filtered steps on Windows', () => {
+    // User is at welcome (override), has actually progressed to connect (canonical idx 3).
+    // Next override target should be plan — NOT permissions, which is filtered.
+    const consumer = getOnboardingSteps(false)
+    const windowsDisplay = consumer.filter((s) => s.id !== 'permissions')
+    const computedIndex = consumer.findIndex((s) => s.id === 'connect') // 3
+    expect(nextOverrideDisplayStep('welcome', windowsDisplay, consumer, computedIndex)).toBe('plan')
+  })
+
+  it('returns null when the next displayed step would catch up to the computed edge', () => {
+    // Computed edge is plan (idx 2). User is at welcome via override. plan IS the edge,
+    // so override can't advance to it — caller should perform the real continue action.
+    const consumer = getOnboardingSteps(false)
+    const windowsDisplay = consumer.filter((s) => s.id !== 'permissions')
+    const computedIndex = consumer.findIndex((s) => s.id === 'plan') // 2
+    expect(nextOverrideDisplayStep('welcome', windowsDisplay, consumer, computedIndex)).toBeNull()
+  })
+
+  it('returns null when displayStep is the last displayed entry', () => {
+    const consumer = getOnboardingSteps(false)
+    expect(nextOverrideDisplayStep('capture', consumer, consumer, consumer.length)).toBeNull()
+  })
+
+  it('macOS unfiltered: welcome → permissions when permissions is the override target', () => {
+    const consumer = getOnboardingSteps(false)
+    const computedIndex = consumer.findIndex((s) => s.id === 'plan') // 2
+    expect(nextOverrideDisplayStep('welcome', consumer, consumer, computedIndex)).toBe(
+      'permissions',
+    )
   })
 })

--- a/src/renderer/pages/main-window/onboarding-state.ts
+++ b/src/renderer/pages/main-window/onboarding-state.ts
@@ -39,10 +39,13 @@ export interface OnboardingInputs {
   hasAnyProgress: boolean
   anyMcpConnected: boolean
   viewStepOverride: OnboardingStepId | null
+  platform: NodeJS.Platform
+  hasExistingActivities: boolean
 }
 
 export interface OnboardingResolution {
   steps: OnboardingStepInfo[]
+  displaySteps: OnboardingStepInfo[]
   computedStep: DisplayStep
   computedIndex: number
   displayStep: DisplayStep
@@ -50,6 +53,17 @@ export interface OnboardingResolution {
   overrideValid: boolean
   canGoBack: boolean
   canGoForward: boolean
+}
+
+/**
+ * macOS is the only platform with TCC permissions the user can fail. On other
+ * platforms `getPermissionStatus()` hard-codes both fields to `granted`, so the
+ * Permissions step has nothing to do — filter it from the stepper UI and treat
+ * it as auto-complete in the resolution logic. Canonical step indices are kept
+ * stable; only the displayed list is filtered.
+ */
+function isPermissionsStepRelevant(platform: NodeJS.Platform): boolean {
+  return platform === 'darwin'
 }
 
 /**
@@ -90,11 +104,14 @@ function isStepComplete(id: OnboardingStepId, idx: number, inputs: OnboardingInp
     hasAnyProgress,
     permissionStatus,
     permissionRestartPending,
+    platform,
   } = inputs
   switch (id) {
     case 'welcome':
       return lastCompletedStepIndex >= idx || hasAnyProgress
     case 'permissions': {
+      // Non-darwin platforms have nothing to grant — skip the step entirely.
+      if (!isPermissionsStepRelevant(platform)) return true
       const granted = arePermissionsGranted(permissionStatus, permissionRestartPending)
       // Loading: only treat as complete if the user previously clicked through.
       if (granted === null) return lastCompletedStepIndex >= idx
@@ -115,6 +132,7 @@ function canStepGoForward(step: DisplayStep, inputs: OnboardingInputs): boolean 
     case 'welcome':
       return true
     case 'permissions': {
+      if (!isPermissionsStepRelevant(inputs.platform)) return true
       const granted = arePermissionsGranted(
         inputs.permissionStatus,
         inputs.permissionRestartPending,
@@ -137,6 +155,9 @@ function canStepGoForward(step: DisplayStep, inputs: OnboardingInputs): boolean 
 
 export function resolveOnboarding(inputs: OnboardingInputs): OnboardingResolution {
   const steps = getOnboardingSteps(inputs.isEnterprise)
+  const displaySteps = isPermissionsStepRelevant(inputs.platform)
+    ? steps
+    : steps.filter((s) => s.id !== 'permissions')
 
   const computedStepIndex = steps.findIndex((s, idx) => !isStepComplete(s.id, idx, inputs))
   const computedStep: DisplayStep =
@@ -161,6 +182,7 @@ export function resolveOnboarding(inputs: OnboardingInputs): OnboardingResolutio
 
   return {
     steps,
+    displaySteps,
     computedStep,
     computedIndex,
     displayStep,
@@ -180,11 +202,24 @@ export function resolveOnboarding(inputs: OnboardingInputs): OnboardingResolutio
  * Returns -1 if nothing is implied.
  */
 export function impliedCompletedIndex(inputs: OnboardingInputs): number {
-  const { isEnterprise, isConfigured, permissionStatus, hasAnyProgress, anyMcpConnected } = inputs
+  const {
+    isEnterprise,
+    isConfigured,
+    permissionStatus,
+    hasAnyProgress,
+    anyMcpConnected,
+    hasExistingActivities,
+    platform,
+  } = inputs
   const steps = getOnboardingSteps(isEnterprise)
+  // Existing recordings mean the user was fully onboarded in some prior
+  // session; localStorage may have been wiped (reinstall, profile reset).
+  // Skip the entire flow rather than walking them back through it.
+  if (hasExistingActivities) return steps.length - 1
   let implied = -1
   if (hasAnyProgress) implied = Math.max(implied, 0) // welcome
   if (
+    isPermissionsStepRelevant(platform) &&
     permissionStatus !== null &&
     permissionStatus.accessibility === 'granted' &&
     permissionStatus.screenRecording === 'granted'

--- a/src/renderer/pages/main-window/onboarding-state.ts
+++ b/src/renderer/pages/main-window/onboarding-state.ts
@@ -167,17 +167,29 @@ export function resolveOnboarding(inputs: OnboardingInputs): OnboardingResolutio
   // Resolve an optional back-navigation override. The override lets the user
   // navigate backward through already-visited steps without mutating real
   // state (granted permissions, saved keys can't be reasonably "undone").
-  // Once the user reaches the dashboard, ignore any override.
+  // Once the user reaches the dashboard, ignore any override. The override
+  // target must also exist in the displayed list — otherwise a stale value
+  // (e.g. 'permissions' carried over to a non-darwin platform) could resolve
+  // to a step the stepper UI doesn't render.
   const overrideIndex =
     inputs.viewStepOverride !== null ? steps.findIndex((s) => s.id === inputs.viewStepOverride) : -1
+  const overrideInDisplay =
+    inputs.viewStepOverride !== null && displaySteps.some((s) => s.id === inputs.viewStepOverride)
   const overrideValid =
-    computedStep !== 'dashboard' && overrideIndex !== -1 && overrideIndex < computedIndex
+    computedStep !== 'dashboard' &&
+    overrideIndex !== -1 &&
+    overrideIndex < computedIndex &&
+    overrideInDisplay
   const displayStep: DisplayStep = overrideValid
     ? (inputs.viewStepOverride as OnboardingStepId)
     : computedStep
   const displayIndex = overrideValid ? overrideIndex : computedIndex
 
-  const canGoBack = displayIndex > 0 && displayStep !== 'dashboard'
+  // canGoBack is anchored to the *displayed* list — canonical indices include
+  // steps that may be filtered out (e.g. Permissions on Windows), so using
+  // displayIndex here would lie about there being an earlier step to land on.
+  const displayedPosition = displaySteps.findIndex((s) => s.id === displayStep)
+  const canGoBack = displayStep !== 'dashboard' && displayedPosition > 0
   const canGoForward = canStepGoForward(displayStep, inputs)
 
   return {
@@ -238,4 +250,37 @@ export function impliedCompletedIndex(inputs: OnboardingInputs): number {
     if (idx !== -1) implied = Math.max(implied, idx)
   }
   return implied
+}
+
+/**
+ * Previous step in the *displayed* list, or `null` at the leading edge.
+ * Display-list anchored so platforms that hide steps (Permissions on Windows)
+ * don't accidentally land on them via back-navigation.
+ */
+export function previousDisplayStep(
+  displayStep: DisplayStep,
+  displaySteps: OnboardingStepInfo[],
+): OnboardingStepId | null {
+  const idx = displaySteps.findIndex((s) => s.id === displayStep)
+  if (idx <= 0) return null
+  return displaySteps[idx - 1].id
+}
+
+/**
+ * Next step the user can advance to via the override path (i.e. while viewing
+ * an earlier step than the computed leading edge). Returns `null` once the
+ * override would catch up with the computed edge — at that point the caller
+ * should perform the step's actual continue action instead.
+ */
+export function nextOverrideDisplayStep(
+  displayStep: DisplayStep,
+  displaySteps: OnboardingStepInfo[],
+  canonicalSteps: OnboardingStepInfo[],
+  computedIndex: number,
+): OnboardingStepId | null {
+  const idx = displaySteps.findIndex((s) => s.id === displayStep)
+  const next = idx === -1 ? undefined : displaySteps[idx + 1]
+  if (!next) return null
+  const nextCanonicalIdx = canonicalSteps.findIndex((s) => s.id === next.id)
+  return nextCanonicalIdx !== -1 && nextCanonicalIdx < computedIndex ? next.id : null
 }

--- a/src/renderer/pages/main-window/onboarding-storage.test.ts
+++ b/src/renderer/pages/main-window/onboarding-storage.test.ts
@@ -1,12 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   LAST_COMPLETED_STEP_INDEX_KEY,
-  LEGACY_CAPTURE_STEP_DONE_KEY,
-  LEGACY_CONNECT_STEP_DONE_KEY,
-  LEGACY_WELCOME_SEEN_KEY,
-  ONBOARDING_LAYOUT_VERSION,
-  ONBOARDING_LAYOUT_VERSION_KEY,
-  readOrMigrateLastCompletedIndex,
+  readLastCompletedIndex,
+  writeIntFlag,
   type OnboardingStorage,
 } from './onboarding-storage'
 
@@ -22,100 +18,19 @@ function makeStorage(seed: Record<string, string> = {}): OnboardingStorage & {
   }
 }
 
-describe('readOrMigrateLastCompletedIndex', () => {
-  let storage: ReturnType<typeof makeStorage>
-
-  beforeEach(() => {
-    storage = makeStorage()
+describe('readLastCompletedIndex', () => {
+  it('returns -1 for a fresh install with no key set', () => {
+    expect(readLastCompletedIndex(makeStorage())).toBe(-1)
   })
 
-  it('returns -1 for a fresh install with no keys', () => {
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(-1)
-    expect(storage.data.get(ONBOARDING_LAYOUT_VERSION_KEY)).toBe(String(ONBOARDING_LAYOUT_VERSION))
+  it('returns the stored integer when present', () => {
+    expect(readLastCompletedIndex(makeStorage({ [LAST_COMPLETED_STEP_INDEX_KEY]: '3' }))).toBe(3)
   })
 
-  it('migrates legacy "captureStepDone" → consumer capture index, then v1→v2 shift', () => {
-    storage = makeStorage({ [LEGACY_CAPTURE_STEP_DONE_KEY]: '1' })
-
-    // Legacy capture index is 4; v1→v2 shifts >=3 by +1, so 4 → 5.
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(5)
-    expect(storage.data.get(LAST_COMPLETED_STEP_INDEX_KEY)).toBe('5')
-    expect(storage.data.has(LEGACY_CAPTURE_STEP_DONE_KEY)).toBe(false)
-    expect(storage.data.get(ONBOARDING_LAYOUT_VERSION_KEY)).toBe(String(ONBOARDING_LAYOUT_VERSION))
-  })
-
-  it('migrates legacy "welcomeSeen" only → 0 (no v1→v2 shift, below threshold)', () => {
-    storage = makeStorage({ [LEGACY_WELCOME_SEEN_KEY]: '1' })
-
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(0)
-    expect(storage.data.has(LEGACY_WELCOME_SEEN_KEY)).toBe(false)
-  })
-
-  it('migrates legacy "connectStepDone" → 3 shifted to 4', () => {
-    storage = makeStorage({ [LEGACY_CONNECT_STEP_DONE_KEY]: '1' })
-
-    // Legacy connect=3; v1→v2 shifts >=3 by +1 → 4.
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(4)
-    expect(storage.data.has(LEGACY_CONNECT_STEP_DONE_KEY)).toBe(false)
-  })
-
-  it('takes the max when multiple legacy flags are present', () => {
-    storage = makeStorage({
-      [LEGACY_WELCOME_SEEN_KEY]: '1',
-      [LEGACY_CONNECT_STEP_DONE_KEY]: '1',
-      [LEGACY_CAPTURE_STEP_DONE_KEY]: '1',
-    })
-
-    // max(0, 3, 4) = 4, then v1→v2 shift → 5.
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(5)
-  })
-
-  it('applies v1→v2 shift to a stored v1 index of 4 (capture)', () => {
-    storage = makeStorage({ [LAST_COMPLETED_STEP_INDEX_KEY]: '4' })
-
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(5)
-    expect(storage.data.get(LAST_COMPLETED_STEP_INDEX_KEY)).toBe('5')
-    expect(storage.data.get(ONBOARDING_LAYOUT_VERSION_KEY)).toBe(String(ONBOARDING_LAYOUT_VERSION))
-  })
-
-  it('applies v1→v2 shift to a stored v1 index of 3 (connect)', () => {
-    storage = makeStorage({ [LAST_COMPLETED_STEP_INDEX_KEY]: '3' })
-
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(4)
-  })
-
-  it('does NOT shift v1 indexes below 3', () => {
-    storage = makeStorage({ [LAST_COMPLETED_STEP_INDEX_KEY]: '2' })
-
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(2)
-    expect(storage.data.get(LAST_COMPLETED_STEP_INDEX_KEY)).toBe('2')
-  })
-
-  it('leaves v2 indexes untouched on subsequent reads', () => {
-    storage = makeStorage({
-      [LAST_COMPLETED_STEP_INDEX_KEY]: '4',
-      [ONBOARDING_LAYOUT_VERSION_KEY]: '2',
-    })
-
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(4)
-    expect(storage.data.get(LAST_COMPLETED_STEP_INDEX_KEY)).toBe('4')
-  })
-
-  it('treats a non-numeric stored value as missing and falls back to legacy migration', () => {
-    storage = makeStorage({
-      [LAST_COMPLETED_STEP_INDEX_KEY]: 'not-a-number',
-      [LEGACY_WELCOME_SEEN_KEY]: '1',
-    })
-
-    // Non-numeric → readIntFlag falls back to -1, which triggers legacy migration.
-    expect(readOrMigrateLastCompletedIndex(storage)).toBe(0)
-  })
-
-  it('writes the layout-version key even when nothing else changes', () => {
-    storage = makeStorage({ [LAST_COMPLETED_STEP_INDEX_KEY]: '0' })
-
-    readOrMigrateLastCompletedIndex(storage)
-    expect(storage.data.get(ONBOARDING_LAYOUT_VERSION_KEY)).toBe(String(ONBOARDING_LAYOUT_VERSION))
+  it('falls back to -1 on a non-numeric stored value', () => {
+    expect(
+      readLastCompletedIndex(makeStorage({ [LAST_COMPLETED_STEP_INDEX_KEY]: 'not-a-number' })),
+    ).toBe(-1)
   })
 
   it('tolerates a storage that throws (e.g. disabled localStorage)', () => {
@@ -131,7 +46,26 @@ describe('readOrMigrateLastCompletedIndex', () => {
       },
     }
 
-    expect(() => readOrMigrateLastCompletedIndex(throwing)).not.toThrow()
-    expect(readOrMigrateLastCompletedIndex(throwing)).toBe(-1)
+    expect(() => readLastCompletedIndex(throwing)).not.toThrow()
+    expect(readLastCompletedIndex(throwing)).toBe(-1)
+  })
+})
+
+describe('writeIntFlag', () => {
+  it('writes the integer as a string', () => {
+    const storage = makeStorage()
+    writeIntFlag(storage, LAST_COMPLETED_STEP_INDEX_KEY, 5)
+    expect(storage.data.get(LAST_COMPLETED_STEP_INDEX_KEY)).toBe('5')
+  })
+
+  it('swallows errors from throwing storage', () => {
+    const throwing: OnboardingStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('disabled')
+      },
+      removeItem: () => {},
+    }
+    expect(() => writeIntFlag(throwing, LAST_COMPLETED_STEP_INDEX_KEY, 1)).not.toThrow()
   })
 })

--- a/src/renderer/pages/main-window/onboarding-storage.ts
+++ b/src/renderer/pages/main-window/onboarding-storage.ts
@@ -1,20 +1,12 @@
-// Storage + migration helpers for the renderer-driven onboarding flow.
+// Storage helpers for the renderer-driven onboarding flow.
 //
 // The current step is persisted as a single integer ("lastCompletedStepIndex").
-// When the step list shape changes, bump ONBOARDING_LAYOUT_VERSION and add a
-// shift in `migrateLayoutVersion` so already-onboarded users aren't bounced
-// back into the new step.
+// Returning users who already captured data are detected via DB activity count
+// (see `hasExistingActivities` in MainWindowApp), not via legacy localStorage
+// flags — that path is the load-bearing one for "skip onboarding for already-
+// onboarded users."
 
 export const LAST_COMPLETED_STEP_INDEX_KEY = 'memorylane:onboarding:lastCompletedStepIndex'
-export const ONBOARDING_LAYOUT_VERSION_KEY = 'memorylane:onboarding:layoutVersion'
-export const ONBOARDING_LAYOUT_VERSION = 2
-
-// Legacy keys, read once on startup to migrate users who already completed
-// onboarding under the old three-flag model. Removed after migration so the
-// new index becomes the sole source of truth.
-export const LEGACY_WELCOME_SEEN_KEY = 'memorylane:onboarding:welcomeSeen'
-export const LEGACY_CONNECT_STEP_DONE_KEY = 'memorylane:onboarding:connectStepDone'
-export const LEGACY_CAPTURE_STEP_DONE_KEY = 'memorylane:onboarding:captureStepDone'
 
 export interface OnboardingStorage {
   getItem(key: string): string | null
@@ -49,59 +41,6 @@ export function writeIntFlag(storage: OnboardingStorage, key: string, value: num
   safe(() => storage.setItem(key, String(value)), undefined)
 }
 
-function readLegacyBool(storage: OnboardingStorage, key: string): boolean {
-  return safe(() => storage.getItem(key) === '1', false)
-}
-
-function removeKey(storage: OnboardingStorage, key: string): void {
-  safe(() => storage.removeItem(key), undefined)
-}
-
-/**
- * Read the persisted last-completed step index, migrating from the old
- * three-flag scheme (welcomeSeen / connectStepDone / captureStepDone) if any
- * of those keys are present. Indexes refer to the consumer step list — the
- * highest possible legacy completion is `capture`, so the migrated value is
- * the consumer "capture" index. On enterprise (5 steps vs. 6) the migrated
- * value can overshoot the step array; that's intentional — `findIndex` returns
- * -1 in that case and `computedStep` resolves to `dashboard`, so the legacy
- * enterprise user lands directly on the dashboard instead of being re-walked
- * through the new Privacy step.
- */
-export function readOrMigrateLastCompletedIndex(storage: OnboardingStorage): number {
-  const stored = readIntFlag(storage, LAST_COMPLETED_STEP_INDEX_KEY, -1)
-  const layoutVersion = readIntFlag(storage, ONBOARDING_LAYOUT_VERSION_KEY, 1)
-
-  let current = stored
-  if (current < 0) {
-    const hadWelcome = readLegacyBool(storage, LEGACY_WELCOME_SEEN_KEY)
-    const hadConnect = readLegacyBool(storage, LEGACY_CONNECT_STEP_DONE_KEY)
-    const hadCapture = readLegacyBool(storage, LEGACY_CAPTURE_STEP_DONE_KEY)
-
-    if (hadWelcome || hadConnect || hadCapture) {
-      // Legacy consumer indices (pre-blacklist):
-      //   welcome=0, permissions=1, plan=2, connect=3, capture=4.
-      let migrated = -1
-      if (hadWelcome) migrated = Math.max(migrated, 0)
-      if (hadConnect) migrated = Math.max(migrated, 3)
-      if (hadCapture) migrated = Math.max(migrated, 4)
-      current = migrated
-      removeKey(storage, LEGACY_WELCOME_SEEN_KEY)
-      removeKey(storage, LEGACY_CONNECT_STEP_DONE_KEY)
-      removeKey(storage, LEGACY_CAPTURE_STEP_DONE_KEY)
-    }
-  }
-
-  // v1 → v2: blacklist step was inserted just before capture. Anything that
-  // used to land on capture (consumer 4, enterprise 3) shifts by one so we
-  // don't drop already-onboarded users back into the new step.
-  if (layoutVersion < 2 && current >= 0) {
-    if (current >= 3) current += 1
-  }
-
-  if (current !== stored) writeIntFlag(storage, LAST_COMPLETED_STEP_INDEX_KEY, current)
-  if (layoutVersion !== ONBOARDING_LAYOUT_VERSION) {
-    writeIntFlag(storage, ONBOARDING_LAYOUT_VERSION_KEY, ONBOARDING_LAYOUT_VERSION)
-  }
-  return current
+export function readLastCompletedIndex(storage: OnboardingStorage): number {
+  return readIntFlag(storage, LAST_COMPLETED_STEP_INDEX_KEY, -1)
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -330,4 +330,6 @@ export interface MainWindowAPI {
   onPermissionStatusChanged: (callback: (status: PermissionStatus) => void) => () => void
   // App lifecycle
   restartApp: () => Promise<void>
+  // Host platform (set at preload time; never changes mid-session)
+  platform: NodeJS.Platform
 }


### PR DESCRIPTION
## Summary

Two regressions in the renderer-driven onboarding flow from #141:

- **Windows showed the Permissions step** even though `getPermissionStatus()` hard-codes both fields to `granted` on non-darwin. The step is now filtered out of the stepper (consumer: 6 → 5 steps; enterprise: 5 → 4 steps) and auto-completes in the resolution logic. `hasAnyProgress` no longer counts trivially-granted Windows permissions as progress, so Welcome isn't skipped for brand-new Windows users.
- **Returning users with activities in the DB but missing/partial onboarding localStorage** (reinstall, profile reset, etc.) got walked back through onboarding and stopped at the new Blacklist step. `impliedCompletedIndex` now short-circuits to the last step when `hasExistingActivities` is true, so the self-heal effect resolves the flow to dashboard.
- **Legacy onboarding migration dropped.** With DB-activity covering "already onboarded," the three-flag (`welcomeSeen` / `connectStepDone` / `captureStepDone`) migration and the v1→v2 layout shift in `onboarding-storage.ts` are no longer load-bearing. `onboarding-storage.ts` is now a simple read/write of `lastCompletedStepIndex`.

Also adds `api.platform` exposed via preload so the renderer doesn't have to sniff `navigator.platform`.

## Test plan

- [x] `npm test` — 659 pass, 33 skipped (50 onboarding tests, incl. explicit Windows step-count coverage for consumer + enterprise + linux)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Fresh Windows install: stepper shows 5 dots (no Permissions), Welcome → Plan → … → Capture
- [ ] macOS fresh install: full 6-step consumer / 5-step enterprise flow unchanged
- [ ] Wipe `memorylane:onboarding:*` localStorage with an activity-bearing DB → app jumps straight to dashboard
- [ ] macOS user mid-onboarding still resumes where they left off

🤖 Generated with [Claude Code](https://claude.com/claude-code)