### PR TITLE
Add Import Database button (backport on v0.26.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ packages/cli/node_modules/
 
 # deepsec
 .deepsec/
+
+# Data directory
+/data

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "tw-animate-css": "^1.4.0",
         "uiohook-napi": "^1.5.4",
         "uuid": "^13.0.0",
+        "yauzl": "^2.10.0",
         "yazl": "^3.3.1"
       },
       "devDependencies": {
@@ -51,6 +52,7 @@
         "@types/react": "^19.2.13",
         "@types/react-dom": "^19.2.3",
         "@types/uuid": "^10.0.0",
+        "@types/yauzl": "^2.10.3",
         "@types/yazl": "^3.3.0",
         "@typescript-eslint/eslint-plugin": "^8.54.0",
         "@typescript-eslint/parser": "^8.54.0",
@@ -5927,7 +5929,6 @@
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -7450,7 +7451,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -10219,7 +10219,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -14150,7 +14149,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -18728,7 +18726,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
     "@types/uuid": "^10.0.0",
+    "@types/yauzl": "^2.10.3",
     "@types/yazl": "^3.3.0",
     "@typescript-eslint/eslint-plugin": "^8.54.0",
     "@typescript-eslint/parser": "^8.54.0",
@@ -118,6 +119,7 @@
     "tw-animate-css": "^1.4.0",
     "uiohook-napi": "^1.5.4",
     "uuid": "^13.0.0",
+    "yauzl": "^2.10.0",
     "yazl": "^3.3.1"
   },
   "lint-staged": {

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -8,6 +8,7 @@ import { createAccessProvider, type AccessProvider } from './access'
 import type { AppEdition } from '../shared/edition'
 import { StorageService } from './storage'
 import { applyMigrations } from './storage/migrator'
+import { applyPendingDatabaseImport } from './ui/database-import'
 import { EmbeddingService } from './processor/embedding'
 import { activityOcrService } from './processor/ocr'
 import { UsageTracker } from './services/usage-tracker'
@@ -73,6 +74,7 @@ export async function createMainRuntime(params: {
   const userDataPath = app.getPath('userData')
   const dbFile = dev ? 'memorylane-dev.db' : 'memorylane.db'
   const dbPath = path.join(userDataPath, dbFile)
+  applyPendingDatabaseImport(dbPath)
   const storage = new StorageService(dbPath)
   applyMigrations(storage.getDatabase())
   const usageTracker = new UsageTracker()

--- a/src/main/ui/database-import.ts
+++ b/src/main/ui/database-import.ts
@@ -1,14 +1,15 @@
-import { app, dialog, type BrowserWindow } from 'electron'
+import { dialog, type BrowserWindow } from 'electron'
 import Database from 'better-sqlite3'
 import fs from 'node:fs'
 import * as fsPromises from 'node:fs/promises'
-import os from 'node:os'
 import path from 'node:path'
 import * as yauzl from 'yauzl'
 import log from '../logger'
 import type { DatabaseImportResult } from '../../shared/types'
 
 interface ImportDatabaseOptions {
+  /** Active database path, resolved by the caller (the open StorageService). */
+  dbPath: string
   parentWindow?: BrowserWindow | null
 }
 
@@ -22,25 +23,16 @@ function buildTimestamp(now = new Date()): string {
   )}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`
 }
 
-/**
- * Resolves the active database path the same way `runtime.ts` does, so an
- * import staged here lands next to the database the app actually opens.
- */
-function getActiveDbPath(): string {
-  const dev = !app.isPackaged
-  const dbFile = dev ? 'memorylane-dev.db' : 'memorylane.db'
-  return path.join(app.getPath('userData'), dbFile)
-}
-
 function pendingImportPath(dbPath: string): string {
   return `${dbPath}.pending-import`
 }
 
 /**
- * Extracts the first regular file from a ZIP archive to `destPath`. The
- * export writes a single `.db` entry, so we take the first file we encounter.
+ * Extracts the database from a ZIP archive to `destPath` — the first `*.db`
+ * entry, ignoring directories and macOS `__MACOSX`/AppleDouble (`._*`) cruft so
+ * a re-zipped export still imports. Rejects if the archive has no `.db` entry.
  */
-function extractSingleFileFromZip(zipPath: string, destPath: string): Promise<void> {
+function extractDatabaseFromZip(zipPath: string, destPath: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     yauzl.open(zipPath, { lazyEntries: true }, (err, zipfile) => {
       if (err || !zipfile) {
@@ -51,12 +43,14 @@ function extractSingleFileFromZip(zipPath: string, destPath: string): Promise<vo
       let extracted = false
       zipfile.on('error', reject)
       zipfile.on('end', () => {
-        if (!extracted) reject(new Error('ZIP archive contained no files'))
+        if (!extracted) reject(new Error('No database (.db) file found in the ZIP archive.'))
       })
 
       zipfile.on('entry', (entry) => {
-        // Skip directory entries (their names end with '/').
-        if (/\/$/.test(entry.fileName)) {
+        const name = entry.fileName
+        const isDir = name.endsWith('/')
+        const isMacCruft = name.startsWith('__MACOSX/') || path.basename(name).startsWith('._')
+        if (isDir || isMacCruft || !name.toLowerCase().endsWith('.db')) {
           zipfile.readEntry()
           return
         }
@@ -90,6 +84,7 @@ function extractSingleFileFromZip(zipPath: string, destPath: string): Promise<vo
  * user-facing message when the file is missing tables or is not a SQLite DB.
  */
 function validateDatabaseFile(dbFilePath: string): void {
+  const names = new Set<string>()
   let db: Database.Database | null = null
   try {
     db = new Database(dbFilePath, { readonly: true, fileMustExist: true })
@@ -98,17 +93,15 @@ function validateDatabaseFile(dbFilePath: string): void {
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('activities', 'schema_migrations')",
       )
       .all() as Array<{ name: string }>
-    const names = new Set(rows.map((r) => r.name))
-    if (!names.has('activities') || !names.has('schema_migrations')) {
-      throw new Error('Selected file is not a MemoryLane database (missing required tables).')
-    }
-  } catch (error) {
-    if (error instanceof Error && error.message.startsWith('Selected file is not')) {
-      throw error
-    }
+    for (const r of rows) names.add(r.name)
+  } catch {
     throw new Error('Selected file could not be read as a SQLite database.')
   } finally {
     db?.close()
+  }
+
+  if (!names.has('activities') || !names.has('schema_migrations')) {
+    throw new Error('Selected file is not a MemoryLane database (missing required tables).')
   }
 }
 
@@ -119,20 +112,21 @@ function validateDatabaseFile(dbFilePath: string): void {
  * the live database is never touched here while it is open.
  */
 export async function importDatabase({
+  dbPath,
   parentWindow = null,
 }: ImportDatabaseOptions): Promise<DatabaseImportResult> {
-  let tempDir: string | null = null
+  const pendingPath = pendingImportPath(dbPath)
+  // Stage onto the same filesystem as the live DB so the final move is an atomic
+  // rename, and write the staged file once. The `.partial` is promoted to the
+  // pending path only after validation, so startup never sees an unvalidated file.
+  const stagingPath = `${pendingPath}.partial`
 
   try {
     const openResult = await dialog.showOpenDialog(parentWindow ?? undefined, {
       title: 'Import Database',
       buttonLabel: 'Import',
       properties: ['openFile'],
-      filters: [
-        { name: 'MemoryLane Database', extensions: ['zip', 'db'] },
-        { name: 'ZIP Archives', extensions: ['zip'] },
-        { name: 'SQLite Database', extensions: ['db'] },
-      ],
+      filters: [{ name: 'MemoryLane Database', extensions: ['zip', 'db'] }],
     })
 
     if (openResult.canceled || openResult.filePaths.length === 0) {
@@ -155,19 +149,14 @@ export async function importDatabase({
       return { success: false, cancelled: true }
     }
 
-    tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'memorylane-db-import-'))
-    const extractedDbPath = path.join(tempDir, 'import.db')
-
     if (selectedPath.toLowerCase().endsWith('.zip')) {
-      await extractSingleFileFromZip(selectedPath, extractedDbPath)
+      await extractDatabaseFromZip(selectedPath, stagingPath)
     } else {
-      await fsPromises.copyFile(selectedPath, extractedDbPath)
+      await fsPromises.copyFile(selectedPath, stagingPath)
     }
 
-    validateDatabaseFile(extractedDbPath)
-
-    const pendingPath = pendingImportPath(getActiveDbPath())
-    await fsPromises.copyFile(extractedDbPath, pendingPath)
+    validateDatabaseFile(stagingPath)
+    await fsPromises.rename(stagingPath, pendingPath)
 
     return { success: true }
   } catch (error) {
@@ -175,13 +164,12 @@ export async function importDatabase({
     const message = error instanceof Error ? error.message : 'Unknown error'
     return { success: false, error: message }
   } finally {
-    if (tempDir) {
-      try {
-        await fsPromises.rm(tempDir, { recursive: true, force: true })
-      } catch (cleanupError) {
-        log.warn('[DatabaseImport] Failed to clean temp import directory:', cleanupError)
-      }
-    }
+    // Drop a leftover partial; the promoted pending file (post-rename) is kept.
+    await fsPromises
+      .rm(stagingPath, { force: true })
+      .catch((cleanupError) =>
+        log.warn('[DatabaseImport] Failed to clean staging file:', cleanupError),
+      )
   }
 }
 

--- a/src/main/ui/database-import.ts
+++ b/src/main/ui/database-import.ts
@@ -1,0 +1,229 @@
+import { app, dialog, type BrowserWindow } from 'electron'
+import Database from 'better-sqlite3'
+import fs from 'node:fs'
+import * as fsPromises from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import * as yauzl from 'yauzl'
+import log from '../logger'
+import type { DatabaseImportResult } from '../../shared/types'
+
+interface ImportDatabaseOptions {
+  parentWindow?: BrowserWindow | null
+}
+
+function pad2(v: number): string {
+  return String(v).padStart(2, '0')
+}
+
+function buildTimestamp(now = new Date()): string {
+  return `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(now.getDate())}-${pad2(
+    now.getHours(),
+  )}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`
+}
+
+/**
+ * Resolves the active database path the same way `runtime.ts` does, so an
+ * import staged here lands next to the database the app actually opens.
+ */
+function getActiveDbPath(): string {
+  const dev = !app.isPackaged
+  const dbFile = dev ? 'memorylane-dev.db' : 'memorylane.db'
+  return path.join(app.getPath('userData'), dbFile)
+}
+
+function pendingImportPath(dbPath: string): string {
+  return `${dbPath}.pending-import`
+}
+
+/**
+ * Extracts the first regular file from a ZIP archive to `destPath`. The
+ * export writes a single `.db` entry, so we take the first file we encounter.
+ */
+function extractSingleFileFromZip(zipPath: string, destPath: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    yauzl.open(zipPath, { lazyEntries: true }, (err, zipfile) => {
+      if (err || !zipfile) {
+        reject(err instanceof Error ? err : new Error('Failed to open ZIP archive'))
+        return
+      }
+
+      let extracted = false
+      zipfile.on('error', reject)
+      zipfile.on('end', () => {
+        if (!extracted) reject(new Error('ZIP archive contained no files'))
+      })
+
+      zipfile.on('entry', (entry) => {
+        // Skip directory entries (their names end with '/').
+        if (/\/$/.test(entry.fileName)) {
+          zipfile.readEntry()
+          return
+        }
+
+        zipfile.openReadStream(entry, (streamErr, readStream) => {
+          if (streamErr || !readStream) {
+            reject(streamErr instanceof Error ? streamErr : new Error('Failed to read ZIP entry'))
+            return
+          }
+          const output = fs.createWriteStream(destPath)
+          readStream.once('error', reject)
+          output.once('error', reject)
+          output.once('close', () => {
+            extracted = true
+            zipfile.close()
+            resolve()
+          })
+          readStream.pipe(output)
+        })
+      })
+
+      zipfile.readEntry()
+    })
+  })
+}
+
+/**
+ * Confirms the file is a usable MemoryLane database by opening it read-only and
+ * checking for the core tables. Migrations run on next startup, so an older
+ * schema is fine — we only require the essentials to be present. Throws with a
+ * user-facing message when the file is missing tables or is not a SQLite DB.
+ */
+function validateDatabaseFile(dbFilePath: string): void {
+  let db: Database.Database | null = null
+  try {
+    db = new Database(dbFilePath, { readonly: true, fileMustExist: true })
+    const rows = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('activities', 'schema_migrations')",
+      )
+      .all() as Array<{ name: string }>
+    const names = new Set(rows.map((r) => r.name))
+    if (!names.has('activities') || !names.has('schema_migrations')) {
+      throw new Error('Selected file is not a MemoryLane database (missing required tables).')
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Selected file is not')) {
+      throw error
+    }
+    throw new Error('Selected file could not be read as a SQLite database.')
+  } finally {
+    db?.close()
+  }
+}
+
+/**
+ * Lets the user pick an exported database (`.zip` or raw `.db`), confirms the
+ * destructive replace, validates it, and stages it next to the active DB. The
+ * actual swap happens on next startup via {@link applyPendingDatabaseImport};
+ * the live database is never touched here while it is open.
+ */
+export async function importDatabase({
+  parentWindow = null,
+}: ImportDatabaseOptions): Promise<DatabaseImportResult> {
+  let tempDir: string | null = null
+
+  try {
+    const openResult = await dialog.showOpenDialog(parentWindow ?? undefined, {
+      title: 'Import Database',
+      buttonLabel: 'Import',
+      properties: ['openFile'],
+      filters: [
+        { name: 'MemoryLane Database', extensions: ['zip', 'db'] },
+        { name: 'ZIP Archives', extensions: ['zip'] },
+        { name: 'SQLite Database', extensions: ['db'] },
+      ],
+    })
+
+    if (openResult.canceled || openResult.filePaths.length === 0) {
+      return { success: false, cancelled: true }
+    }
+    const selectedPath = openResult.filePaths[0]
+
+    const confirm = await dialog.showMessageBox(parentWindow ?? undefined, {
+      type: 'warning',
+      buttons: ['Cancel', 'Import and Replace'],
+      defaultId: 0,
+      cancelId: 0,
+      title: 'Replace Database',
+      message: 'Replace the current database with the imported one?',
+      detail:
+        'All current activities and data will be replaced by the imported database. ' +
+        'A backup of your current database is saved automatically, and the app will restart to finish importing.',
+    })
+    if (confirm.response !== 1) {
+      return { success: false, cancelled: true }
+    }
+
+    tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'memorylane-db-import-'))
+    const extractedDbPath = path.join(tempDir, 'import.db')
+
+    if (selectedPath.toLowerCase().endsWith('.zip')) {
+      await extractSingleFileFromZip(selectedPath, extractedDbPath)
+    } else {
+      await fsPromises.copyFile(selectedPath, extractedDbPath)
+    }
+
+    validateDatabaseFile(extractedDbPath)
+
+    const pendingPath = pendingImportPath(getActiveDbPath())
+    await fsPromises.copyFile(extractedDbPath, pendingPath)
+
+    return { success: true }
+  } catch (error) {
+    log.error('[DatabaseImport] Error importing database:', error)
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return { success: false, error: message }
+  } finally {
+    if (tempDir) {
+      try {
+        await fsPromises.rm(tempDir, { recursive: true, force: true })
+      } catch (cleanupError) {
+        log.warn('[DatabaseImport] Failed to clean temp import directory:', cleanupError)
+      }
+    }
+  }
+}
+
+/**
+ * Applies a staged database import, if one exists. Called once during startup
+ * BEFORE the database connection is opened. Backs up the current database, then
+ * replaces it (and its WAL/SHM sidecars) with the staged file. On any failure
+ * the existing database is left untouched so the app still boots.
+ */
+export function applyPendingDatabaseImport(dbPath: string): void {
+  const pendingPath = pendingImportPath(dbPath)
+  if (!fs.existsSync(pendingPath)) {
+    return
+  }
+
+  log.info('[DatabaseImport] Pending database import detected, applying...')
+  try {
+    if (fs.existsSync(dbPath)) {
+      const backupPath = path.join(path.dirname(dbPath), `memorylane-backup-${buildTimestamp()}.db`)
+      fs.copyFileSync(dbPath, backupPath)
+      log.info(`[DatabaseImport] Backed up current database to ${backupPath}`)
+    }
+
+    // Drop the live DB and its journal sidecars so no stale WAL is reattached.
+    for (const suffix of ['', '-wal', '-shm']) {
+      const target = `${dbPath}${suffix}`
+      if (fs.existsSync(target)) {
+        fs.rmSync(target, { force: true })
+      }
+    }
+
+    fs.renameSync(pendingPath, dbPath)
+    log.info('[DatabaseImport] Database import applied successfully')
+  } catch (error) {
+    log.error('[DatabaseImport] Failed to apply pending database import:', error)
+    // Leave the existing DB intact and drop the partial staging file so the app boots.
+    try {
+      if (fs.existsSync(pendingPath)) {
+        fs.rmSync(pendingPath, { force: true })
+      }
+    } catch (cleanupError) {
+      log.warn('[DatabaseImport] Failed to remove pending import file:', cleanupError)
+    }
+  }
+}

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -20,6 +20,7 @@ import { DEFAULT_EDITION, type AppEditionConfig } from '../../shared/edition'
 import log from '../logger'
 import { updateTrayMenu } from './tray'
 import { exportDatabaseZip } from './database-export'
+import { importDatabase } from './database-import'
 import { integrations } from '../integrations'
 import { listInstalledApps } from '../apps/installed-apps'
 import type { VendorCredentialsManager } from '../settings/vendor-credentials-manager'
@@ -672,6 +673,19 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: false, error: 'Dependencies not initialized' }
     }
     return exportDatabaseZip({ storage: deps.storage, parentWindow: getMainWindow() })
+  })
+
+  ipcMain.handle('main-window:importDatabase', async () => {
+    if (!deps) {
+      return { success: false, error: 'Dependencies not initialized' }
+    }
+    return importDatabase({ parentWindow: getMainWindow() })
+  })
+
+  ipcMain.handle('main-window:restartApp', () => {
+    log.info('[App] Restart requested from renderer')
+    app.relaunch()
+    app.quit()
   })
 
   ipcMain.handle('main-window:syncDatabaseToRemote', async () => {

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -679,7 +679,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     if (!deps) {
       return { success: false, error: 'Dependencies not initialized' }
     }
-    return importDatabase({ parentWindow: getMainWindow() })
+    return importDatabase({ dbPath: deps.storage.getDbPath(), parentWindow: getMainWindow() })
   })
 
   ipcMain.handle('main-window:restartApp', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -75,6 +75,8 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
     ipcRenderer.invoke('main-window:setDatabaseExportDirectory', directoryPath),
   // Database export
   exportDatabaseZip: () => ipcRenderer.invoke('main-window:exportDatabaseZip'),
+  importDatabase: () => ipcRenderer.invoke('main-window:importDatabase'),
+  restartApp: () => ipcRenderer.invoke('main-window:restartApp'),
   syncDatabaseToRemote: () => ipcRenderer.invoke('main-window:syncDatabaseToRemote'),
   // Shell
   openExternal: (url: string) => ipcRenderer.invoke('main-window:openExternal', url),

--- a/src/renderer/pages/main-window/components/DatabaseImportSection.tsx
+++ b/src/renderer/pages/main-window/components/DatabaseImportSection.tsx
@@ -15,19 +15,19 @@ export function DatabaseImportSection({ api }: DatabaseImportSectionProps): Reac
     setIsImportingDb(true)
     try {
       const result = await api.importDatabase()
-      if (result.cancelled) return
       if (!result.success) {
-        toast.error(result.error ?? 'Database import failed')
+        if (!result.cancelled) toast.error(result.error ?? 'Database import failed')
+        setIsImportingDb(false)
         return
       }
-      // The imported DB is staged; it replaces the live one on restart.
+      // The imported DB is staged; it replaces the live one on restart. Keep the
+      // button disabled through the restart so a second import can't race it.
       toast.success('Database imported — restarting…')
       await new Promise((resolve) => setTimeout(resolve, 800))
       await api.restartApp()
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Database import failed'
       toast.error(message)
-    } finally {
       setIsImportingDb(false)
     }
   }, [api])

--- a/src/renderer/pages/main-window/components/DatabaseImportSection.tsx
+++ b/src/renderer/pages/main-window/components/DatabaseImportSection.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@components/ui/button'
+import type { MainWindowAPI } from '@types'
+
+interface DatabaseImportSectionProps {
+  api: MainWindowAPI
+}
+
+export function DatabaseImportSection({ api }: DatabaseImportSectionProps): React.JSX.Element {
+  const [isImportingDb, setIsImportingDb] = useState(false)
+
+  const handleImportDatabase = useCallback(async () => {
+    setIsImportingDb(true)
+    try {
+      const result = await api.importDatabase()
+      if (result.cancelled) return
+      if (!result.success) {
+        toast.error(result.error ?? 'Database import failed')
+        return
+      }
+      // The imported DB is staged; it replaces the live one on restart.
+      toast.success('Database imported — restarting…')
+      await new Promise((resolve) => setTimeout(resolve, 800))
+      await api.restartApp()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Database import failed'
+      toast.error(message)
+    } finally {
+      setIsImportingDb(false)
+    }
+  }, [api])
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => void handleImportDatabase()}
+      disabled={isImportingDb}
+    >
+      {isImportingDb ? 'Importing...' : 'Import Database'}
+    </Button>
+  )
+}

--- a/src/renderer/pages/main-window/components/advanced-settings/ConnectionsDataSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/ConnectionsDataSection.tsx
@@ -7,6 +7,7 @@ import type { AppEditionConfig } from '@/shared/edition'
 import type { MainWindowAPI } from '@types'
 import { IntegrationsSection } from '../IntegrationsSection'
 import { DatabaseExportSection } from '../DatabaseExportSection'
+import { DatabaseImportSection } from '../DatabaseImportSection'
 import { DatabaseSyncSection } from '../DatabaseSyncSection'
 import { SectionToggle } from './SectionToggle'
 import { SubSectionToggle } from './SubSectionToggle'
@@ -67,9 +68,10 @@ export function ConnectionsDataSection({
           <IntegrationsSection api={api} />
 
           <div className="space-y-2">
-            <Label className="text-xs text-muted-foreground">Manual Export</Label>
+            <Label className="text-xs text-muted-foreground">Manual Export &amp; Import</Label>
             <div className="flex gap-2">
               <DatabaseExportSection api={api} />
+              <DatabaseImportSection api={api} />
             </div>
           </div>
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -141,6 +141,12 @@ export interface DatabaseExportResult {
   error?: string | undefined
 }
 
+export interface DatabaseImportResult {
+  success: boolean
+  cancelled?: boolean | undefined
+  error?: string | undefined
+}
+
 export interface DirectorySelectionResult {
   cancelled: boolean
   directoryPath?: string | undefined
@@ -304,6 +310,8 @@ export interface MainWindowAPI {
   setDatabaseExportDirectory: (directoryPath: string) => Promise<SaveResult>
   // Database export
   exportDatabaseZip: () => Promise<DatabaseExportResult>
+  importDatabase: () => Promise<DatabaseImportResult>
+  restartApp: () => Promise<void>
   syncDatabaseToRemote: () => Promise<{ success: boolean; error?: string }>
   // Updater
   getUpdateState: () => Promise<UpdateState>


### PR DESCRIPTION
## Summary

Adds an **Import Database** button next to the existing **Export Database (.zip)** action on the Connections & Data settings page. Importing replaces the active SQLite database with a previously exported one (`.zip` or raw `.db`).

Primary use case: migrating a **Customer**-edition database into an **Enterprise** install — schema, embedding model, and vector dimensions are identical across editions, so the data is fully compatible. (Screenshot/video files are not part of an export, so imported activities keep summaries/OCR/search/patterns but not their original images.)

Branched from the `v0.26.1` tag and targeted at `release/v0.26.1` (this is a backport onto the latest stable release, not `main`).

## How it works

The DB connection and the whole runtime graph are opened once at startup and held for the app's lifetime, so import uses a **stage-then-restart** approach:

1. Pick a file → native warning dialog (Cancel / Import and Replace).
2. Extract (`.zip` via `yauzl`) or copy (`.db`), then validate it's a real MemoryLane DB (checks for `activities` + `schema_migrations` tables).
3. Stage it next to the active DB, then relaunch.
4. On next boot, `applyPendingDatabaseImport` backs up the current DB to `memorylane-backup-<ts>.db`, drops the live DB plus its WAL/SHM sidecars, and moves the staged file into place **before** the connection opens. Migrations then run as usual, upgrading older-schema imports.

On any failure the existing database is left untouched so the app still boots.

## Changes

- **new** `src/main/ui/database-import.ts` — `importDatabase` + `applyPendingDatabaseImport`
- `src/main/runtime.ts` — apply a pending import before opening storage
- `src/main/ui/main-window.ts` — `main-window:importDatabase` + new `main-window:restartApp` IPC handlers
- `src/preload/index.ts` + `src/shared/types.ts` — expose `importDatabase` / `restartApp` (`DatabaseImportResult`)
- **new** `DatabaseImportSection.tsx`, rendered in `ConnectionsDataSection.tsx` under "Manual Export & Import"
- `package.json` — `yauzl` promoted to a production dependency

## Testing

- `npm run lint` (0 errors) and `npm run build` pass.
- Manual end-to-end verification not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)