### PR TITLE
feat(updater): in-app "Relaunch to update" banner

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -242,8 +242,10 @@ app.on('ready', async () => {
 
   if (editionConfig.edition === 'customer') {
     const { initAutoUpdater } = await import('./updater')
+    const { sendUpdateState } = await import('./ui/main-window')
     initAutoUpdater(() => {
       void updateTrayMenu()
+      sendUpdateState()
     })
   } else {
     log.info('[Updater] Skipping auto-updater for enterprise edition')

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -20,6 +20,7 @@ import { DEFAULT_EDITION, type AppEditionConfig } from '../../shared/edition'
 import { PURGE_CONFIRMATION_PHRASE } from '../../shared/constants'
 import log from '../logger'
 import { updateTrayMenu } from './tray'
+import { getUpdateInfo, quitAndInstall } from '../updater'
 import { exportDatabaseZip } from './database-export'
 import { importDatabase } from './database-import'
 import { getPermissionStatus, openPermissionSettings, type PermissionStatus } from './permissions'
@@ -188,6 +189,15 @@ export function sendStatusToRenderer(): void {
 export function sendObservationUpdate(state: ObservationState): void {
   if (!mainWindow || mainWindow.isDestroyed()) return
   mainWindow.webContents.send('main-window:observationUpdate', state)
+}
+
+/**
+ * Broadcast the current auto-update state to the renderer so it can show the
+ * "Relaunch to update" banner when an update is ready.
+ */
+export function sendUpdateState(): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  mainWindow.webContents.send('main-window:updateStateChanged', getUpdateInfo())
 }
 
 // Permission status broadcaster — the renderer subscribes while on the
@@ -1013,5 +1023,10 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     log.info('[App] Restart requested from renderer')
     app.relaunch()
     app.quit()
+  })
+  ipcMain.handle('main-window:getUpdateState', () => getUpdateInfo())
+  ipcMain.handle('main-window:installUpdate', () => {
+    log.info('[Updater] Install requested from renderer')
+    void quitAndInstall()
   })
 }

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -1024,7 +1024,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     app.relaunch()
     app.quit()
   })
