### PR TITLE
fix(settings): allow http baseURL for private/LAN addresses

### DIFF
--- a/src/main/settings/vendor-credentials-manager.test.ts
+++ b/src/main/settings/vendor-credentials-manager.test.ts
@@ -270,9 +270,19 @@ describe('VendorCredentialsManager', () => {
       expect(validateVendorBaseURL('https://example.com/path')).toBe('https://example.com/path')
     })
 
-    it('accepts http URLs only for loopback hosts', () => {
+    it('accepts http URLs for loopback hosts', () => {
       expect(validateVendorBaseURL('http://localhost:11434/v1')).toBe('http://localhost:11434/v1')
       expect(validateVendorBaseURL('http://127.0.0.1:11434/v1')).toBe('http://127.0.0.1:11434/v1')
+    })
+
+    it('accepts http URLs for private / link-local network hosts (LAN Ollama)', () => {
+      expect(validateVendorBaseURL('http://10.0.0.92:11434/v1')).toBe('http://10.0.0.92:11434/v1')
+      expect(validateVendorBaseURL('http://192.168.1.50:11434/v1')).toBe(
+        'http://192.168.1.50:11434/v1',
+      )
+      expect(validateVendorBaseURL('http://172.16.0.1/')).toBe('http://172.16.0.1/')
+      expect(validateVendorBaseURL('http://172.31.255.255/')).toBe('http://172.31.255.255/')
+      expect(validateVendorBaseURL('http://169.254.1.1/')).toBe('http://169.254.1.1/')
     })
 
     it('returns empty string for empty / whitespace / undefined input', () => {
@@ -282,9 +292,14 @@ describe('VendorCredentialsManager', () => {
       expect(validateVendorBaseURL(null)).toBe('')
     })
 
-    it('rejects http URLs to non-loopback hosts', () => {
-      expect(() => validateVendorBaseURL('http://10.0.0.1/')).toThrow(/localhost/)
+    it('rejects http URLs to public hosts', () => {
+      expect(() => validateVendorBaseURL('http://8.8.8.8/')).toThrow(/localhost/)
       expect(() => validateVendorBaseURL('http://evil.example.com/v1')).toThrow(/localhost/)
+      // Just outside the 172.16.0.0/12 private block on either side.
+      expect(() => validateVendorBaseURL('http://172.15.0.1/')).toThrow(/localhost/)
+      expect(() => validateVendorBaseURL('http://172.32.0.1/')).toThrow(/localhost/)
+      // Hostname that merely starts with a private octet must not slip through.
+      expect(() => validateVendorBaseURL('http://10.0.0.1.evil.com/')).toThrow(/localhost/)
     })
 
     it('rejects file:, ftp:, and other schemes', () => {
@@ -383,7 +398,7 @@ describe('VendorCredentialsManager', () => {
     expect(() =>
       m.saveCredentials('openai-compatible', {
         apiKey: 'sk-x',
-        baseURL: 'http://10.0.0.1/v1',
+        baseURL: 'http://attacker.example/v1',
       }),
     ).toThrow(/localhost/)
     // Nothing should have been persisted.

--- a/src/main/settings/vendor-credentials-manager.ts
+++ b/src/main/settings/vendor-credentials-manager.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import log from '../logger'
 import type { Vendor, VendorCredentials, VendorStatus } from '../../shared/types'
 import { VENDORS } from '../../shared/types'
-import { registrableDomain } from '../../shared/url-utils'
+import { isPrivateNetworkHost, registrableDomain } from '../../shared/url-utils'
 
 interface SafeStorageLike {
   isEncryptionAvailable(): boolean
@@ -412,7 +412,9 @@ const VENDOR_EXPECTED_DOMAIN: Partial<Record<Vendor, string>> = {
  *   - empty/whitespace input → '' (caller treats this as "use default")
  *   - https:// URLs (constrained to the vendor's expected registrable domain
  *     when one is pinned in `VENDOR_EXPECTED_DOMAIN`; arbitrary host otherwise)
- *   - http:// URLs only when the host is a loopback address (Ollama-style local dev)
+ *   - http:// URLs only when the host is a loopback or private/link-local
+ *     network address (Ollama-style local dev, on this box or elsewhere on the
+ *     LAN) — never a public host, where http would leak the key in cleartext
  * and reject everything else (file:, ftp:, embedded credentials, etc.).
  */
 export function validateVendorBaseURL(value: unknown, vendor?: Vendor): string {
@@ -442,10 +444,10 @@ export function validateVendorBaseURL(value: unknown, vendor?: Vendor): string {
     return trimmed
   }
   if (url.protocol === 'http:') {
-    if (LOOPBACK_HOSTS.has(url.hostname)) {
+    if (LOOPBACK_HOSTS.has(url.hostname) || isPrivateNetworkHost(url.hostname)) {
       return trimmed
     }
-    throw new Error('Invalid baseURL: http is only allowed for localhost')
+    throw new Error('Invalid baseURL: http is only allowed for localhost and private networks')
   }
   throw new Error(`Invalid baseURL: unsupported scheme ${url.protocol}`)
 }

--- a/src/shared/url-utils.test.ts
+++ b/src/shared/url-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isSameRegistrableDomain, registrableDomain } from './url-utils'
+import { isPrivateNetworkHost, isSameRegistrableDomain, registrableDomain } from './url-utils'
 
 describe('registrableDomain', () => {
   it('returns the last two labels for multi-label hosts', () => {
@@ -24,6 +24,37 @@ describe('registrableDomain', () => {
   it('returns IPv6 literals unchanged (with or without brackets)', () => {
     expect(registrableDomain('[::1]')).toBe('[::1]')
     expect(registrableDomain('::1')).toBe('::1')
+  })
+})
+
+describe('isPrivateNetworkHost', () => {
+  it('accepts RFC 1918 and link-local IPv4 ranges', () => {
+    expect(isPrivateNetworkHost('10.0.0.92')).toBe(true)
+    expect(isPrivateNetworkHost('10.255.255.255')).toBe(true)
+    expect(isPrivateNetworkHost('192.168.1.50')).toBe(true)
+    expect(isPrivateNetworkHost('169.254.1.1')).toBe(true)
+  })
+
+  it('respects the 172.16.0.0/12 boundaries', () => {
+    expect(isPrivateNetworkHost('172.16.0.0')).toBe(true)
+    expect(isPrivateNetworkHost('172.31.255.255')).toBe(true)
+    expect(isPrivateNetworkHost('172.15.255.255')).toBe(false)
+    expect(isPrivateNetworkHost('172.32.0.0')).toBe(false)
+  })
+
+  it('rejects public IPv4 addresses', () => {
+    expect(isPrivateNetworkHost('8.8.8.8')).toBe(false)
+    expect(isPrivateNetworkHost('1.1.1.1')).toBe(false)
+    expect(isPrivateNetworkHost('0.0.0.0')).toBe(false)
+  })
+
+  it('rejects hostnames, IPv6, and malformed octets (fail-closed)', () => {
+    expect(isPrivateNetworkHost('10.0.0.1.evil.com')).toBe(false)
+    expect(isPrivateNetworkHost('localhost')).toBe(false)
+    expect(isPrivateNetworkHost('[fc00::1]')).toBe(false)
+    expect(isPrivateNetworkHost('10.0.0')).toBe(false)
+    expect(isPrivateNetworkHost('10.0.0.256')).toBe(false)
+    expect(isPrivateNetworkHost('10.0.0.1.1')).toBe(false)
   })
 })
 

--- a/src/shared/url-utils.ts
+++ b/src/shared/url-utils.ts
@@ -21,6 +21,46 @@ export function registrableDomain(hostname: string): string {
   return labels.slice(-2).join('.')
 }
 
+/**
+ * Parse a canonical dotted-decimal IPv4 literal into its four octets, or
+ * `null` if `host` is not such a literal. Intended for `URL.hostname`, which
+ * the WHATWG parser already normalizes (`0x7f.0.0.1`, `2130706433`, `0177...`
+ * all collapse to dotted-decimal), so octal/hex/decimal evasions are handled
+ * before we get here. Any non-IPv4 host (hostnames, IPv6) returns `null`.
+ */
+function parseIPv4(host: string): [number, number, number, number] | null {
+  const parts = host.split('.')
+  if (parts.length !== 4) return null
+  const octets: number[] = []
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null
+    const n = Number(part)
+    if (n > 255) return null
+    octets.push(n)
+  }
+  return octets as [number, number, number, number]
+}
+
+/**
+ * True iff `hostname` is an IPv4 literal in a private (RFC 1918) or link-local
+ * range — i.e. reachable only on the user's own LAN, never on the public
+ * internet. Used to allow plain `http://` to local servers (Ollama, LM Studio
+ * on another box) while still blocking `http://` to public hosts, where it
+ * would leak the api key in cleartext. Only IPv4 literals qualify; hostnames
+ * are rejected (we don't resolve DNS — that would invite rebinding), so the
+ * failure mode is fail-closed.
+ */
+export function isPrivateNetworkHost(hostname: string): boolean {
+  const ip = parseIPv4(hostname)
+  if (!ip) return false
+  const [a, b] = ip
+  if (a === 10) return true // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12
+  if (a === 192 && b === 168) return true // 192.168.0.0/16
+  if (a === 169 && b === 254) return true // 169.254.0.0/16 (link-local)
+  return false
+}
+
 function hostnameOf(input: string): string | null {
   try {
     return new URL(input).hostname


### PR DESCRIPTION
## Problem

A user pointing the vendor baseURL at an Ollama server on another machine on their LAN (`http://10.0.0.92:11434/v1`) hit **"Invalid baseURL: http is only allowed for localhost"**. The validator only permitted plain `http://` to loopback hosts, so any "Ollama/LM Studio on a different box" setup was rejected — a common, legitimate configuration.

## Change

Relax the `http://` allow-list in `validateVendorBaseURL` from **loopback-only** to **loopback + private/link-local IPv4 ranges**, via a new `isPrivateNetworkHost()` helper in `src/shared/url-utils.ts`:

- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC 1918) + `169.254.0.0/16` (link-local)
- Public hosts over `http://` stay rejected — the api key would travel in cleartext.

### Why it's safe

- **IPv4 literals only.** Hostnames and IPv6 are rejected — no DNS resolution, so no rebinding risk; the check **fails closed**.
- The WHATWG URL parser canonicalizes IPv4 literals before the range check (verified: `0x7f.0.0.1`, `2130706433`, `0177.0.0.1` all collapse to dotted-decimal), so octal/hex/decimal evasions are normalized away.
- `https://` to arbitrary hosts is already allowed for `openai-compatible`, so this doesn't widen the existing exfil surface for a compromised renderer — it only unblocks the honest LAN case.

## Not included

- `.local` mDNS hostnames (kept to IP literals to avoid DNS ambiguity).
- IPv4-mapped IPv6 (`::ffff:10.0.0.1`) — obscure; fails closed.

## Tests

- `isPrivateNetworkHost` unit tests: RFC 1918 / link-local accepts, `172.16/12` boundary cases, public rejects, fail-closed cases (`10.0.0.1.evil.com`, IPv6, malformed octets).
- `validateVendorBaseURL`: LAN-accept cases, public-reject cases; updated the SSRF test that used `10.0.0.1` (now a valid private address) to a public host.
- All 43 tests in the two suites pass; ESLint + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)