### PR TITLE
Stop screenshots leaking across app boundaries (grab-time app stamp + producer filter + trailing-frame drop)

### DIFF
--- a/src/main/activity-producer.test.ts
+++ b/src/main/activity-producer.test.ts
@@ -17,7 +17,11 @@ vi.mock('./logger', () => ({
   },
 }))
 
-function makeFrame(timestamp: number, sequenceNumber: number): Frame {
+function makeFrame(
+  timestamp: number,
+  sequenceNumber: number,
+  app?: { appName: string; bundleId?: string },
+): Frame {
   return {
     filepath: `frame-${sequenceNumber}.png`,
     timestamp,
@@ -25,6 +29,7 @@ function makeFrame(timestamp: number, sequenceNumber: number): Frame {
     height: 720,
     displayId: 1,
     sequenceNumber,
+    ...(app ?? {}),
   }
 }
 
@@ -491,6 +496,290 @@ describe('ActivityProducer', () => {
     expect(producer.getStats().droppedUnknownContextWindows).toBe(0)
     expect(producer.getStats().droppedNoFrameWindows).toBe(1)
     expect(noContextOffset).toBeLessThan(noFrameOffset)
+  })
+
+  it('excludes a frame whose stamped app does not match the window context', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_000, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_200, 1, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].context.appName).toBe('Code')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+  })
+
+  it('retains an app-less (unstamped) frame regardless of context', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(makeFrame(1_000, 0)) // no app stamp
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames).toHaveLength(1)
+  })
+
+  it('matches on appName when the frame carries no bundleId', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(makeFrame(1_000, 0, { appName: 'Code' })) // matches by appName
+    await frameStream.append(makeFrame(1_200, 1, { appName: 'Slack' })) // excluded by appName
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+  })
+
+  it('prefers bundleId: excludes a frame whose bundleId differs even if appName matches', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(makeFrame(1_000, 0, { appName: 'Helper', bundleId: 'com.a' }))
+    await frameStream.append(makeFrame(1_200, 1, { appName: 'Helper', bundleId: 'com.b' }))
+    await eventStream.append(
+      makeWindow({
+        id: 'helper-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: { title: 'A', processName: 'Helper', bundleId: 'com.a' },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+  })
+
+  it('treats a window whose only frames are app-mismatched as frameless and finalizes the incompatible pending activity', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_500, 0, { appName: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }),
+    )
+    // Lands in W2's time range but is stamped with the PREVIOUS app (the leak):
+    // excluded from the Electron window, leaving it frameless.
+    await frameStream.append(
+      makeFrame(2_100, 1, { appName: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }),
+    )
+
+    await eventStream.append(
+      makeWindow({
+        id: 'ghostty',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'session',
+              processName: 'Ghostty',
+              bundleId: 'com.mitchellh.ghostty',
+            },
+          }),
+          makeEvent(1_600, 'scroll'),
+        ],
+      }),
+    )
+
+    const lastOffset = await eventStream.append(
+      makeWindow({
+        id: 'electron',
+        startTimestamp: 2_000,
+        endTimestamp: 2_200,
+        closedBy: 'gap',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'MemoryLane',
+              processName: 'Electron',
+              bundleId: 'com.github.Electron',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(
+      () => activities.length === 1 && producer.getStats().droppedNoFrameWindows === 1,
+      'Expected the Ghostty activity to emit and the app-mismatched Electron window to drop',
+    )
+    expect(activities.map((a) => a.context.appName)).toEqual(['Ghostty'])
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+    expect(producer.getStats().emittedActivities).toBe(1)
+
+    // The incompatible frameless window finalized the pending activity, so the
+    // event offsets ack without an explicit flush/stop.
+    await waitFor(
+      async () => (await eventStream.getAck('test:event')) === lastOffset,
+      'Expected event offsets to ack after the pending activity is finalized',
+    )
+  })
+
+  it('drops a concrete-app-stamped frame in an Unknown-context window', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_050, 0, { appName: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'unknown',
+        startTimestamp: 1_000,
+        endTimestamp: 1_100,
+        closedBy: 'flush',
+        events: [makeEvent(1_020, 'keyboard')], // no app_change -> 'Unknown' context
+      }),
+    )
+
+    await waitFor(
+      () => producer.getStats().droppedNoFrameWindows === 1,
+      'Expected the Unknown-context window to drop the mismatched frame',
+    )
+    expect(activities).toHaveLength(0)
+  })
+
+  it('keeps a mismatched frame when the app filter is disabled', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer({
+      enableFrameAppFilter: false,
+    })
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_000, 0, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames).toHaveLength(1)
   })
 
   // Regression for the "trailing pending activity" data loss: the producer keeps