-  ipcMain.handle('main-window:getUpdateState', () => getUpdateInfo())
+  ipcMain.handle('main-window:getUpdateInfo', () => getUpdateInfo())
   ipcMain.handle('main-window:installUpdate', () => {
     log.info('[Updater] Install requested from renderer')
     void quitAndInstall()

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,16 +1,15 @@
-import { app, Notification } from 'electron'
+import { app } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import log from './logger'
 import { confirmWindowsUpdateInstall } from './windows-update-install'
+import type { UpdateInfo, UpdateState } from '../shared/types'
 
-export type UpdateState = 'idle' | 'downloading' | 'ready'
 let state: UpdateState = 'idle'
-let reminderInterval: ReturnType<typeof setInterval> | null = null
-// Must be kept in module scope so the click handler isn't garbage-collected.
-let currentNotification: Notification | null = null
+let availableVersion: string | null = null
 const DISABLE_AUTO_UPDATE_ENV_VAR = 'MEMORYLANE_DISABLE_AUTO_UPDATE'
 
 export const getUpdateState = (): UpdateState => state
+export const getUpdateInfo = (): UpdateInfo => ({ state, version: availableVersion })
 
 const isAutoUpdateDisabled = (): boolean => {
   const rawValue = process.env[DISABLE_AUTO_UPDATE_ENV_VAR]
@@ -21,11 +20,6 @@ const isAutoUpdateDisabled = (): boolean => {
 }
 
 export const quitAndInstall = async (): Promise<void> => {
-  if (reminderInterval) {
-    clearInterval(reminderInterval)
-    reminderInterval = null
-  }
-
   if (!(await confirmWindowsUpdateInstall(process.execPath))) {
     return
   }
@@ -45,17 +39,6 @@ export const quitAndInstall = async (): Promise<void> => {
     log.warn('[Updater] App still running after quitAndInstall — forcing exit')
     app.exit(0)
   }, 3_000)
-}
-
-const showUpdateNotification = (version: string): void => {
-  if (currentNotification) currentNotification.close()
-  currentNotification = new Notification({
-    title: 'MemoryLane Update Ready',
-    body: `Version ${version} is ready. Click to restart and update.`,
-    silent: true,
-  })
-  currentNotification.on('click', () => void quitAndInstall())
-  currentNotification.show()
 }
 
 export const initAutoUpdater = (onUpdateStateChange: () => void): void => {
@@ -80,22 +63,20 @@ export const initAutoUpdater = (onUpdateStateChange: () => void): void => {
   autoUpdater.on('update-available', (info) => {
     log.info(`[Updater] Update available: ${info.version}`)
     state = 'downloading'
+    availableVersion = info.version
     onUpdateStateChange()
   })
 
   autoUpdater.on('update-downloaded', (info) => {
     log.info(`[Updater] Update downloaded: ${info.version}`)
     state = 'ready'
+    availableVersion = info.version
     onUpdateStateChange()
-
-    showUpdateNotification(info.version)
-
-    if (reminderInterval) clearInterval(reminderInterval)
-    reminderInterval = setInterval(() => showUpdateNotification(info.version), 4 * 60 * 60 * 1000)
   })
 
   autoUpdater.on('update-not-available', () => {
     state = 'idle'
+    availableVersion = null
     log.info('[Updater] Up to date.')
   })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -123,6 +123,16 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
       ipcRenderer.off('main-window:permissionStatusChanged', handler)
     }
   },
+  // Updater
+  getUpdateState: () => ipcRenderer.invoke('main-window:getUpdateState'),
+  installUpdate: () => ipcRenderer.invoke('main-window:installUpdate'),
+  onUpdateStateChanged: (callback: (info: unknown) => void) => {
+    const handler = (_event: unknown, info: unknown): void => callback(info)
+    ipcRenderer.on('main-window:updateStateChanged', handler)
+    return () => {
+      ipcRenderer.off('main-window:updateStateChanged', handler)
+    }
+  },
   // App lifecycle
   restartApp: () => ipcRenderer.invoke('main-window:restartApp'),
   // Host platform — read once at preload time; never changes mid-session.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -124,7 +124,7 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
     }
   },
   // Updater
-  getUpdateState: () => ipcRenderer.invoke('main-window:getUpdateState'),
+  getUpdateInfo: () => ipcRenderer.invoke('main-window:getUpdateInfo'),
   installUpdate: () => ipcRenderer.invoke('main-window:installUpdate'),
   onUpdateStateChanged: (callback: (info: unknown) => void) => {
     const handler = (_event: unknown, info: unknown): void => callback(info)

--- a/src/renderer/pages/main-window/MainWindowApp.tsx
+++ b/src/renderer/pages/main-window/MainWindowApp.tsx
@@ -38,6 +38,7 @@ import type {
   PatternInfo,
   PermissionState,
   PermissionStatus,
+  UpdateInfo,
   Vendor,
   VendorStatus,
 } from '@types'
@@ -67,6 +68,7 @@ export function MainWindowApp(): React.JSX.Element {
     readLastCompletedIndex(localStorageAdapter),
   )
   const [permissionStatus, setPermissionStatus] = useState<PermissionStatus | null>(null)
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null)
   // Captured synchronously on the first non-null permission status so we can
   // detect a mid-session screen-recording grant — macOS won't let the running
   // process actually capture until it restarts, so we gate onboarding on a
@@ -333,6 +335,12 @@ export function MainWindowApp(): React.JSX.Element {
     return () => unsubscribe()
   }, [api, updatePermissionStatus])
 
+  useEffect(() => {
+    void api.getUpdateState().then(setUpdateInfo)
+    const unsubscribe = api.onUpdateStateChanged(setUpdateInfo)
+    return () => unsubscribe()
+  }, [api])
+
   // Self-heal `lastCompletedStepIndex` from concrete state once everything
   // has loaded. If a returning user has already granted permissions, set a
   // key, or connected MCP, those steps are implicitly done — bump the mark
