### PR TITLE
feat(sync): include user_context in backend uploads

### DIFF
--- a/src/main/services/strip-database-for-upload.test.ts
+++ b/src/main/services/strip-database-for-upload.test.ts
@@ -60,18 +60,22 @@ describe('stripDatabaseForUpload', () => {
     expect(tables).toHaveLength(1)
   })
 
-  it('drops user_context and pattern_detection_runs tables', async () => {
+  it('drops pattern_detection_runs but preserves user_context', async () => {
     await setupAndBackup()
     stripDatabaseForUpload(COPY_DB_PATH, { detailLevel: 'summary' })
 
     const db = new Database(COPY_DB_PATH)
-    const tables = db
+    const runs = db
       .prepare(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('user_context', 'pattern_detection_runs')",
+        "SELECT name FROM sqlite_master WHERE type='table' AND name = 'pattern_detection_runs'",
       )
       .all()
+    const userContext = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = 'user_context'")
+      .all()
     db.close()
-    expect(tables).toHaveLength(0)
+    expect(runs).toHaveLength(0)
+    expect(userContext).toHaveLength(1)
   })
 
   it('drops FTS triggers', async () => {
@@ -151,7 +155,7 @@ describe('stripDatabaseForUpload', () => {
   })
 
   describe('detailed mode', () => {
-    it('drops user_context but preserves ocr_text', async () => {
+    it('preserves user_context and ocr_text', async () => {
       await setupAndBackup()
       stripDatabaseForUpload(COPY_DB_PATH, { detailLevel: 'detailed' })
 
@@ -160,7 +164,7 @@ describe('stripDatabaseForUpload', () => {
       const userContext = db
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = 'user_context'")
         .all()
-      expect(userContext).toHaveLength(0)
+      expect(userContext).toHaveLength(1)
 
       const columns = db.prepare('PRAGMA table_info(activities)').all() as { name: string }[]
       const columnNames = columns.map((c) => c.name)

--- a/src/main/services/strip-database-for-upload.ts
+++ b/src/main/services/strip-database-for-upload.ts
@@ -4,7 +4,7 @@ export interface StripOptions {
   detailLevel: 'summary' | 'detailed'
 }
 
-const ALWAYS_DROP_TABLES = ['user_context', 'pattern_detection_runs']
+const ALWAYS_DROP_TABLES = ['pattern_detection_runs']
 
 const SUMMARY_TRIGGERS_TO_DROP = ['activities_ai', 'activities_ad', 'activities_au']
 const SUMMARY_TABLES_TO_DROP = ['activities_fts']

--- a/src/renderer/pages/main-window/components/advanced-settings/DataTabPanel.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/DataTabPanel.tsx
@@ -142,7 +142,7 @@ export function DataTabPanel({
         <SettingsSection
           title="Share with remote"
           icon={<Share2 className="h-4 w-4" />}
-          description="Off disables sharing. Summary strips OCR text and full-text search index. Both Summary and Detailed strip personal context; pattern detection runs locally either way."
+          description="Off disables sharing. Summary strips OCR text and full-text search index."
         >
           <SettingsRow
             layout="stacked"


### PR DESCRIPTION
## Summary
- Stop stripping `user_context` from the database backup before upload, so it now syncs to the backend in both `summary` and `detailed` modes.
- `pattern_detection_runs` remains the only table dropped in `ALWAYS_DROP_TABLES`.

## Changes
- `strip-database-for-upload.ts`: removed `user_context` from `ALWAYS_DROP_TABLES`.
- `strip-database-for-upload.test.ts`: updated tests to assert `user_context` is preserved (summary + detailed modes) while `pattern_detection_runs` is still dropped.

## Test plan
- `npm test -- strip-database-for-upload` — all 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)