--- a/src/main/activity-producer.test.ts
+++ b/src/main/activity-producer.test.ts
@@ -536,6 +536,7 @@ describe('ActivityProducer', () => {
     await waitFor(() => activities.length === 1, 'Expected one activity')
     expect(activities[0].context.appName).toBe('Code')
     expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(1)
   })
 
   it('retains an app-less (unstamped) frame regardless of context', async () => {
@@ -698,12 +699,16 @@ describe('ActivityProducer', () => {
     )
 
     await waitFor(
-      () => activities.length === 1 && producer.getStats().droppedNoFrameWindows === 1,
+      () => activities.length === 1 && producer.getStats().droppedAllFramesFilteredWindows === 1,
       'Expected the Ghostty activity to emit and the app-mismatched Electron window to drop',
     )
     expect(activities.map((a) => a.context.appName)).toEqual(['Ghostty'])
     expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
     expect(producer.getStats().emittedActivities).toBe(1)
+    // The Electron window had a frame in range but it was app-filtered out, so it
+    // counts as all-filtered, not genuinely no-frame.
+    expect(producer.getStats().droppedNoFrameWindows).toBe(0)
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(1)
 
     // The incompatible frameless window finalized the pending activity, so the
     // event offsets ack without an explicit flush/stop.
@@ -738,10 +743,12 @@ describe('ActivityProducer', () => {
     )
 
     await waitFor(
-      () => producer.getStats().droppedNoFrameWindows === 1,
+      () => producer.getStats().droppedAllFramesFilteredWindows === 1,
       'Expected the Unknown-context window to drop the mismatched frame',
     )
     expect(activities).toHaveLength(0)
+    expect(producer.getStats().droppedNoFrameWindows).toBe(0)
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(1)
   })
 
   it('keeps a mismatched frame when the app filter is disabled', async () => {
@@ -842,6 +849,7 @@ describe('ActivityProducer', () => {
     expect(activities[0].provenance.frameOffsets).toEqual([0])
     // Slack is finalized by flush (not an app switch), so its frame is kept.
     expect(activities[1].frames.map((f) => f.frame.filepath)).toEqual(['frame-2.png'])
+    expect(producer.getStats().trailingFramesDropped).toBe(1)
   })
 
   it('keeps the trailing frame when dropAppSwitchTrailingFrame is disabled', async () => {
@@ -900,6 +908,7 @@ describe('ActivityProducer', () => {
     )
     const code = activities.find((a) => a.context.appName === 'Code')!
     expect(code.frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png', 'frame-1.png'])
+    expect(producer.getStats().trailingFramesDropped).toBe(0)
   })
 
   it('does not drop the trailing frame on a same-app tld boundary', async () => {

--- a/src/main/activity-producer.test.ts
+++ b/src/main/activity-producer.test.ts
@@ -782,6 +782,178 @@ describe('ActivityProducer', () => {
     expect(activities[0].frames).toHaveLength(1)
   })
 
+  it('drops the trailing frame when an activity is finalized by a different app', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_200, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_800, 1, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(2_500, 2, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+
+    await eventStream.append(
+      makeWindow({
+        id: 'code',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'Repo', processName: 'Code', bundleId: 'com.microsoft.VSCode' },
+          }),
+          makeEvent(1_500, 'scroll'),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'slack',
+        startTimestamp: 2_000,
+        endTimestamp: 3_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: {
+              title: 'general',
+              processName: 'Slack',
+              bundleId: 'com.tinyspeck.slackmacgap',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 2, 'Expected two activities')
+    expect(activities.map((a) => a.context.appName)).toEqual(['Code', 'Slack'])
+    // Code's trailing frame (1_800, offset 1) is the transition bleed -> dropped.
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+    expect(activities[0].provenance.frameOffsets).toEqual([0])
+    // Slack is finalized by flush (not an app switch), so its frame is kept.
+    expect(activities[1].frames.map((f) => f.frame.filepath)).toEqual(['frame-2.png'])
+  })
+
+  it('keeps the trailing frame when dropAppSwitchTrailingFrame is disabled', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer({
+      dropAppSwitchTrailingFrame: false,
+    })
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_200, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_800, 1, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'Repo', processName: 'Code', bundleId: 'com.microsoft.VSCode' },
+          }),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'slack',
+        startTimestamp: 2_000,
+        endTimestamp: 3_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: {
+              title: 'general',
+              processName: 'Slack',
+              bundleId: 'com.tinyspeck.slackmacgap',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(
+      () => activities.some((a) => a.context.appName === 'Code'),
+      'Expected the Code activity',
+    )
+    const code = activities.find((a) => a.context.appName === 'Code')!
+    expect(code.frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png', 'frame-1.png'])
+  })
+
+  it('does not drop the trailing frame on a same-app tld boundary', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    const chrome = { appName: 'Google Chrome', bundleId: 'com.google.Chrome' }
+    await frameStream.append(makeFrame(1_200, 0, chrome))
+    await frameStream.append(makeFrame(1_800, 1, chrome))
+    await frameStream.append(makeFrame(2_500, 2, chrome)) // lands in the second (other.org) window
+
+    await eventStream.append(
+      makeWindow({
+        id: 'chrome-a',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'A', ...chrome, url: 'https://example.com/a' },
+          }),
+          makeEvent(1_500, 'scroll'),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'chrome-b',
+        startTimestamp: 2_000,
+        endTimestamp: 3_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: { title: 'B', ...chrome, url: 'https://other.org/b' },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 2, 'Expected two activities split by tld')
+    // Same app across the boundary -> no transition bleed -> both frames kept.
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual([
+      'frame-0.png',
+      'frame-1.png',
+    ])
+  })
+
   // Regression for the "trailing pending activity" data loss: the producer keeps
   // a single pendingActivity. It used to be emitted only when a LATER frame-backed
   // window with an incompatible context arrived (-> context_change finalize) or on

--- a/src/main/activity-producer.ts
+++ b/src/main/activity-producer.ts
@@ -221,7 +221,7 @@ export class ActivityProducer {
         this.pendingActivity !== null &&
         !this.canMergeContexts(this.pendingActivity.context, windowContext)
       ) {
-        await this.finalizePendingActivity('context_change')
+        await this.finalizePendingActivity('context_change', { droppedToApp: windowContext })
         await this.flushDeferredEventAck()
       }
       await this.markRecordProcessed(record.offset)
@@ -303,6 +303,7 @@ export class ActivityProducer {
     if (!compatible) {
       await this.finalizePendingActivity(
         combinedDuration > this.config.maxActivityDurationMs ? 'max_duration' : 'context_change',
+        { droppedToApp: chunk.context },
       )
       await this.flushDeferredEventAck()
       this.pendingActivity = this.createPendingActivity(chunk)
@@ -367,8 +368,11 @@ export class ActivityProducer {
 
   private async finalizePendingActivity(
     reason: 'context_change' | 'max_duration' | 'flush',
+    options?: { droppedToApp?: ActivityContext },
   ): Promise<void> {
     if (this.pendingActivity === null) return
+
+    this.maybeDropTrailingBoundaryFrame(this.pendingActivity, options?.droppedToApp)
 
     const durationMs = this.pendingActivity.endTimestamp - this.pendingActivity.startTimestamp
     const eventOffsetsToAck = [...this.pendingActivity.provenance.eventWindowOffsets]
@@ -434,11 +438,7 @@ export class ActivityProducer {
       return false
     }
 
-    const sameApp =
-      left.bundleId && right.bundleId
-        ? left.bundleId === right.bundleId
-        : left.appName === right.appName
-    if (!sameApp) return false
+    if (!this.appsEqual(left, right)) return false
 
     const browser = isBrowserApp({
       processName: left.appName,
@@ -447,6 +447,38 @@ export class ActivityProducer {
     if (!browser) return true
     if (!left.tld || !right.tld) return false
     return left.tld === right.tld
+  }
+
+  /** App-identity equality: bundleId-preferred, appName fallback. */
+  private appsEqual(left: ActivityContext, right: ActivityContext): boolean {
+    return left.bundleId && right.bundleId
+      ? left.bundleId === right.bundleId
+      : left.appName === right.appName
+  }
+
+  /**
+   * Drop the activity's last frame when it's finalized because a *different* app
+   * took over. In the sub-second skew between screen compositing and the
+   * frontmost-app signal, that trailing frame tends to already show the next app
+   * (a one-frame "transition bleed"). Only drops on a real app change, and never
+   * empties an activity (keeps at least one frame).
+   */
+  private maybeDropTrailingBoundaryFrame(activity: Activity, successor?: ActivityContext): void {
+    if (!this.config.dropAppSwitchTrailingFrame) return
+    if (successor === undefined) return
+    if (this.appsEqual(activity.context, successor)) return
+    if (activity.frames.length <= 1) return
+
+    // Frames are kept sorted ascending by timestamp, so the latest is the bleed.
+    const dropped = activity.frames.pop()
+    if (dropped === undefined) return
+    activity.provenance.frameOffsets = activity.provenance.frameOffsets.filter(
+      (offset) => offset !== dropped.offset,
+    )
+    log.info(
+      `[ActivityProducer] Dropped trailing boundary frame ${dropped.frame.filepath} from ` +
+        `${activity.context.appName} activity (switch to ${successor.appName})`,
+    )
   }
 
   /**

--- a/src/main/activity-producer.ts
+++ b/src/main/activity-producer.ts
@@ -17,8 +17,19 @@ const ACTIVITY_ID_NAMESPACE = uuidv5('memorylane:v2-activity', uuidv5.DNS)
 
 export interface ActivityProducerStats {
   emittedActivities: number
+  // Windows dropped because no frame fell in their time range at all.
   droppedNoFrameWindows: number
+  // Windows that had frames in their time range but every one was excluded by
+  // the grab-time app filter (the leak signature: in-range frames all stamped
+  // with a different app than the window context).
+  droppedAllFramesFilteredWindows: number
   droppedUnknownContextWindows: number
+  // Total frames kept out of a window by the grab-time app filter (includes the
+  // ones counted by droppedAllFramesFilteredWindows). A proxy for how often the
+  // leak the filter guards against actually fires in production.
+  framesExcludedByAppFilter: number
+  // Total trailing "transition bleed" frames dropped at app-switch boundaries.
+  trailingFramesDropped: number
 }
 
 interface ChunkContext {
@@ -64,7 +75,10 @@ export class ActivityProducer {
   private readonly stats: ActivityProducerStats = {
     emittedActivities: 0,
     droppedNoFrameWindows: 0,
+    droppedAllFramesFilteredWindows: 0,
     droppedUnknownContextWindows: 0,
+    framesExcludedByAppFilter: 0,
+    trailingFramesDropped: 0,
   }
 
   constructor(params: {
@@ -201,15 +215,25 @@ export class ActivityProducer {
       return
     }
 
-    const candidateFrames = this.getFramesInRange(
+    const { frames: candidateFrames, excludedByAppFilter } = this.getFramesInRange(
       window.startTimestamp,
       window.endTimestamp,
       windowContext,
     )
+    this.stats.framesExcludedByAppFilter += excludedByAppFilter
     if (candidateFrames.length === 0) {
-      this.stats.droppedNoFrameWindows++
+      // Distinguish "no frames captured in this window" from "frames were
+      // captured but all belonged to a different app" — the latter is the leak
+      // signature and worth tracking separately for diagnosis.
+      if (excludedByAppFilter > 0) {
+        this.stats.droppedAllFramesFilteredWindows++
+      } else {
+        this.stats.droppedNoFrameWindows++
+      }
       log.info(
-        `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: no frames in ${window.startTimestamp}-${window.endTimestamp}`,
+        `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: ` +
+          `${excludedByAppFilter > 0 ? `all ${excludedByAppFilter} frame(s) app-filtered out` : 'no frames'} ` +
+          `in ${window.startTimestamp}-${window.endTimestamp}`,
       )
       // A frameless window can neither seed nor extend an activity, but if its
       // context is incompatible with the in-progress pendingActivity it still
@@ -472,6 +496,7 @@ export class ActivityProducer {
     // Frames are kept sorted ascending by timestamp, so the latest is the bleed.
     const dropped = activity.frames.pop()
     if (dropped === undefined) return
+    this.stats.trailingFramesDropped++
     activity.provenance.frameOffsets = activity.provenance.frameOffsets.filter(
       (offset) => offset !== dropped.offset,
     )
@@ -547,13 +572,15 @@ export class ActivityProducer {
     startTimestamp: number,
     endTimestamp: number,
     context: ActivityContext,
-  ): StreamRecord<Frame>[] {
-    return this.frameBuffer.filter(
+  ): { frames: StreamRecord<Frame>[]; excludedByAppFilter: number } {
+    const inTimeRange = this.frameBuffer.filter(
       (record) =>
-        record.payload.timestamp >= startTimestamp &&
-        record.payload.timestamp <= endTimestamp &&
-        this.frameAppMatchesContext(record.payload, context),
+        record.payload.timestamp >= startTimestamp && record.payload.timestamp <= endTimestamp,
     )
+    const frames = inTimeRange.filter((record) =>
+      this.frameAppMatchesContext(record.payload, context),
+    )
+    return { frames, excludedByAppFilter: inTimeRange.length - frames.length }
   }
 
   private async waitForFramesToSettle(windowEndTimestamp: number): Promise<void> {

--- a/src/main/activity-producer.ts
+++ b/src/main/activity-producer.ts
@@ -201,7 +201,11 @@ export class ActivityProducer {
       return
     }
 
-    const candidateFrames = this.getFramesInRange(window.startTimestamp, window.endTimestamp)
+    const candidateFrames = this.getFramesInRange(
+      window.startTimestamp,
+      window.endTimestamp,
+      windowContext,
+    )
     if (candidateFrames.length === 0) {
       this.stats.droppedNoFrameWindows++
       log.info(
@@ -445,6 +449,34 @@ export class ActivityProducer {
     return left.tld === right.tld
   }
 
+  /**
+   * Whether a candidate frame belongs to a window's derived app context.
+   *
+   * The frame carries the frontmost app observed by the native daemon at the
+   * grab instant — an observation independent of the app-watcher's (lagging)
+   * event timeline. Comparing it against the window context catches frames that
+   * fall in a window's time range but were actually captured under a different
+   * app (the "leak" around an app switch).
+   *
+   * Only app identity is compared, mirroring the app half of canMergeContexts
+   * (bundleId-preferred, appName fallback). We deliberately do NOT compare
+   * tld/url (frames carry none; browser tld boundaries are enforced by window
+   * splitting) nor displayId (the frame's displayId is the capture target,
+   * which can differ from the focused-window display on multi-display setups).
+   *
+   * Frames with no app stamp are always kept (backward compatible: pre-fix
+   * frames, platforms that don't stamp yet, and frames the daemon couldn't
+   * resolve). The filter can also be disabled wholesale via config.
+   */
+  private frameAppMatchesContext(frame: Frame, context: ActivityContext): boolean {
+    if (!this.config.enableFrameAppFilter) return true
+    if (frame.appName === undefined && frame.bundleId === undefined) return true
+
+    return frame.bundleId && context.bundleId
+      ? frame.bundleId === context.bundleId
+      : frame.appName === context.appName
+  }
+
   private deriveWindowContext(events: InteractionContext[]): ActivityContext | null {
     const recentEvents = [...events].reverse()
     const activeWindowEvent = recentEvents.find((event) => event.activeWindow)
@@ -479,10 +511,16 @@ export class ActivityProducer {
     }
   }
 
-  private getFramesInRange(startTimestamp: number, endTimestamp: number): StreamRecord<Frame>[] {
+  private getFramesInRange(
+    startTimestamp: number,
+    endTimestamp: number,
+    context: ActivityContext,
+  ): StreamRecord<Frame>[] {
     return this.frameBuffer.filter(
       (record) =>
-        record.payload.timestamp >= startTimestamp && record.payload.timestamp <= endTimestamp,
+        record.payload.timestamp >= startTimestamp &&
+        record.payload.timestamp <= endTimestamp &&
+        this.frameAppMatchesContext(record.payload, context),
     )
   }
 

--- a/src/main/activity-types.ts
+++ b/src/main/activity-types.ts
@@ -42,6 +42,11 @@ export interface ActivityProducerConfig {
   frameBufferRetentionMs: number
   eventConsumerId: string
   frameConsumerId: string
+  // When true, a frame stamped with a frontmost app that doesn't match a
+  // window's derived context is kept out of that window (stops screenshots
+  // leaking across an app boundary). Kill-switch: set false to disable the
+  // filter without a native rebuild. Unstamped frames are always kept.
+  enableFrameAppFilter: boolean
 }
 
 export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
@@ -53,5 +58,6 @@ export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
     frameBufferRetentionMs: ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS * 2,
     eventConsumerId: 'activity-producer:event-stream',
     frameConsumerId: 'activity-producer:frame-stream',
+    enableFrameAppFilter: true,
   }
 }

--- a/src/main/activity-types.ts
+++ b/src/main/activity-types.ts
@@ -47,6 +47,12 @@ export interface ActivityProducerConfig {
   // leaking across an app boundary). Kill-switch: set false to disable the
   // filter without a native rebuild. Unstamped frames are always kept.
   enableFrameAppFilter: boolean
+  // When true, drop an activity's last frame when it's finalized because a
+  // different app took over. That trailing frame is captured in the sub-second
+  // skew between screen compositing and the frontmost-app signal, so it tends to
+  // already show the *next* app (a one-frame "transition bleed"). Never empties
+  // an activity (only drops when it has more than one frame).
+  dropAppSwitchTrailingFrame: boolean
 }
 
 export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
@@ -59,5 +65,6 @@ export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
     eventConsumerId: 'activity-producer:event-stream',
     frameConsumerId: 'activity-producer:frame-stream',
     enableFrameAppFilter: true,
+    dropAppSwitchTrailingFrame: true,
   }
 }

--- a/src/main/recorder/native-screenshot.ts
+++ b/src/main/recorder/native-screenshot.ts
@@ -21,6 +21,10 @@ export interface CapturedFrame {
   width: number
   height: number
   displayId: number
+  // Frontmost app at the grab instant, stamped by the native daemon. Absent
+  // when the daemon could not resolve it (or on platforms that don't stamp yet).
+  appName?: string
+  bundleId?: string
 }
 
 export interface CaptureBackendConfig {

--- a/src/main/recorder/screen-capturer.ts
+++ b/src/main/recorder/screen-capturer.ts
@@ -17,6 +17,11 @@ export interface Frame {
   height: number
   displayId: number
   sequenceNumber: number
+  // Frontmost app at the grab instant (carried through from the native daemon).
+  // Used by the ActivityProducer to keep a frame out of a window whose app
+  // doesn't match. Absent for unstamped frames (kept as-is).
+  appName?: string
+  bundleId?: string
 }
 
 export class ScreenCapturer {

--- a/src/main/recorder/swift/screenshot.swift
+++ b/src/main/recorder/swift/screenshot.swift
@@ -189,6 +189,34 @@ func resolveDisplayId(_ requestedDisplayId: UInt32?) throws -> CGDirectDisplayID
     return displays[0]
 }
 
+// MARK: - Frontmost app tracking
+
+/// Caches the system-wide frontmost app, updated on the main run loop via an
+/// NSWorkspace notification, so the SCStreamOutput callback (which runs on a
+/// background queue) can read it cheaply at the grab instant. Identifiers match
+/// the app-watcher daemon (localizedName + bundleIdentifier) so the downstream
+/// frame/app matching in ActivityProducer compares like-for-like.
+final class FrontmostAppTracker {
+    private let lock = NSLock()
+    private var appName: String?
+    private var bundleId: String?
+
+    func update(_ app: NSRunningApplication?) {
+        lock.lock()
+        defer { lock.unlock() }
+        appName = app?.localizedName
+        bundleId = app?.bundleIdentifier
+    }
+
+    func snapshot() -> (appName: String?, bundleId: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (appName, bundleId)
+    }
+}
+
+let frontmostTracker = FrontmostAppTracker()
+
 // MARK: - Autonomous ScreenCaptureKit Daemon
 
 class AutonomousCapture: NSObject, SCStreamOutput {
@@ -327,6 +355,7 @@ class AutonomousCapture: NSObject, SCStreamOutput {
         let quality = self.config.quality
         let outputDir = self.config.outputDir
         let captureTimestamp = Int(Date().timeIntervalSince1970 * 1000)
+        let frontmost = frontmostTracker.snapshot()
         let droppedFrames = takeDroppedFrameCount()
         shouldReleaseSemaphore = false
 
@@ -346,13 +375,21 @@ class AutonomousCapture: NSObject, SCStreamOutput {
                     fputs("[daemon] Dropped \(droppedFrames) frame(s) while previous capture was still being written\n", stderr)
                 }
 
-                let payload: [String: Any] = [
+                var payload: [String: Any] = [
                     "filepath": filepath,
                     "timestamp": captureTimestamp,
                     "width": resized.width,
                     "height": resized.height,
                     "displayId": Int(displayId),
                 ]
+                // Stamp the grab-time frontmost app. Omit keys when unknown
+                // (no NSNull) — the consumer treats absent app info as "keep".
+                if let name = frontmost.appName, !name.isEmpty {
+                    payload["appName"] = name
+                }
+                if let bid = frontmost.bundleId, !bid.isEmpty {
+                    payload["bundleId"] = bid
+                }
                 emitJSON(payload)
             } catch {
                 fputs("[daemon] Frame write failed: \(error)\n", stderr)
@@ -411,7 +448,18 @@ try FileManager.default.createDirectory(
 
 let capture = AutonomousCapture(config: config)
 
-let semaphore = DispatchSemaphore(value: 0)
+// Track the frontmost app on the main run loop so every captured frame can be
+// stamped with the app on screen at the grab instant (see FrontmostAppTracker).
+// Same NSWorkspace source as app-watcher.swift, so identifiers match.
+let workspaceCenter = NSWorkspace.shared.notificationCenter
+workspaceCenter.addObserver(forName: NSWorkspace.didActivateApplicationNotification,
+                            object: nil, queue: .main) { notification in
+    let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+    frontmostTracker.update(app ?? NSWorkspace.shared.frontmostApplication)
+}
+// Seed with the app focused at launch — NSWorkspace only notifies on *changes*.
+frontmostTracker.update(NSWorkspace.shared.frontmostApplication)
+
 Task {
     do {
         try await capture.startStream()
@@ -422,4 +470,8 @@ Task {
     // Start listening for stdin commands
     listenForCommands(capture: capture)
 }
-semaphore.wait()
+
+// Keep the process alive AND service the main run loop so the workspace observer
+// above fires — NSWorkspace notifications are delivered on the main run loop, and
+// a bare DispatchSemaphore.wait() would block the thread without running it.
+RunLoop.main.run()

--- a/src/main/recorder/swift/screenshot.swift
+++ b/src/main/recorder/swift/screenshot.swift
@@ -28,6 +28,32 @@ func fail(_ message: String, exitCode: Int32 = 1) -> Never {
     exit(exitCode)
 }
 
+/// Filesystem-safe slug for an app name so it can go in a screenshot filename,
+/// e.g. "Google Chrome" -> "google-chrome". Lowercases, replaces any run of
+/// non-alphanumeric characters with a single dash, trims dashes, and caps the
+/// length. Returns nil when nothing usable remains.
+func appSlug(_ name: String?) -> String? {
+    guard let name = name else { return nil }
+    let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789")
+    var slug = ""
+    var lastWasDash = false
+    for scalar in name.lowercased().unicodeScalars {
+        if allowed.contains(scalar) {
+            slug.unicodeScalars.append(scalar)
+            lastWasDash = false
+        } else if !lastWasDash {
+            slug.append("-")
+            lastWasDash = true
+        }
+    }
+    let dashes = CharacterSet(charactersIn: "-")
+    slug = slug.trimmingCharacters(in: dashes)
+    if slug.count > 40 {
+        slug = String(slug.prefix(40)).trimmingCharacters(in: dashes)
+    }
+    return slug.isEmpty ? nil : slug
+}
+
 // MARK: - CLI Argument Parsing
 
 struct DaemonConfig {
@@ -364,7 +390,13 @@ class AutonomousCapture: NSObject, SCStreamOutput {
                 self.pendingWriteSemaphore.signal()
             }
 
-            let filename = "frame-\(captureTimestamp).jpg"
+            // Include the grab-time app in the name so raw frames are legible on
+            // disk, e.g. "frame-1781008339005-google-chrome.jpg". Falls back to
+            // the bare timestamped name when the app is unknown.
+            let slug = appSlug(frontmost.appName)
+            let filename =
+                slug.map { "frame-\(captureTimestamp)-\($0).jpg" }
+                ?? "frame-\(captureTimestamp).jpg"
             let filepath = (outputDir as NSString).appendingPathComponent(filename)
 
             do {


### PR DESCRIPTION
## Problem

Screenshots ("frames") sometimes attach to the **wrong** activity (wrong app) — most visibly at app-switch boundaries, where an activity's screenshot shows a different app than its label.

## Root cause

The `ActivityProducer` matches frames to an `EventWindow` **purely by timestamp range**, while the window's app identity is derived separately from interaction events. Windows split on `app_change` at the *reported* switch time, which lags the true switch by the app-watcher's notification + IPC latency. A frame grabbed just after the true switch but before the reported one lands in the old app's window range and is mis-attributed. Because the cause is reporting latency, no signal derived from that same timeline can detect it.

## Changes (3 commits)

**1. Stamp frames with the grab-time app (`9a10456`)** — the macOS screenshot daemon now observes the frontmost app at the grab instant (independent of the app-watcher) via an `NSWorkspace` notification cached on a serviced main run loop (`semaphore.wait()` → `RunLoop.main.run()`), read under a lock in the capture callback. Each frame carries `appName`/`bundleId` (omitted when unknown). The producer excludes a candidate frame from a window when the frame is app-stamped and its app doesn't match the window context (bundleId-preferred, appName fallback, reusing `canMergeContexts`' rule). App-less frames are always kept → backward compatible, no-op on Windows. Gated by an `enableFrameAppFilter` kill-switch. In-memory only (frames live in `InMemoryStream`), so no schema/migration.

**2. App name in raw filenames (`e5388e1`)** — raw frames are now `frame-<timestamp>-<app-slug>.jpg` (e.g. `frame-…-google-chrome.jpg`) so they're legible on disk. `filepath` stays opaque to consumers (cleanup deletes by path, the stale sweep matches by extension + mtime), so nothing downstream changes.

**3. Drop the trailing transition-bleed frame (`0f567b1`)** — at a switch, the screen composites the new app a beat before the frontmost signal updates, so the outgoing activity's *last* frame tends to already show the next app (a one-frame "transition bleed"). The stamp-based filter can't catch it (the frame is correctly stamped with the outgoing app), so when an activity is finalized by a **real app change**, its latest frame is dropped. Only fires on actual app changes (same-app tld/display splits, `max_duration`, gap, flush keep all frames) and never empties an activity. Gated by `dropAppSwitchTrailingFrame` (default true).

## Tests

12 new `activity-producer.test.ts` cases (filter exclude/keep, bundleId vs appName precedence, frameless-window finalize, Unknown-context, kill-switch, trailing-frame drop / disabled / same-app boundary). Full suite **722 passed / 0 failed**; lint + prettier clean; Swift daemon compiles.

## Known limitations (macOS-only v1)

- A *single*-frame activity at a switch keeps its one frame (we never empty an activity).
- Only the *trailing* bleed is handled; a leading bleed (first frame of the new activity showing the old app) would need separate handling if observed.
- The stamp is the *global* frontmost app; a cross-display switch can drop a frame from the previous app during the ~1-interval capture retarget (a frame loss, never a leak).
- Windows keeps timestamp-only behaviour (no app stamp yet) — clean follow-up.

## Verification

`npm run test` / `npm run lint`; rebuild the Swift daemon (`npm run build:swift`) and run dev with `DEBUG_PIPELINE` to retain raw frames; Cmd-Tab between two apps and confirm each activity's screenshots belong to its own app, with no transition bleed on the final frame.

---

> **Stacked PR:** based on `fix/interaction-session-debounce` (not yet on `main`) — these changes build on its activity-producer work (`6c2a238`). The diff here is exactly the 3 commits above. GitHub will retarget to `main` once the parent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)