@@ -533,6 +541,9 @@ export function MainWindowApp(): React.JSX.Element {
       llmHealth={llmHealth}
       configured={isConfigured}
       onOpenLlmSettings={handleOpenLlmSettings}
+      updateReady={updateInfo?.state === 'ready'}
+      updateVersion={updateInfo?.version ?? null}
+      onInstallUpdate={() => void api.installUpdate()}
       collapsed={sidebarCollapsed}
       onToggleCollapsed={handleToggleSidebar}
     />

--- a/src/renderer/pages/main-window/MainWindowApp.tsx
+++ b/src/renderer/pages/main-window/MainWindowApp.tsx
@@ -336,7 +336,7 @@ export function MainWindowApp(): React.JSX.Element {
   }, [api, updatePermissionStatus])
 
   useEffect(() => {
-    void api.getUpdateState().then(setUpdateInfo)
+    void api.getUpdateInfo().then(setUpdateInfo)
     const unsubscribe = api.onUpdateStateChanged(setUpdateInfo)
     return () => unsubscribe()
   }, [api])

--- a/src/renderer/pages/main-window/components/shell/Sidebar.tsx
+++ b/src/renderer/pages/main-window/components/shell/Sidebar.tsx
@@ -12,6 +12,7 @@ import type { LlmHealthStatus, Vendor } from '@types'
 import { CaptureControlSection } from '../CaptureControlSection'
 import { SidebarNavItem } from './SidebarNavItem'
 import { LlmStatusPanel } from './LlmStatusPanel'
+import { UpdateBanner } from './UpdateBanner'
 import { Logo } from '@/renderer/components/Logo'
 
 export type MainSection = 'activities' | 'patterns' | 'settings'
@@ -32,6 +33,9 @@ interface SidebarProps {
   llmHealth: LlmHealthStatus | null
   configured: boolean
   onOpenLlmSettings: () => void
+  updateReady: boolean
+  updateVersion: string | null
+  onInstallUpdate: () => void
   collapsed: boolean
   onToggleCollapsed: () => void
 }
@@ -46,6 +50,9 @@ export function Sidebar({
   llmHealth,
   configured,
   onOpenLlmSettings,
+  updateReady,
+  updateVersion,
+  onInstallUpdate,
   collapsed,
   onToggleCollapsed,
 }: SidebarProps): React.JSX.Element {
@@ -94,6 +101,10 @@ export function Sidebar({
       </nav>
 
       <div className="flex-1" />
+
+      {updateReady ? (
+        <UpdateBanner version={updateVersion} onRelaunch={onInstallUpdate} collapsed={collapsed} />
+      ) : null}
 
       <LlmStatusPanel
         vendor={vendor}

--- a/src/renderer/pages/main-window/components/shell/UpdateBanner.tsx
+++ b/src/renderer/pages/main-window/components/shell/UpdateBanner.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { ArrowRight, Leaf } from 'lucide-react'
+import { cn } from '@/renderer/lib/utils'
+
+interface UpdateBannerProps {
+  version: string | null
+  onRelaunch: () => void
+  collapsed?: boolean
+}
+
+export function UpdateBanner({
+  version,
+  onRelaunch,
+  collapsed = false,
+}: UpdateBannerProps): React.JSX.Element {
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        onClick={onRelaunch}
+        aria-label="Relaunch to update"
+        title={version ? `Relaunch to update · v${version}` : 'Relaunch to update'}
+        className={cn(
+          'flex items-center justify-center size-9 rounded-md',
+          'bg-primary/15 text-primary hover:bg-primary/25 transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+        )}
+      >
+        <Leaf className="size-4" />
+      </button>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={onRelaunch}
+      aria-label={version ? `Relaunch to update — v${version}` : 'Relaunch to update'}
+      className={cn(
+        'flex items-center gap-2.5 w-full text-left px-3 py-2 rounded-lg',
+        'border border-primary/50 bg-primary/10',
+        'hover:bg-primary/15 transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+      )}
+    >
+      <Leaf className="size-4 shrink-0 text-primary" />
+      <span className="min-w-0 flex-1">
+        <span className="block text-xs font-medium leading-tight text-sidebar-foreground">
+          Relaunch to update
+        </span>
+        {version ? (
+          <span className="block text-[11px] leading-tight text-sidebar-foreground/60">
+            v{version}
+          </span>
+        ) : null}
+      </span>
+      <ArrowRight className="size-3.5 shrink-0 text-sidebar-foreground/60" aria-hidden />
+    </button>
+  )
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -249,6 +249,11 @@ export type SemanticPipelineMode = 'auto' | 'video' | 'image'
 
 export type UpdateState = 'idle' | 'downloading' | 'ready'
 
+export interface UpdateInfo {
+  state: UpdateState
+  version: string | null
+}
+
 export type PermissionKind = 'accessibility' | 'screenRecording'
 export type PermissionState = 'granted' | 'denied' | 'unknown'
 export interface PermissionStatus {
@@ -355,8 +360,8 @@ export interface MainWindowAPI {
   syncDatabaseToRemote: () => Promise<{ success: boolean; error?: string }>
   purgeDatabase: (confirmation: string) => Promise<{ success: boolean; error?: string }>
   // Updater
-  getUpdateState: () => Promise<UpdateState>
-  onUpdateStateChanged: (callback: (state: UpdateState) => void) => void
+  getUpdateState: () => Promise<UpdateInfo>
+  onUpdateStateChanged: (callback: (info: UpdateInfo) => void) => () => void
   installUpdate: () => Promise<void>
   openExternal: (url: string) => Promise<void>
   // Observation (build exclusion list from live activity)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -360,7 +360,7 @@ export interface MainWindowAPI {
   syncDatabaseToRemote: () => Promise<{ success: boolean; error?: string }>
   purgeDatabase: (confirmation: string) => Promise<{ success: boolean; error?: string }>
   // Updater
-  getUpdateState: () => Promise<UpdateInfo>
+  getUpdateInfo: () => Promise<UpdateInfo>
   onUpdateStateChanged: (callback: (info: UpdateInfo) => void) => () => void
   installUpdate: () => Promise<void>
   openExternal: (url: string) => Promise<void>


### PR DESCRIPTION
## What

Surfaces a ready-to-install update prominently inside the app. When `electron-updater` finishes downloading a new version, a primary-tinted **"Relaunch to update"** banner appears in the sidebar, just above the LLM status (OpenRouter) panel. Clicking it triggers quit-and-install. The banner follows the sidebar collapse state (compact leaf-icon button when collapsed).

Previously a downloaded update was only signalled by a silent OS notification (re-firing every 4 hours) and a tray-menu item — easy to miss.

## Changes

- **`updater.ts`** — track the available version, expose `getUpdateInfo()`; **removed** the OS `Notification` and its 4-hour reminder interval. `UpdateState` now imported from shared types rather than redefined.
- **`index.ts`** — updater state-change callback also broadcasts to the renderer.
- **`ui/main-window.ts`** — `sendUpdateState()` broadcaster + `getUpdateState` / `installUpdate` IPC handlers.
- **`shared/types.ts`** — new `UpdateInfo`; updater API signatures now carry the version.
- **`preload/index.ts`** — exposes `getUpdateState`, `installUpdate`, `onUpdateStateChanged`.
- **`UpdateBanner.tsx`** (new) — sidebar control with expanded + collapsed variants.
- **`Sidebar.tsx` / `MainWindowApp.tsx`** — render the banner above the LLM panel when an update is ready.

## Notes

- Updater only initializes for the `customer` edition and when `app.isPackaged`, so the banner won't appear in normal dev. Verified visually by temporarily seeding the `getUpdateState` handler to `ready`.
- Tray "Install Update Now" item is unchanged.

## Test

- `tsc --noEmit` clean, `npm run test` 700 passed, lint/format clean (pre-commit hooks).
- Manual visual check in dev (seeded ready state): banner renders over the OpenRouter status in both expanded and collapsed sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)