### PR TITLE
Harden interaction sessions & activity boundaries (+ DEBUG_PIPELINE tooling)

### DIFF
--- a/src/main/activity-producer.test.ts
+++ b/src/main/activity-producer.test.ts
@@ -17,7 +17,11 @@ vi.mock('./logger', () => ({
   },
 }))
 
-function makeFrame(timestamp: number, sequenceNumber: number): Frame {
+function makeFrame(
+  timestamp: number,
+  sequenceNumber: number,
+  app?: { appName: string; bundleId?: string },
+): Frame {
   return {
     filepath: `frame-${sequenceNumber}.png`,
     timestamp,
@@ -25,6 +29,7 @@ function makeFrame(timestamp: number, sequenceNumber: number): Frame {
     height: 720,
     displayId: 1,
     sequenceNumber,
+    ...(app ?? {}),
   }
 }
 
@@ -491,6 +496,471 @@ describe('ActivityProducer', () => {
     expect(producer.getStats().droppedUnknownContextWindows).toBe(0)
     expect(producer.getStats().droppedNoFrameWindows).toBe(1)
     expect(noContextOffset).toBeLessThan(noFrameOffset)
+  })
+
+  it('excludes a frame whose stamped app does not match the window context', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_000, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_200, 1, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].context.appName).toBe('Code')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(1)
+  })
+
+  it('retains an app-less (unstamped) frame regardless of context', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(makeFrame(1_000, 0)) // no app stamp
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames).toHaveLength(1)
+  })
+
+  it('matches on appName when the frame carries no bundleId', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(makeFrame(1_000, 0, { appName: 'Code' })) // matches by appName
+    await frameStream.append(makeFrame(1_200, 1, { appName: 'Slack' })) // excluded by appName
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+  })
+
+  it('prefers bundleId: excludes a frame whose bundleId differs even if appName matches', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(makeFrame(1_000, 0, { appName: 'Helper', bundleId: 'com.a' }))
+    await frameStream.append(makeFrame(1_200, 1, { appName: 'Helper', bundleId: 'com.b' }))
+    await eventStream.append(
+      makeWindow({
+        id: 'helper-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: { title: 'A', processName: 'Helper', bundleId: 'com.a' },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+  })
+
+  it('treats a window whose only frames are app-mismatched as frameless and finalizes the incompatible pending activity', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_500, 0, { appName: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }),
+    )
+    // Lands in W2's time range but is stamped with the PREVIOUS app (the leak):
+    // excluded from the Electron window, leaving it frameless.
+    await frameStream.append(
+      makeFrame(2_100, 1, { appName: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }),
+    )
+
+    await eventStream.append(
+      makeWindow({
+        id: 'ghostty',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'session',
+              processName: 'Ghostty',
+              bundleId: 'com.mitchellh.ghostty',
+            },
+          }),
+          makeEvent(1_600, 'scroll'),
+        ],
+      }),
+    )
+
+    const lastOffset = await eventStream.append(
+      makeWindow({
+        id: 'electron',
+        startTimestamp: 2_000,
+        endTimestamp: 2_200,
+        closedBy: 'gap',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'MemoryLane',
+              processName: 'Electron',
+              bundleId: 'com.github.Electron',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(
+      () => activities.length === 1 && producer.getStats().droppedAllFramesFilteredWindows === 1,
+      'Expected the Ghostty activity to emit and the app-mismatched Electron window to drop',
+    )
+    expect(activities.map((a) => a.context.appName)).toEqual(['Ghostty'])
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+    expect(producer.getStats().emittedActivities).toBe(1)
+    // The Electron window had a frame in range but it was app-filtered out, so it
+    // counts as all-filtered, not genuinely no-frame.
+    expect(producer.getStats().droppedNoFrameWindows).toBe(0)
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(1)
+
+    // The incompatible frameless window finalized the pending activity, so the
+    // event offsets ack without an explicit flush/stop.
+    await waitFor(
+      async () => (await eventStream.getAck('test:event')) === lastOffset,
+      'Expected event offsets to ack after the pending activity is finalized',
+    )
+  })
+
+  it('drops a concrete-app-stamped frame in an Unknown-context window', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_050, 0, { appName: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'unknown',
+        startTimestamp: 1_000,
+        endTimestamp: 1_100,
+        closedBy: 'flush',
+        events: [makeEvent(1_020, 'keyboard')], // no app_change -> 'Unknown' context
+      }),
+    )
+
+    await waitFor(
+      () => producer.getStats().droppedAllFramesFilteredWindows === 1,
+      'Expected the Unknown-context window to drop the mismatched frame',
+    )
+    expect(activities).toHaveLength(0)
+    expect(producer.getStats().droppedNoFrameWindows).toBe(0)
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(1)
+  })
+
+  it('keeps a mismatched frame when the app filter is disabled', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer({
+      enableFrameAppFilter: false,
+    })
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_000, 0, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames).toHaveLength(1)
+  })
+
+  it('drops the trailing frame when an activity is finalized by a different app', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_200, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_800, 1, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(2_500, 2, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+
+    await eventStream.append(
+      makeWindow({
+        id: 'code',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'Repo', processName: 'Code', bundleId: 'com.microsoft.VSCode' },
+          }),
+          makeEvent(1_500, 'scroll'),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'slack',
+        startTimestamp: 2_000,
+        endTimestamp: 3_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: {
+              title: 'general',
+              processName: 'Slack',
+              bundleId: 'com.tinyspeck.slackmacgap',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 2, 'Expected two activities')
+    expect(activities.map((a) => a.context.appName)).toEqual(['Code', 'Slack'])
+    // Code's trailing frame (1_800, offset 1) is the transition bleed -> dropped.
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+    expect(activities[0].provenance.frameOffsets).toEqual([0])
+    // Slack is finalized by flush (not an app switch), so its frame is kept.
+    expect(activities[1].frames.map((f) => f.frame.filepath)).toEqual(['frame-2.png'])
+    expect(producer.getStats().trailingFramesDropped).toBe(1)
+  })
+
+  it('keeps the trailing frame when dropAppSwitchTrailingFrame is disabled', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer({
+      dropAppSwitchTrailingFrame: false,
+    })
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_200, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_800, 1, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'Repo', processName: 'Code', bundleId: 'com.microsoft.VSCode' },
+          }),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'slack',
+        startTimestamp: 2_000,
+        endTimestamp: 3_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: {
+              title: 'general',
+              processName: 'Slack',
+              bundleId: 'com.tinyspeck.slackmacgap',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(
+      () => activities.some((a) => a.context.appName === 'Code'),
+      'Expected the Code activity',
+    )
+    const code = activities.find((a) => a.context.appName === 'Code')!
+    expect(code.frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png', 'frame-1.png'])
+    expect(producer.getStats().trailingFramesDropped).toBe(0)
+  })
+
+  it('does not drop the trailing frame on a same-app tld boundary', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    const chrome = { appName: 'Google Chrome', bundleId: 'com.google.Chrome' }
+    await frameStream.append(makeFrame(1_200, 0, chrome))
+    await frameStream.append(makeFrame(1_800, 1, chrome))
+    await frameStream.append(makeFrame(2_500, 2, chrome)) // lands in the second (other.org) window
+
+    await eventStream.append(
+      makeWindow({
+        id: 'chrome-a',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'A', ...chrome, url: 'https://example.com/a' },
+          }),
+          makeEvent(1_500, 'scroll'),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'chrome-b',
+        startTimestamp: 2_000,
+        endTimestamp: 3_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: { title: 'B', ...chrome, url: 'https://other.org/b' },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 2, 'Expected two activities split by tld')
+    // Same app across the boundary -> no transition bleed -> both frames kept.
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual([
+      'frame-0.png',
+      'frame-1.png',
+    ])
   })
 
   // Regression for the "trailing pending activity" data loss: the producer keeps

--- a/src/main/activity-producer.test.ts
+++ b/src/main/activity-producer.test.ts
@@ -6,6 +6,7 @@ import type { StreamSubscription } from './streams/stream'
 import type { Frame } from './recorder/screen-capturer'
 import type { Activity } from './activity-types'
 import { ActivityProducer } from './activity-producer'
+import { ActivityExtractor } from './activity-extractor'
 
 vi.mock('./logger', () => ({
   default: {
@@ -490,6 +491,228 @@ describe('ActivityProducer', () => {
     expect(producer.getStats().droppedUnknownContextWindows).toBe(0)
     expect(producer.getStats().droppedNoFrameWindows).toBe(1)
     expect(noContextOffset).toBeLessThan(noFrameOffset)
+  })
+
+  // Regression for the "trailing pending activity" data loss: the producer keeps
+  // a single pendingActivity. It used to be emitted only when a LATER frame-backed
+  // window with an incompatible context arrived (-> context_change finalize) or on
+  // an explicit flush/stop. A no-frame successor is dropped BEFORE
+  // buildWindowChunks/integrateChunk run, so it never finalized the pending
+  // activity, and the last frame-backed window of a session was stranded and lost.
+  // Now a frameless window with an incompatible context still finalizes the
+  // pending activity.
+  //
+  // Mirrors a real recording: App-X (Unknown) -> Ghostty (frames) -> switch to a
+  // frameless window at session end. Both App-X and Ghostty must be persisted.
+  it('finalizes the trailing pending activity when its successor is an incompatible no-frame window', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+
+    // Frames for the first two windows; the trailing window gets none.
+    await frameStream.append(makeFrame(1_500, 0)) // App-X window
+    await frameStream.append(makeFrame(2_500, 1)) // Ghostty window
+    await frameStream.append(makeFrame(3_500, 2)) // Ghostty window
+
+    // W1 - pre-existing focus, no app_change inside it -> 'Unknown' context.
+    // Closed by the switch to Ghostty (the app_change lands in the NEXT window).
+    await eventStream.append(
+      makeWindow({
+        id: 'appx',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [makeEvent(1_500, 'scroll')],
+      }),
+    )
+
+    // W2 - Ghostty: frame-backed, valid context, well above min duration.
+    // Its arrival is what flushes W1 out (incompatible context), and it then
+    // becomes the trailing pendingActivity.
+    await eventStream.append(
+      makeWindow({
+        id: 'ghostty',
+        startTimestamp: 2_000,
+        endTimestamp: 4_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'activity-boundary-bugs',
+              processName: 'Ghostty',
+              bundleId: 'com.mitchellh.ghostty',
+            },
+          }),
+          makeEvent(3_000, 'scroll'),
+        ],
+      }),
+    )
+
+    // W3 - switch to a context whose window has no frames yet (end of session).
+    // Dropped as a no-frame window WITHOUT flushing the pending Ghostty activity.
+    const lastOffset = await eventStream.append(
+      makeWindow({
+        id: 'electron',
+        startTimestamp: 4_000,
+        endTimestamp: 4_200,
+        closedBy: 'gap',
+        events: [
+          makeEvent(4_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'MemoryLane',
+              processName: 'Electron',
+              bundleId: 'com.github.Electron',
+            },
+          }),
+        ],
+      }),
+    )
+
+    // All three windows processed - WITHOUT any explicit flush/stop: App-X
+    // emitted, Ghostty finalized by the incompatible frameless successor, and
+    // the trailing no-frame window dropped.
+    await waitFor(
+      () => activities.length === 2 && producer.getStats().droppedNoFrameWindows === 1,
+      'Expected both App-X and Ghostty to emit, and the trailing no-frame window to drop',
+    )
+
+    // Ghostty (frames + valid context + 2000ms duration) is persisted even though
+    // its only successor was a frameless window, instead of being stranded.
+    expect(activities.map((a) => a.context.appName)).toEqual(['Unknown', 'Ghostty'])
+    expect(activities[1].provenance.sourceWindowIds).toEqual(['ghostty'])
+    expect(producer.getStats().emittedActivities).toBe(2)
+
+    // The pending activity was finalized by the incompatible window, so its event
+    // offsets ack without needing a flush/stop.
+    await waitFor(
+      async () => (await eventStream.getAck('test:event')) === lastOffset,
+      'Expected event offsets to ack after the pending activity is finalized',
+    )
+  })
+
+  it('shutdown: trailing activities emitted at stop are still persisted by the extractor', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer({
+      minActivityDurationMs: 0,
+    })
+    const persisted: string[] = []
+    let releaseFirst: (() => void) | null = null
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let firstSeen = false
+
+    const extractor = new ActivityExtractor({
+      activityStream,
+      transformer: {
+        transform: async (a) => {
+          // Hold the FIRST activity's transform in-flight to mirror the real
+          // timing: the first activity's (slow LLM) transform is still running
+          // when capture stops and the trailing activities are emitted.
+          if (!firstSeen) {
+            firstSeen = true
+            await firstGate
+          }
+          return {
+            activityId: a.id,
+            startTimestamp: a.startTimestamp,
+            endTimestamp: a.endTimestamp,
+            appName: a.context.appName,
+            windowTitle: a.context.windowTitle ?? '',
+            tld: a.context.tld,
+            summary: '',
+            summaryModel: '',
+            ocrText: '',
+            vector: [0, 0, 0],
+          }
+        },
+      },
+      sink: {
+        persist: async ({ extracted }) => {
+          persisted.push(extracted.appName)
+        },
+      },
+      config: { consumerId: 'shutdown:x', maxConcurrent: 1, maxRetries: 0, retryBackoffMs: 0 },
+    })
+
+    await producer.start()
+    await extractor.start()
+
+    // App-X (no app_change -> Unknown), closed by switch to Ghostty.
+    await frameStream.append(makeFrame(1_500, 0))
+    await eventStream.append(
+      makeWindow({
+        id: 'appx',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [makeEvent(1_500, 'scroll')],
+      }),
+    )
+    // Ghostty, closed by switch to Electron.
+    await frameStream.append(makeFrame(2_500, 1))
+    await frameStream.append(makeFrame(3_500, 2))
+    await eventStream.append(
+      makeWindow({
+        id: 'ghostty',
+        startTimestamp: 2_000,
+        endTimestamp: 4_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'term',
+              processName: 'Ghostty',
+              bundleId: 'com.mitchellh.ghostty',
+            },
+          }),
+          makeEvent(3_000, 'scroll'),
+        ],
+      }),
+    )
+    // Electron (final app), closed by switch (becomes trailing pending).
+    await frameStream.append(makeFrame(4_500, 3))
+    await eventStream.append(
+      makeWindow({
+        id: 'electron',
+        startTimestamp: 4_000,
+        endTimestamp: 5_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(4_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'MemoryLane',
+              processName: 'Electron',
+              bundleId: 'com.github.Electron',
+            },
+          }),
+        ],
+      }),
+    )
+
+    // Wait until the first emitted activity (Unknown) is in-flight on the gate.
+    await waitFor(() => firstSeen, 'Expected the first activity transform to start')
+
+    // Mirror harness.stop(): producer first (flushes the trailing pending), then extractor.
+    const stopProducer = producer.stop()
+    releaseFirst?.()
+    await stopProducer
+    await extractor.stop()
+
+    // Every emitted activity must be persisted — nothing lost in the shutdown drain.
+    expect(persisted).toContain('Unknown')
+    expect(persisted).toContain('Ghostty')
+    expect(persisted).toContain('Electron')
   })
 
   it('enforces max activity duration while keeping each emitted activity frame-backed', async () => {

--- a/src/main/activity-producer.ts
+++ b/src/main/activity-producer.ts
@@ -207,6 +207,19 @@ export class ActivityProducer {
       log.info(
         `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: no frames in ${window.startTimestamp}-${window.endTimestamp}`,
       )
+      // A frameless window can neither seed nor extend an activity, but if its
+      // context is incompatible with the in-progress pendingActivity it still
+      // marks a real boundary. Finalize the pending activity here so it isn't
+      // stranded waiting for a frame-backed successor that may never arrive
+      // (e.g. the last app of a session, before capture stops). A compatible
+      // frameless window is left alone so the same activity keeps accruing.
+      if (
+        this.pendingActivity !== null &&
+        !this.canMergeContexts(this.pendingActivity.context, windowContext)
+      ) {
+        await this.finalizePendingActivity('context_change')
+        await this.flushDeferredEventAck()
+      }
       await this.markRecordProcessed(record.offset)
       await this.advanceFrameAck(window.endTimestamp)
       return

--- a/src/main/activity-producer.ts
+++ b/src/main/activity-producer.ts
@@ -17,8 +17,19 @@ const ACTIVITY_ID_NAMESPACE = uuidv5('memorylane:v2-activity', uuidv5.DNS)
 
 export interface ActivityProducerStats {
   emittedActivities: number
+  // Windows dropped because no frame fell in their time range at all.
   droppedNoFrameWindows: number
+  // Windows that had frames in their time range but every one was excluded by
+  // the grab-time app filter (the leak signature: in-range frames all stamped
+  // with a different app than the window context).
+  droppedAllFramesFilteredWindows: number
   droppedUnknownContextWindows: number
+  // Total frames kept out of a window by the grab-time app filter (includes the
+  // ones counted by droppedAllFramesFilteredWindows). A proxy for how often the
+  // leak the filter guards against actually fires in production.
+  framesExcludedByAppFilter: number
+  // Total trailing "transition bleed" frames dropped at app-switch boundaries.
+  trailingFramesDropped: number
 }
 
 interface ChunkContext {
@@ -64,7 +75,10 @@ export class ActivityProducer {
   private readonly stats: ActivityProducerStats = {
     emittedActivities: 0,
     droppedNoFrameWindows: 0,
+    droppedAllFramesFilteredWindows: 0,
     droppedUnknownContextWindows: 0,
+    framesExcludedByAppFilter: 0,
+    trailingFramesDropped: 0,
   }
 
   constructor(params: {
@@ -201,11 +215,25 @@ export class ActivityProducer {
       return
     }
 
-    const candidateFrames = this.getFramesInRange(window.startTimestamp, window.endTimestamp)
+    const { frames: candidateFrames, excludedByAppFilter } = this.getFramesInRange(
+      window.startTimestamp,
+      window.endTimestamp,
+      windowContext,
+    )
+    this.stats.framesExcludedByAppFilter += excludedByAppFilter
     if (candidateFrames.length === 0) {
-      this.stats.droppedNoFrameWindows++
+      // Distinguish "no frames captured in this window" from "frames were
+      // captured but all belonged to a different app" — the latter is the leak
+      // signature and worth tracking separately for diagnosis.
+      if (excludedByAppFilter > 0) {
+        this.stats.droppedAllFramesFilteredWindows++
+      } else {
+        this.stats.droppedNoFrameWindows++
+      }
       log.info(
-        `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: no frames in ${window.startTimestamp}-${window.endTimestamp}`,
+        `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: ` +
+          `${excludedByAppFilter > 0 ? `all ${excludedByAppFilter} frame(s) app-filtered out` : 'no frames'} ` +
+          `in ${window.startTimestamp}-${window.endTimestamp}`,
       )
       // A frameless window can neither seed nor extend an activity, but if its
       // context is incompatible with the in-progress pendingActivity it still
@@ -217,7 +245,7 @@ export class ActivityProducer {
         this.pendingActivity !== null &&
         !this.canMergeContexts(this.pendingActivity.context, windowContext)
       ) {
-        await this.finalizePendingActivity('context_change')
+        await this.finalizePendingActivity('context_change', { droppedToApp: windowContext })
         await this.flushDeferredEventAck()
       }
       await this.markRecordProcessed(record.offset)
@@ -299,6 +327,7 @@ export class ActivityProducer {
     if (!compatible) {
       await this.finalizePendingActivity(
         combinedDuration > this.config.maxActivityDurationMs ? 'max_duration' : 'context_change',
+        { droppedToApp: chunk.context },
       )
       await this.flushDeferredEventAck()
       this.pendingActivity = this.createPendingActivity(chunk)
@@ -363,8 +392,11 @@ export class ActivityProducer {
 
   private async finalizePendingActivity(
     reason: 'context_change' | 'max_duration' | 'flush',
+    options?: { droppedToApp?: ActivityContext },
   ): Promise<void> {
     if (this.pendingActivity === null) return
+
+    this.maybeDropTrailingBoundaryFrame(this.pendingActivity, options?.droppedToApp)
 
     const durationMs = this.pendingActivity.endTimestamp - this.pendingActivity.startTimestamp
     const eventOffsetsToAck = [...this.pendingActivity.provenance.eventWindowOffsets]
@@ -430,11 +462,7 @@ export class ActivityProducer {
       return false
     }
 
-    const sameApp =
-      left.bundleId && right.bundleId
-        ? left.bundleId === right.bundleId
-        : left.appName === right.appName
-    if (!sameApp) return false
+    if (!this.appsEqual(left, right)) return false
 
     const browser = isBrowserApp({
       processName: left.appName,
@@ -443,6 +471,67 @@ export class ActivityProducer {
     if (!browser) return true
     if (!left.tld || !right.tld) return false
     return left.tld === right.tld
+  }
+
+  /** App-identity equality: bundleId-preferred, appName fallback. */
+  private appsEqual(left: ActivityContext, right: ActivityContext): boolean {
+    return left.bundleId && right.bundleId
+      ? left.bundleId === right.bundleId
+      : left.appName === right.appName
+  }
+
+  /**
+   * Drop the activity's last frame when it's finalized because a *different* app
+   * took over. In the sub-second skew between screen compositing and the
+   * frontmost-app signal, that trailing frame tends to already show the next app
+   * (a one-frame "transition bleed"). Only drops on a real app change, and never
+   * empties an activity (keeps at least one frame).
+   */
+  private maybeDropTrailingBoundaryFrame(activity: Activity, successor?: ActivityContext): void {
+    if (!this.config.dropAppSwitchTrailingFrame) return
+    if (successor === undefined) return
+    if (this.appsEqual(activity.context, successor)) return
+    if (activity.frames.length <= 1) return
+
+    // Frames are kept sorted ascending by timestamp, so the latest is the bleed.
+    const dropped = activity.frames.pop()
+    if (dropped === undefined) return
+    this.stats.trailingFramesDropped++
+    activity.provenance.frameOffsets = activity.provenance.frameOffsets.filter(
+      (offset) => offset !== dropped.offset,
+    )
+    log.info(
+      `[ActivityProducer] Dropped trailing boundary frame ${dropped.frame.filepath} from ` +
+        `${activity.context.appName} activity (switch to ${successor.appName})`,
+    )
+  }
+
+  /**
+   * Whether a candidate frame belongs to a window's derived app context.
+   *
+   * The frame carries the frontmost app observed by the native daemon at the
+   * grab instant — an observation independent of the app-watcher's (lagging)
+   * event timeline. Comparing it against the window context catches frames that
+   * fall in a window's time range but were actually captured under a different
+   * app (the "leak" around an app switch).
+   *
+   * Only app identity is compared, mirroring the app half of canMergeContexts
+   * (bundleId-preferred, appName fallback). We deliberately do NOT compare
+   * tld/url (frames carry none; browser tld boundaries are enforced by window
+   * splitting) nor displayId (the frame's displayId is the capture target,
+   * which can differ from the focused-window display on multi-display setups).
+   *
+   * Frames with no app stamp are always kept (backward compatible: pre-fix
+   * frames, platforms that don't stamp yet, and frames the daemon couldn't
+   * resolve). The filter can also be disabled wholesale via config.
+   */
+  private frameAppMatchesContext(frame: Frame, context: ActivityContext): boolean {
+    if (!this.config.enableFrameAppFilter) return true
+    if (frame.appName === undefined && frame.bundleId === undefined) return true
+
+    return frame.bundleId && context.bundleId
+      ? frame.bundleId === context.bundleId
+      : frame.appName === context.appName
   }
 
   private deriveWindowContext(events: InteractionContext[]): ActivityContext | null {
@@ -479,11 +568,19 @@ export class ActivityProducer {
     }
   }
 
-  private getFramesInRange(startTimestamp: number, endTimestamp: number): StreamRecord<Frame>[] {
-    return this.frameBuffer.filter(
+  private getFramesInRange(
+    startTimestamp: number,
+    endTimestamp: number,
+    context: ActivityContext,
+  ): { frames: StreamRecord<Frame>[]; excludedByAppFilter: number } {
+    const inTimeRange = this.frameBuffer.filter(
       (record) =>
         record.payload.timestamp >= startTimestamp && record.payload.timestamp <= endTimestamp,
     )
+    const frames = inTimeRange.filter((record) =>
+      this.frameAppMatchesContext(record.payload, context),
+    )
+    return { frames, excludedByAppFilter: inTimeRange.length - frames.length }
   }
 
   private async waitForFramesToSettle(windowEndTimestamp: number): Promise<void> {

--- a/src/main/activity-types.ts
+++ b/src/main/activity-types.ts
@@ -42,6 +42,17 @@ export interface ActivityProducerConfig {
   frameBufferRetentionMs: number
   eventConsumerId: string
   frameConsumerId: string
+  // When true, a frame stamped with a frontmost app that doesn't match a
+  // window's derived context is kept out of that window (stops screenshots
+  // leaking across an app boundary). Kill-switch: set false to disable the
+  // filter without a native rebuild. Unstamped frames are always kept.
+  enableFrameAppFilter: boolean
+  // When true, drop an activity's last frame when it's finalized because a
+  // different app took over. That trailing frame is captured in the sub-second
+  // skew between screen compositing and the frontmost-app signal, so it tends to
+  // already show the *next* app (a one-frame "transition bleed"). Never empties
+  // an activity (only drops when it has more than one frame).
+  dropAppSwitchTrailingFrame: boolean
 }
 
 export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
@@ -53,5 +64,7 @@ export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
     frameBufferRetentionMs: ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS * 2,
     eventConsumerId: 'activity-producer:event-stream',
     frameConsumerId: 'activity-producer:frame-stream',
+    enableFrameAppFilter: true,
+    dropAppSwitchTrailingFrame: true,
   }
 }

--- a/src/main/event-capturer.late-events.test.ts
+++ b/src/main/event-capturer.late-events.test.ts
@@ -92,4 +92,52 @@ describe('EventCapturer late event handling', () => {
     expect(windows[1].startTimestamp).toBe(2_000)
     expect(windows[1].endTimestamp).toBe(2_000)
   })
+
+  it('emits windows in close order when capture stops while an earlier window is still in grace', async () => {
+    const appOf = (window: EventWindow): string | undefined =>
+      [...window.events].reverse().find((event) => event.activeWindow)?.activeWindow?.processName
+
+    // W1 (Unknown): keyboard, closed by the switch to Ghostty.
+    capturer.handleEvent(makeEvent({ type: 'keyboard', timestamp: 1_000 }))
+    capturer.handleEvent(
+      makeEvent({
+        type: 'app_change',
+        timestamp: 2_000,
+        activeWindow: { title: 'term', processName: 'ghostty' },
+      }),
+    )
+    // Let W1 finalize through its grace so it has the lowest offset.
+    vi.advanceTimersByTime(80)
+    await flushAsyncAppends()
+    expect(windows).toHaveLength(1)
+
+    // W2 (Ghostty): scroll, then switch to Electron — closes W2 and starts its grace.
+    capturer.handleEvent(makeEvent({ type: 'scroll', timestamp: 3_000 }))
+    capturer.handleEvent(
+      makeEvent({
+        type: 'app_change',
+        timestamp: 4_000,
+        activeWindow: { title: 'MemoryLane', processName: 'electron' },
+      }),
+    )
+
+    // Capture stops while W2 (Ghostty) is STILL in its late-event grace. The flush
+    // window (Electron) must not jump ahead of the not-yet-finalized Ghostty window.
+    capturer.flush()
+    // Drain the async append chain (the fix emits both Ghostty and Electron here).
+    for (let i = 0; i < 10 && windows.length < 3; i++) {
+      vi.advanceTimersByTime(80)
+      await flushAsyncAppends()
+    }
+    expect(windows).toHaveLength(3)
+
+    const ghosttyIdx = windows.findIndex((window) => appOf(window) === 'ghostty')
+    const electronIdx = windows.findIndex((window) => appOf(window) === 'electron')
+
+    expect(ghosttyIdx).toBeGreaterThanOrEqual(0)
+    expect(electronIdx).toBeGreaterThanOrEqual(0)
+    // Ghostty (closed first) must be emitted before the Electron flush window, so
+    // the producer processes it before Electron's frame-ack trims its frames.
+    expect(ghosttyIdx).toBeLessThan(electronIdx)
+  })
 })

--- a/src/main/event-capturer.ts
+++ b/src/main/event-capturer.ts
@@ -252,7 +252,21 @@ export class EventCapturer {
     const index = this.pendingWindows.findIndex((window) => window.id === windowId)
     if (index < 0) return
 
-    const [pendingWindow] = this.pendingWindows.splice(index, 1)
+    // Finalize this window AND every earlier still-pending one, oldest first, so
+    // windows always reach the stream in close (chronological) order. Otherwise a
+    // window finalized with no grace delay — e.g. the flush window on
+    // capture-stop — can jump ahead of an earlier app_change window still in its
+    // late-event grace. The producer would then process the later window first
+    // and advance its frame ack past the earlier window's range, dropping that
+    // earlier window for "no frames" even though it had screenshots.
+    for (let i = 0; i <= index; i++) {
+      const pendingWindow = this.pendingWindows.shift()
+      if (pendingWindow === undefined) break
+      this.emitPendingWindow(pendingWindow)
+    }
+  }
+
+  private emitPendingWindow(pendingWindow: PendingWindow): void {
     if (pendingWindow.finalizeTimer !== null) {
       clearTimeout(pendingWindow.finalizeTimer)
       pendingWindow.finalizeTimer = null

--- a/src/main/interaction-event-debug-dump.test.ts
+++ b/src/main/interaction-event-debug-dump.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { InteractionEventDebugDumper } from './interaction-event-debug-dump'
+import type { InteractionContext } from '../shared/types'
+
+describe('InteractionEventDebugDumper', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ml-interaction-dump-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('appends one JSONL record per event, carrying dumpedAt and lagMs', () => {
+    const dumper = new InteractionEventDebugDumper(dir)
+    const scroll: InteractionContext = {
+      type: 'scroll',
+      timestamp: 1000,
+      scrollAmount: 5,
+      durationMs: 200,
+    }
+    const appChange: InteractionContext = { type: 'app_change', timestamp: 2000 }
+
+    dumper.dump(scroll)
+    dumper.dump(appChange)
+
+    const lines = fs.readFileSync(dumper.getFilePath(), 'utf8').trim().split('\n')
+    expect(lines).toHaveLength(2)
+
+    const first = JSON.parse(lines[0])
+    expect(first).toMatchObject({
+      type: 'scroll',
+      timestamp: 1000,
+      scrollAmount: 5,
+      durationMs: 200,
+    })
+    expect(typeof first.dumpedAt).toBe('number')
+    expect(first.lagMs).toBe(first.dumpedAt - 1000)
+
+    const second = JSON.parse(lines[1])
+    expect(second).toMatchObject({ type: 'app_change', timestamp: 2000 })
+    expect(second.lagMs).toBe(second.dumpedAt - 2000)
+  })
+
+  it('creates the target directory if it does not exist', () => {
+    const nested = path.join(dir, 'a', 'b')
+    const dumper = new InteractionEventDebugDumper(nested)
+    dumper.dump({ type: 'click', timestamp: 1 })
+    expect(fs.existsSync(dumper.getFilePath())).toBe(true)
+  })
+})

--- a/src/main/interaction-event-debug-dump.ts
+++ b/src/main/interaction-event-debug-dump.ts
@@ -1,0 +1,41 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import log from './logger'
+import type { InteractionContext } from '../shared/types'
+
+/**
+ * Appends every emitted InteractionContext to a JSONL file in the debug-pipeline
+ * directory, for inspecting the raw interaction stream (timestamps, durations,
+ * interim scroll/typing sub-windows, app changes).
+ *
+ * Dev-only: wired in runtime.ts behind the same `DEBUG_PIPELINE` gate as the
+ * semantic round-trip dumper. Each record carries `dumpedAt` (wall-clock at dump
+ * time) and `lagMs` (dumpedAt - event.timestamp) so the debounce delay between
+ * when an interaction occurred and when it was emitted is visible at a glance.
+ */
+export class InteractionEventDebugDumper {
+  private readonly filePath: string
+
+  constructor(rootDir: string, fileName = 'interaction-events.jsonl') {
+    fs.mkdirSync(rootDir, { recursive: true })
+    this.filePath = path.join(rootDir, fileName)
+    log.info(`[InteractionEventDebugDumper] Writing interaction events to ${this.filePath}`)
+  }
+
+  getFilePath(): string {
+    return this.filePath
+  }
+
+  dump(event: InteractionContext): void {
+    try {
+      const dumpedAt = Date.now()
+      const record = { dumpedAt, lagMs: dumpedAt - event.timestamp, ...event }
+      fs.appendFileSync(this.filePath, `${JSON.stringify(record)}\n`, 'utf8')
+    } catch (error) {
+      log.warn(
+        '[InteractionEventDebugDumper] Failed to write interaction event',
+        error instanceof Error ? error.message : String(error),
+      )
+    }
+  }
+}

--- a/src/main/logger-electron.ts
+++ b/src/main/logger-electron.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron'
+import * as path from 'path'
 import { setLogger } from './logger'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -6,8 +7,20 @@ const electronLog = require('electron-log/main')
 const isDev = !app.isPackaged
 const level = isDev ? 'debug' : 'info'
 
-electronLog.transports.file.level = isDev ? false : level
+// File logging is normally off in dev (console is primary). Enable it when
+// debugging the pipeline so the run's logs — including otherwise console-only
+// extractor dead-letters — are captured to a file for inspection, written next
+// to the dev DB and screenshots. Packaged builds always log to file.
+const devFileLogging =
+  isDev && Boolean(process.env.DEBUG_PIPELINE || process.env.MEMORYLANE_DEV_FILE_LOG)
+
+electronLog.transports.file.level = isDev ? (devFileLogging ? level : false) : level
 electronLog.transports.console.level = level
 electronLog.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}] [{level}] {text}'
+
+if (devFileLogging) {
+  electronLog.transports.file.resolvePathFn = (): string =>
+    path.join(app.getPath('userData'), 'memorylane-dev.log')
+}
 
 setLogger(electronLog)

--- a/src/main/pipeline-harness.test.ts
+++ b/src/main/pipeline-harness.test.ts
@@ -71,6 +71,16 @@ vi.mock('./recorder/native-screenshot', () => ({
   }),
 }))
 
+const { cleanupSpy, sweepSpy } = vi.hoisted(() => ({
+  cleanupSpy: vi.fn(),
+  sweepSpy: vi.fn(),
+}))
+
+vi.mock('./activity-cleanup', () => ({
+  cleanupActivityFiles: cleanupSpy,
+  sweepStaleFiles: sweepSpy,
+}))
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -101,6 +111,8 @@ describe('pipeline harness', () => {
       clearInterval(mockBackendState.frameTimer)
       mockBackendState.frameTimer = null
     }
+    cleanupSpy.mockClear()
+    sweepSpy.mockClear()
     for (const sub of subscriptions.splice(0)) {
       sub.unsubscribe()
     }
@@ -275,6 +287,80 @@ describe('pipeline harness', () => {
     expect(transformedActivityIds).toHaveLength(1)
     expect(persistedActivityIds).toEqual(transformedActivityIds)
     expect(extractor.getStats().succeeded).toBe(1)
+
+    // Default behavior: each completed activity has its frames/video cleaned up.
+    await waitFor(
+      () => cleanupSpy.mock.calls.length === 1,
+      'Expected cleanupActivityFiles to run for the completed activity',
+    )
+    expect(cleanupSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: transformedActivityIds[0] }),
+      expect.any(String),
+    )
+
+    await harness.stop()
+  })
+
+  it('retains screenshots (skips per-activity cleanup) when retainScreenshots is set', async () => {
+    const persistedActivityIds: string[] = []
+
+    const harness = createPipelineHarness({
+      outputDir: path.join(process.cwd(), '.tmp-harness-retain'),
+      frameIntervalMs: 10,
+      retainScreenshots: true,
+      activityProducerConfig: {
+        frameJoinGraceMs: 0,
+        maxFrameWaitMs: 0,
+        minActivityDurationMs: 0,
+        eventConsumerId: 'harness:event:retain',
+        frameConsumerId: 'harness:frame:retain',
+      },
+      activityExtractorConfig: {
+        consumerId: 'harness:activity-extractor:retain',
+        maxConcurrent: 1,
+        maxRetries: 0,
+        retryBackoffMs: 0,
+      },
+      extractorTransformer: {
+        transform: async (activity): Promise<ExtractedActivity> => ({
+          activityId: activity.id,
+          startTimestamp: activity.startTimestamp,
+          endTimestamp: activity.endTimestamp,
+          appName: activity.context.appName,
+          windowTitle: activity.context.windowTitle ?? '',
+          tld: activity.context.tld,
+          summary: `summary:${activity.id}`,
+          summaryModel: '',
+          ocrText: `ocr:${activity.id}`,
+          vector: [0.1, 0.2, 0.3],
+        }),
+      },
+      extractorSink: {
+        persist: async ({ activity }) => {
+          persistedActivityIds.push(activity.id)
+        },
+      },
+    })
+
+    await harness.start()
+
+    harness.handleEvent({
+      type: 'app_change',
+      timestamp: Date.now(),
+      activeWindow: {
+        title: 'Retain Window',
+        processName: 'Code',
+        bundleId: 'com.microsoft.VSCode',
+      },
+    })
+    await sleep(60)
+    harness.handleEvent({ type: 'keyboard', timestamp: Date.now(), keyCount: 2, durationMs: 60 })
+    harness.eventCapturer.flush()
+
+    await waitFor(() => persistedActivityIds.length >= 1, 'Expected the activity to persist')
+    // Let onTaskComplete run; with retention on it must NOT clean up files.
+    await sleep(50)
+    expect(cleanupSpy).not.toHaveBeenCalled()
 
     await harness.stop()
   })

--- a/src/main/pipeline-harness.ts
+++ b/src/main/pipeline-harness.ts
@@ -12,6 +12,7 @@ import type {
 import { InMemoryStream } from './streams/in-memory-stream'
 import { ScreenCapturer, type Frame } from './recorder/screen-capturer'
 import { cleanupActivityFiles, sweepStaleFiles } from './activity-cleanup'
+import log from './logger'
 
 export interface PipelineHarness {
   frameStream: InMemoryStream<Frame>
@@ -38,7 +39,12 @@ export function createPipelineHarness(params: {
   activityExtractorConfig?: Partial<ActivityExtractorConfig>
   extractorTransformer?: ActivityTransformer
   extractorSink?: ActivitySink
+  // Debug-only: when true, processed activities' frames/videos are NOT deleted
+  // and the periodic stale-file sweep is disabled, so screenshots survive for
+  // inspection. Lets the screenshots dir grow unbounded — dev use only.
+  retainScreenshots?: boolean
 }): PipelineHarness {
+  const retainScreenshots = params.retainScreenshots ?? false
   const frameStream = new InMemoryStream<Frame>()
   const eventStream = new InMemoryStream<EventWindow>()
   const activityStream = new InMemoryStream<Activity>()
@@ -72,7 +78,9 @@ export function createPipelineHarness(params: {
           config: {
             ...params.activityExtractorConfig,
             onTaskComplete: (activity) => {
-              cleanupActivityFiles(activity, params.outputDir)
+              if (!retainScreenshots) {
+                cleanupActivityFiles(activity, params.outputDir)
+              }
             },
           },
         })
@@ -102,9 +110,16 @@ export function createPipelineHarness(params: {
           await screenCapturer.start()
         }
 
-        cleanupTimer = setInterval(() => {
-          sweepStaleFiles(params.outputDir)
-        }, SCREENSHOT_CLEANUP_CONFIG.CLEANUP_INTERVAL_MS)
+        if (retainScreenshots) {
+          log.warn(
+            '[PipelineHarness] retainScreenshots enabled — activity frames/videos are kept and the ' +
+              'stale-file sweep is disabled. The screenshots dir will grow unbounded (debug only).',
+          )
+        } else {
+          cleanupTimer = setInterval(() => {
+            sweepStaleFiles(params.outputDir)
+          }, SCREENSHOT_CLEANUP_CONFIG.CLEANUP_INTERVAL_MS)
+        }
       } catch (error) {
         running = false
         throw error

--- a/src/main/recorder/interaction-monitor.test.ts
+++ b/src/main/recorder/interaction-monitor.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { INTERACTION_MONITOR_CONFIG } from '@constants'
+import type { InteractionContext } from '../../shared/types'
+
+// --- Mocks -----------------------------------------------------------------
+// Defined via vi.hoisted so they are initialized before the hoisted vi.mock
+// factories (and the top-level import of the module under test) run.
+
+const { mockScreen, handlers, mockUiohook } = vi.hoisted(() => {
+  const handlers: Record<string, (event: unknown) => void> = {}
+  return {
+    mockScreen: { getDisplayNearestPoint: vi.fn(() => ({ id: 1 })) },
+    handlers,
+    mockUiohook: {
+      on: vi.fn((event: string, handler: (event: unknown) => void) => {
+        handlers[event] = handler
+      }),
+      start: vi.fn(),
+      stop: vi.fn(),
+      removeAllListeners: vi.fn(),
+    },
+  }
+})
+
+vi.mock('electron', () => ({ screen: mockScreen }))
+vi.mock('uiohook-napi', () => ({
+  uIOhook: mockUiohook,
+  UiohookMouseEvent: class {},
+  UiohookWheelEvent: class {},
+}))
+
+vi.mock('./app-watcher', () => ({ addAppWatcherListener: vi.fn(() => () => {}) }))
+vi.mock('./app-watcher-display', () => ({
+  resolveAppWatcherDisplay: vi.fn(() => ({ displayId: 1, source: 'window' })),
+}))
+vi.mock('../logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+import * as monitor from './interaction-monitor'
+
+// --- Helpers ---------------------------------------------------------------
+
+function wheel(rotation = 1): void {
+  handlers['wheel']?.({ rotation, direction: 3, x: 0, y: 0 })
+}
+
+function key(): void {
+  handlers['keydown']?.({})
+}
+
+describe('interaction-monitor session emission', () => {
+  // Registered once; the interaction-callback list is module-level and not
+  // cleared by stop(), so we reuse a single buffer and reset it per test.
+  const emitted: InteractionContext[] = []
+
+  beforeAll(() => {
+    monitor.onInteraction((c) => emitted.push(c))
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const k of Object.keys(handlers)) delete handlers[k]
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    emitted.length = 0
+    monitor.startInteractionMonitoring()
+  })
+
+  afterEach(() => {
+    monitor.stopInteractionMonitoring()
+    vi.useRealTimers()
+  })
+
+  it('emits interim events during a long continuous scroll (instead of one late event)', () => {
+    // 20 wheel events, one every 500ms => 10s of continuous scrolling, which
+    // exceeds MAX_SESSION_MS (4000) and the gap window several times over.
+    for (let i = 0; i < 20; i++) {
+      wheel(1)
+      vi.advanceTimersByTime(500)
+    }
+    // Stop scrolling and let the debounce flush the final sub-window.
+    vi.advanceTimersByTime(INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS)
+
+    // Old behavior emitted exactly one event at the very end; the fix emits
+    // interim sub-windows so the downstream window stays alive.
+    expect(emitted.length).toBeGreaterThan(1)
+    expect(emitted.every((c) => c.type === 'scroll')).toBe(true)
+
+    // An interim must land mid-session, well before the final emit.
+    expect(emitted[0].timestamp).toBeLessThan(emitted[emitted.length - 1].timestamp)
+
+    // Every raw event is accounted for exactly once across sub-windows
+    // (accumulation resets per emit; nothing double-counted or dropped).
+    const totalScroll = emitted.reduce((sum, c) => sum + (c.scrollAmount ?? 0), 0)
+    expect(totalScroll).toBe(20)
+
+    // Each sub-window carries a non-negative duration and a receipt-time stamp.
+    for (const c of emitted) {
+      expect(c.durationMs).toBeGreaterThanOrEqual(0)
+      expect(c.timestamp).toBeGreaterThan(0)
+      expect(c.scrollDirection).toBe('vertical')
+    }
+  })
+
+  it('stamps a short scroll session at the last event receipt time', () => {
+    vi.advanceTimersByTime(1000) // now = 1000
+    wheel(3)
+    vi.advanceTimersByTime(INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS)
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]).toMatchObject({
+      type: 'scroll',
+      timestamp: 1000, // receipt time of the only raw event
+      scrollAmount: 3,
+      durationMs: 0,
+    })
+  })
+
+  it('honors a runtime debounce change without restart (config read lazily)', () => {
+    const original = INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS
+    try {
+      INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS = 500
+      vi.advanceTimersByTime(1000) // now = 1000
+      wheel(2)
+      // With the new 500ms debounce the final emit fires at 1500. If the value
+      // were captured at construction (the regression), nothing emits here.
+      vi.advanceTimersByTime(500)
+      expect(emitted).toHaveLength(1)
+      expect(emitted[0]).toMatchObject({ type: 'scroll', timestamp: 1000, scrollAmount: 2 })
+    } finally {
+      INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS = original
+    }
+  })
+
+  it('emits interim events during a long continuous typing session', () => {
+    for (let i = 0; i < 20; i++) {
+      key()
+      vi.advanceTimersByTime(500)
+    }
+    vi.advanceTimersByTime(INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS)
+
+    expect(emitted.length).toBeGreaterThan(1)
+    expect(emitted.every((c) => c.type === 'keyboard')).toBe(true)
+    const totalKeys = emitted.reduce((sum, c) => sum + (c.keyCount ?? 0), 0)
+    expect(totalKeys).toBe(20)
+  })
+
+  it('cancels pending session timers on stop (no emit after stop)', () => {
+    wheel(1) // opens a session with pending debounce + max-session timers
+    monitor.stopInteractionMonitoring()
+    vi.advanceTimersByTime(60_000)
+    expect(emitted).toHaveLength(0)
+  })
+})

--- a/src/main/recorder/interaction-monitor.test.ts
+++ b/src/main/recorder/interaction-monitor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { INTERACTION_MONITOR_CONFIG } from '@constants'
+import { EVENT_CAPTURER_CONFIG, INTERACTION_MONITOR_CONFIG } from '@constants'
 import type { InteractionContext } from '../../shared/types'
 
 // --- Mocks -----------------------------------------------------------------
@@ -151,5 +151,17 @@ describe('interaction-monitor session emission', () => {
     monitor.stopInteractionMonitoring()
     vi.advanceTimersByTime(60_000)
     expect(emitted).toHaveLength(0)
+  })
+})
+
+describe('interaction-monitor keep-alive invariant', () => {
+  // The interim flush only keeps the downstream event-capturer window alive if a
+  // continuous session emits more often than the gap timer closes it. If this
+  // regresses (e.g. MAX_SESSION_MS bumped to >= GAP_TIMEOUT_MS), long scroll/typing
+  // sessions are silently dropped again — the exact bug this module fixes.
+  it('emits interim sub-windows faster than the event-capturer gap closes the window', () => {
+    expect(INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS).toBeLessThan(
+      EVENT_CAPTURER_CONFIG.GAP_TIMEOUT_MS,
+    )
   })
 })

--- a/src/main/recorder/interaction-monitor.ts
+++ b/src/main/recorder/interaction-monitor.ts
@@ -8,22 +8,17 @@ import log from '../logger'
 
 // State
 let isRunning = false
-let typingSessionTimeoutId: NodeJS.Timeout | null = null
-let isTyping = false
+
+// Typing session accumulation (counters only; timers/lifecycle live in `typingSession`)
 let typingSessionKeyCount = 0
-let typingSessionStartTime = 0
 
-// Scroll state
-let scrollSessionTimeoutId: NodeJS.Timeout | null = null
-let isScrolling = false
+// Scroll session accumulation
 let scrollSessionAmount = 0
+let scrollSessionEventCount = 0
 let scrollSessionDirection: 'vertical' | 'horizontal' = 'vertical'
-let scrollSessionStartTime = 0
 
-// Click debounce state
-let clickSessionTimeoutId: NodeJS.Timeout | null = null
+// Click session accumulation
 let clickSessionCount = 0
-let clickSessionStartTime = 0
 let lastClickPosition: { x: number; y: number } | null = null
 let lastClickDisplayId: number | undefined
 
@@ -51,6 +46,171 @@ function getDisplayIdForPoint(x: number, y: number): number {
 type OnInteractionCallback = (context: InteractionContext) => void
 const interactionCallbacks: OnInteractionCallback[] = []
 
+function notifyInteraction(context: InteractionContext): void {
+  interactionCallbacks.forEach((callback) => {
+    try {
+      callback(context)
+    } catch (error) {
+      log.error('Error in interaction callback:', error)
+    }
+  })
+}
+
+/**
+ * Manages a debounced interaction "session" — a burst of same-type raw events
+ * (clicks, keystrokes, scroll) coalesced into emitted InteractionContexts.
+ *
+ * Two timers drive emission:
+ * - a debounce timer, reset on every raw event, emits the final sub-window once
+ *   input stops; and
+ * - a max-session timer that emits an interim sub-window during *continuous*
+ *   input, so a long session (e.g. a 30s scroll) keeps emitting and the
+ *   downstream event-capturer window stays alive instead of being cut by its
+ *   idle/gap timer.
+ *
+ * Each emitted sub-window is timestamped at the receipt time of its last raw
+ * event (occurrence time) — not at the moment a timer happens to fire.
+ */
+class DebouncedSession {
+  private active = false
+  private debounceTimer: NodeJS.Timeout | null = null
+  private maxTimer: NodeJS.Timeout | null = null
+  private subWindowStart = 0
+  private lastEventTime = 0
+
+  constructor(
+    // Read lazily so runtime settings changes (capture-settings-manager
+    // mutates INTERACTION_MONITOR_CONFIG) take effect without a restart.
+    private readonly debounceMs: () => number,
+    private readonly maxSessionMs: () => number,
+    private readonly handlers: {
+      hasActivity: () => boolean
+      emit: (subWindowStart: number, lastEventTime: number) => void
+      resetAccumulation: () => void
+      onStart?: () => void
+    },
+  ) {}
+
+  /** Call synchronously from the raw event handler, with the receipt time. */
+  record(now: number): void {
+    if (!this.active) {
+      this.active = true
+      this.subWindowStart = now
+      this.handlers.resetAccumulation()
+      this.handlers.onStart?.()
+      this.maxTimer = setTimeout(() => this.flushInterim(), this.maxSessionMs())
+    }
+    this.lastEventTime = now
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => this.flushFinal(), this.debounceMs())
+  }
+
+  private flushInterim(): void {
+    if (this.handlers.hasActivity()) {
+      this.handlers.emit(this.subWindowStart, this.lastEventTime)
+      this.handlers.resetAccumulation()
+      this.subWindowStart = this.lastEventTime
+    }
+    // Re-arm: continuous input keeps emitting at most maxSessionMs apart.
+    this.maxTimer = setTimeout(() => this.flushInterim(), this.maxSessionMs())
+  }
+
+  private flushFinal(): void {
+    if (this.handlers.hasActivity()) {
+      this.handlers.emit(this.subWindowStart, this.lastEventTime)
+      this.handlers.resetAccumulation()
+    }
+    this.reset()
+  }
+
+  /** Cancel timers and clear lifecycle state without emitting (used on stop). */
+  reset(): void {
+    this.active = false
+    if (this.maxTimer) {
+      clearTimeout(this.maxTimer)
+      this.maxTimer = null
+    }
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+      this.debounceTimer = null
+    }
+  }
+}
+
+const clickSession = new DebouncedSession(
+  () => INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS,
+  () => INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS,
+  {
+    hasActivity: () => clickSessionCount > 0,
+    resetAccumulation: () => {
+      clickSessionCount = 0
+    },
+    onStart: () => log.info('[Interaction Monitor] Click session started'),
+    emit: (subWindowStart, lastEventTime) => {
+      log.info(
+        `[Interaction Monitor] Click session: ${clickSessionCount} clicks over ${lastEventTime - subWindowStart}ms`,
+      )
+      notifyInteraction({
+        type: 'click',
+        timestamp: lastEventTime,
+        displayId: lastClickDisplayId,
+        clickPosition: lastClickPosition ?? undefined,
+      })
+    },
+  },
+)
+
+const typingSession = new DebouncedSession(
+  () => INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS,
+  () => INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS,
+  {
+    hasActivity: () => typingSessionKeyCount > 0,
+    resetAccumulation: () => {
+      typingSessionKeyCount = 0
+    },
+    onStart: () => log.info('[Interaction Monitor] Typing session started'),
+    emit: (subWindowStart, lastEventTime) => {
+      log.info(
+        `[Interaction Monitor] Typing session: ${typingSessionKeyCount} keys over ${lastEventTime - subWindowStart}ms`,
+      )
+      notifyInteraction({
+        type: 'keyboard',
+        timestamp: lastEventTime,
+        displayId: cachedDisplayId ?? undefined,
+        keyCount: typingSessionKeyCount,
+        durationMs: Math.max(0, lastEventTime - subWindowStart),
+        windowTitle: cachedWindowTitle ?? undefined,
+      })
+    },
+  },
+)
+
+const scrollSession = new DebouncedSession(
+  () => INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS,
+  () => INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS,
+  {
+    hasActivity: () => scrollSessionEventCount > 0,
+    resetAccumulation: () => {
+      scrollSessionAmount = 0
+      scrollSessionEventCount = 0
+    },
+    onStart: () => log.info('[Interaction Monitor] Scroll session started'),
+    emit: (subWindowStart, lastEventTime) => {
+      log.info(
+        `[Interaction Monitor] Scroll session: ${scrollSessionAmount} rotation over ${lastEventTime - subWindowStart}ms`,
+      )
+      notifyInteraction({
+        type: 'scroll',
+        timestamp: lastEventTime,
+        displayId: cachedDisplayId ?? undefined,
+        scrollDirection: scrollSessionDirection,
+        scrollAmount: scrollSessionAmount,
+        durationMs: Math.max(0, lastEventTime - subWindowStart),
+      })
+    },
+  },
+)
+
 /**
  * Handle mouse click events
  * Debounced: accumulates clicks and emits a single event when clicking stops,
@@ -61,51 +221,10 @@ function handleMouseClick(event: UiohookMouseEvent): void {
     return
   }
 
-  const now = Date.now()
-
-  if (clickSessionTimeoutId) {
-    clearTimeout(clickSessionTimeoutId)
-  }
-
-  if (clickSessionCount === 0) {
-    clickSessionStartTime = now
-    log.info('[Interaction Monitor] Click session started')
-  }
-
+  clickSession.record(Date.now())
   clickSessionCount++
   lastClickPosition = { x: event.x, y: event.y }
   lastClickDisplayId = getDisplayIdForPoint(event.x, event.y)
-
-  clickSessionTimeoutId = setTimeout(() => {
-    if (clickSessionCount === 0) return
-
-    const endTime = Date.now() - INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS
-    const durationMs = endTime - clickSessionStartTime
-
-    log.info(
-      `[Interaction Monitor] Click session ended: ${clickSessionCount} clicks over ${durationMs}ms`,
-    )
-
-    const context: InteractionContext = {
-      type: 'click',
-      timestamp: endTime,
-      displayId: lastClickDisplayId,
-      clickPosition: lastClickPosition ?? undefined,
-    }
-
-    interactionCallbacks.forEach((callback) => {
-      try {
-        callback(context)
-      } catch (error) {
-        log.error('Error in interaction callback:', error)
-      }
-    })
-
-    clickSessionCount = 0
-    clickSessionStartTime = 0
-    lastClickPosition = null
-    lastClickDisplayId = undefined
-  }, INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS)
 }
 
 /**
@@ -117,58 +236,8 @@ function handleKeyboard(): void {
     return
   }
 
-  const now = Date.now()
-
-  // Clear any existing typing session timeout
-  if (typingSessionTimeoutId) {
-    clearTimeout(typingSessionTimeoutId)
-  }
-
-  // Mark that user is typing and track session
-  if (!isTyping) {
-    isTyping = true
-    typingSessionKeyCount = 0
-    typingSessionStartTime = now
-    log.info('[Interaction Monitor] Typing session started')
-  }
-
-  // Increment key count
+  typingSession.record(Date.now())
   typingSessionKeyCount++
-
-  // Set timeout to detect when typing stops
-  typingSessionTimeoutId = setTimeout(() => {
-    if (!isTyping) return
-
-    isTyping = false
-    const endTime = Date.now() - INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS
-    const durationMs = Math.max(0, endTime - typingSessionStartTime)
-
-    log.info(
-      `[Interaction Monitor] Typing session ended: ${typingSessionKeyCount} keys over ${durationMs}ms`,
-    )
-
-    const context: InteractionContext = {
-      type: 'keyboard',
-      timestamp: endTime,
-      displayId: cachedDisplayId ?? undefined,
-      keyCount: typingSessionKeyCount,
-      durationMs: durationMs,
-      windowTitle: cachedWindowTitle ?? undefined,
-    }
-
-    // Notify all callbacks
-    interactionCallbacks.forEach((callback) => {
-      try {
-        callback(context)
-      } catch (error) {
-        log.error('Error in interaction callback:', error)
-      }
-    })
-
-    // Reset session tracking
-    typingSessionKeyCount = 0
-    typingSessionStartTime = 0
-  }, INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS)
 }
 
 /**
@@ -180,58 +249,10 @@ function handleScroll(event: UiohookWheelEvent): void {
     return
   }
 
-  const now = Date.now()
-
-  // Clear any existing scroll session timeout
-  if (scrollSessionTimeoutId) {
-    clearTimeout(scrollSessionTimeoutId)
-  }
-
-  // Mark that user is scrolling and track session
-  if (!isScrolling) {
-    isScrolling = true
-    scrollSessionAmount = 0
-    scrollSessionStartTime = now
-    scrollSessionDirection = event.direction === 3 ? 'vertical' : 'horizontal' // WheelDirection.VERTICAL = 3
-    log.info('[Interaction Monitor] Scroll session started')
-  }
-
-  // Accumulate scroll amount
+  scrollSession.record(Date.now())
   scrollSessionAmount += event.rotation
-
-  // Set timeout to detect when scrolling stops
-  scrollSessionTimeoutId = setTimeout(() => {
-    if (!isScrolling) return
-
-    isScrolling = false
-    const endTime = Date.now() - INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS
-    const durationMs = endTime - scrollSessionStartTime
-
-    log.info(
-      `[Interaction Monitor] Scroll session ended: ${scrollSessionAmount} rotation over ${durationMs}ms`,
-    )
-
-    const context: InteractionContext = {
-      type: 'scroll',
-      timestamp: endTime,
-      displayId: cachedDisplayId ?? undefined,
-      scrollDirection: scrollSessionDirection,
-      scrollAmount: scrollSessionAmount,
-    }
-
-    // Notify all callbacks
-    interactionCallbacks.forEach((callback) => {
-      try {
-        callback(context)
-      } catch (error) {
-        log.error('Error in interaction callback:', error)
-      }
-    })
-
-    // Reset session tracking
-    scrollSessionAmount = 0
-    scrollSessionStartTime = 0
-  }, INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS)
+  scrollSessionEventCount++
+  scrollSessionDirection = event.direction === 3 ? 'vertical' : 'horizontal' // WheelDirection.VERTICAL = 3
 }
 
 /**
@@ -374,38 +395,21 @@ export function stopInteractionMonitoring(): void {
   try {
     log.info('[Interaction Monitor] Stopping')
     isRunning = false
-    isTyping = false
+
+    // Cancel pending session timers and clear accumulation
+    clickSession.reset()
+    typingSession.reset()
+    scrollSession.reset()
     typingSessionKeyCount = 0
-    typingSessionStartTime = 0
-    isScrolling = false
     scrollSessionAmount = 0
-    scrollSessionStartTime = 0
+    scrollSessionEventCount = 0
     clickSessionCount = 0
-    clickSessionStartTime = 0
     lastClickPosition = null
     lastClickDisplayId = undefined
     previousWindow = null
     previousWindowDisplayId = null
     cachedDisplayId = null
     cachedWindowTitle = null
-
-    // Clear any pending typing session timeout
-    if (typingSessionTimeoutId) {
-      clearTimeout(typingSessionTimeoutId)
-      typingSessionTimeoutId = null
-    }
-
-    // Clear any pending scroll session timeout
-    if (scrollSessionTimeoutId) {
-      clearTimeout(scrollSessionTimeoutId)
-      scrollSessionTimeoutId = null
-    }
-
-    // Clear any pending click session timeout
-    if (clickSessionTimeoutId) {
-      clearTimeout(clickSessionTimeoutId)
-      clickSessionTimeoutId = null
-    }
 
     // Stop the native app-watcher process (only our listener; others may still be attached)
     if (appWatcherUnsubscribe) {

--- a/src/main/recorder/native-screenshot.ts
+++ b/src/main/recorder/native-screenshot.ts
@@ -21,6 +21,10 @@ export interface CapturedFrame {
   width: number
   height: number
   displayId: number
+  // Frontmost app at the grab instant, stamped by the native daemon. Absent
+  // when the daemon could not resolve it (or on platforms that don't stamp yet).
+  appName?: string
+  bundleId?: string
 }
 
 export interface CaptureBackendConfig {

--- a/src/main/recorder/screen-capturer.ts
+++ b/src/main/recorder/screen-capturer.ts
@@ -17,6 +17,11 @@ export interface Frame {
   height: number
   displayId: number
   sequenceNumber: number
+  // Frontmost app at the grab instant (carried through from the native daemon).
+  // Used by the ActivityProducer to keep a frame out of a window whose app
+  // doesn't match. Absent for unstamped frames (kept as-is).
+  appName?: string
+  bundleId?: string
 }
 
 export class ScreenCapturer {

--- a/src/main/recorder/swift/app-watcher.swift
+++ b/src/main/recorder/swift/app-watcher.swift
@@ -352,5 +352,15 @@ emit([
     "timestamp": nowMs(),
 ])
 
+// Emit the current frontmost app as the initial app_change so the first activity
+// inherits its real identity instead of falling back to 'Unknown'. NSWorkspace
+// only notifies on focus *changes*, so the app already focused at launch would
+// otherwise never be announced. (The Windows watcher already emits the initial
+// foreground window on startup — see native/windows/app-watcher/src/main.rs.)
+if let frontmost = NSWorkspace.shared.frontmostApplication {
+    let title = windowTitle(forPid: frontmost.processIdentifier) ?? ""
+    emit(buildEvent(type: "app_change", app: frontmost, title: title))
+}
+
 // Keep the process alive
 RunLoop.main.run()

--- a/src/main/recorder/swift/screenshot.swift
+++ b/src/main/recorder/swift/screenshot.swift
@@ -28,6 +28,32 @@ func fail(_ message: String, exitCode: Int32 = 1) -> Never {
     exit(exitCode)
 }
 
+/// Filesystem-safe slug for an app name so it can go in a screenshot filename,
+/// e.g. "Google Chrome" -> "google-chrome". Lowercases, replaces any run of
+/// non-alphanumeric characters with a single dash, trims dashes, and caps the
+/// length. Returns nil when nothing usable remains.
+func appSlug(_ name: String?) -> String? {
+    guard let name = name else { return nil }
+    let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789")
+    var slug = ""
+    var lastWasDash = false
+    for scalar in name.lowercased().unicodeScalars {
+        if allowed.contains(scalar) {
+            slug.unicodeScalars.append(scalar)
+            lastWasDash = false
+        } else if !lastWasDash {
+            slug.append("-")
+            lastWasDash = true
+        }
+    }
+    let dashes = CharacterSet(charactersIn: "-")
+    slug = slug.trimmingCharacters(in: dashes)
+    if slug.count > 40 {
+        slug = String(slug.prefix(40)).trimmingCharacters(in: dashes)
+    }
+    return slug.isEmpty ? nil : slug
+}
+
 // MARK: - CLI Argument Parsing
 
 struct DaemonConfig {
@@ -189,6 +215,34 @@ func resolveDisplayId(_ requestedDisplayId: UInt32?) throws -> CGDirectDisplayID
     return displays[0]
 }
 
+// MARK: - Frontmost app tracking
+
+/// Caches the system-wide frontmost app, updated on the main run loop via an
+/// NSWorkspace notification, so the SCStreamOutput callback (which runs on a
+/// background queue) can read it cheaply at the grab instant. Identifiers match
+/// the app-watcher daemon (localizedName + bundleIdentifier) so the downstream
+/// frame/app matching in ActivityProducer compares like-for-like.
+final class FrontmostAppTracker {
+    private let lock = NSLock()
+    private var appName: String?
+    private var bundleId: String?
+
+    func update(_ app: NSRunningApplication?) {
+        lock.lock()
+        defer { lock.unlock() }
+        appName = app?.localizedName
+        bundleId = app?.bundleIdentifier
+    }
+
+    func snapshot() -> (appName: String?, bundleId: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (appName, bundleId)
+    }
+}
+
+let frontmostTracker = FrontmostAppTracker()
+
 // MARK: - Autonomous ScreenCaptureKit Daemon
 
 class AutonomousCapture: NSObject, SCStreamOutput {
@@ -327,6 +381,7 @@ class AutonomousCapture: NSObject, SCStreamOutput {
         let quality = self.config.quality
         let outputDir = self.config.outputDir
         let captureTimestamp = Int(Date().timeIntervalSince1970 * 1000)
+        let frontmost = frontmostTracker.snapshot()
         let droppedFrames = takeDroppedFrameCount()
         shouldReleaseSemaphore = false
 
@@ -335,7 +390,13 @@ class AutonomousCapture: NSObject, SCStreamOutput {
                 self.pendingWriteSemaphore.signal()
             }
 
-            let filename = "frame-\(captureTimestamp).jpg"
+            // Include the grab-time app in the name so raw frames are legible on
+            // disk, e.g. "frame-1781008339005-google-chrome.jpg". Falls back to
+            // the bare timestamped name when the app is unknown.
+            let slug = appSlug(frontmost.appName)
+            let filename =
+                slug.map { "frame-\(captureTimestamp)-\($0).jpg" }
+                ?? "frame-\(captureTimestamp).jpg"
             let filepath = (outputDir as NSString).appendingPathComponent(filename)
 
             do {
@@ -346,13 +407,21 @@ class AutonomousCapture: NSObject, SCStreamOutput {
                     fputs("[daemon] Dropped \(droppedFrames) frame(s) while previous capture was still being written\n", stderr)
                 }
 
-                let payload: [String: Any] = [
+                var payload: [String: Any] = [
                     "filepath": filepath,
                     "timestamp": captureTimestamp,
                     "width": resized.width,
                     "height": resized.height,
                     "displayId": Int(displayId),
                 ]
+                // Stamp the grab-time frontmost app. Omit keys when unknown
+                // (no NSNull) — the consumer treats absent app info as "keep".
+                if let name = frontmost.appName, !name.isEmpty {
+                    payload["appName"] = name
+                }
+                if let bid = frontmost.bundleId, !bid.isEmpty {
+                    payload["bundleId"] = bid
+                }
                 emitJSON(payload)
             } catch {
                 fputs("[daemon] Frame write failed: \(error)\n", stderr)
@@ -411,7 +480,18 @@ try FileManager.default.createDirectory(
 
 let capture = AutonomousCapture(config: config)
 
-let semaphore = DispatchSemaphore(value: 0)
+// Track the frontmost app on the main run loop so every captured frame can be
+// stamped with the app on screen at the grab instant (see FrontmostAppTracker).
+// Same NSWorkspace source as app-watcher.swift, so identifiers match.
+let workspaceCenter = NSWorkspace.shared.notificationCenter
+workspaceCenter.addObserver(forName: NSWorkspace.didActivateApplicationNotification,
+                            object: nil, queue: .main) { notification in
+    let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+    frontmostTracker.update(app ?? NSWorkspace.shared.frontmostApplication)
+}
+// Seed with the app focused at launch — NSWorkspace only notifies on *changes*.
+frontmostTracker.update(NSWorkspace.shared.frontmostApplication)
+
 Task {
     do {
         try await capture.startStream()
@@ -422,4 +502,8 @@ Task {
     // Start listening for stdin commands
     listenForCommands(capture: capture)
 }
-semaphore.wait()
+
+// Keep the process alive AND service the main run loop so the workspace observer
+// above fires — NSWorkspace notifications are delivered on the main run loop, and
+// a bare DispatchSemaphore.wait() would block the thread without running it.
+RunLoop.main.run()

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -95,6 +95,17 @@ export async function createMainRuntime(params: {
     ? new InteractionEventDebugDumper(debugPipelineDir)
     : undefined
 
+  // Debug-only: keep screenshots (skip per-activity cleanup + the stale sweep)
+  // so frames survive for inspection. On by default whenever the debug pipeline
+  // is active, and independently togglable via MEMORYLANE_RETAIN_SCREENSHOTS.
+  const retainScreenshots =
+    dev && Boolean(process.env.DEBUG_PIPELINE || process.env.MEMORYLANE_RETAIN_SCREENSHOTS)
+  if (retainScreenshots) {
+    log.info(
+      '[Runtime] Screenshot retention enabled — captured frames will not be cleaned up (debug only)',
+    )
+  }
+
   const presets = VENDOR_PRESETS[params.getActiveVendor()]
   const initialVideoModels = buildModelChain(params.initialVideoModel ?? '', presets.semanticVideo)
   const initialSnapshotModels = buildModelChain(
@@ -148,6 +159,7 @@ export async function createMainRuntime(params: {
     outputDir,
     extractorTransformer: transformer,
     extractorSink: sink,
+    retainScreenshots,
   })
 
   const capture: RuntimeCaptureController = createCaptureController({

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -18,6 +18,7 @@ import { SqliteActivitySink } from './sqlite-activity-sink'
 import { FfmpegVideoStitcher } from './video/video-stitcher'
 import { ActivitySemanticService, SemanticFileDebugDumper } from './activity-semantic-service'
 import type { SemanticPipelinePreference } from './activity-semantic-service'
+import { InteractionEventDebugDumper } from './interaction-event-debug-dump'
 import { InferenceProviderImpl, type InferenceProvider } from './llm'
 import type { Vendor } from '../shared/types'
 import { VENDOR_PRESETS, buildModelChain } from '../shared/vendor-defaults'
@@ -80,14 +81,19 @@ export async function createMainRuntime(params: {
   applyMigrations(storage.getDatabase())
   const usageTracker = new UsageTracker()
 
+  const debugPipelineDir = path.join(app.getAppPath(), '.debug-pipeline')
   const debugDumper =
     !app.isPackaged && process.env.DEBUG_PIPELINE
       ? new SemanticFileDebugDumper({
-          rootDir: path.join(app.getAppPath(), '.debug-pipeline'),
+          rootDir: debugPipelineDir,
           cleanRootDir: true,
           copyMediaAssets: true,
         })
       : undefined
+  // Created after the semantic dumper so its cleanRootDir has already run.
+  const interactionDumper = debugDumper
+    ? new InteractionEventDebugDumper(debugPipelineDir)
+    : undefined
 
   const presets = VENDOR_PRESETS[params.getActiveVendor()]
   const initialVideoModels = buildModelChain(params.initialVideoModel ?? '', presets.semanticVideo)
@@ -169,6 +175,7 @@ export async function createMainRuntime(params: {
   })
 
   const interactionHandler = (event: Parameters<typeof harness.handleEvent>[0]): void => {
+    interactionDumper?.dump(event)
     blacklistCoordinator.handleInteraction(event)
   }
   interactionMonitor.onInteraction(interactionHandler)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -16,8 +16,17 @@ export const INTERACTION_MONITOR_CONFIG = {
   SCROLL_DEBOUNCE_MS: 2000, // Wait for scrolling to stop before emitting event (200-2000ms)
   // Force-emit an interim event when a continuous session runs longer than this,
   // so long scroll/typing keeps the event-capturer's window alive instead of
-  // being cut by its idle gap. MUST be > the longest debounce above and
-  // < EVENT_CAPTURER_CONFIG.GAP_TIMEOUT_MS.
+  // being cut by its idle gap. The binding invariant is
+  // MAX_SESSION_MS < EVENT_CAPTURER_CONFIG.GAP_TIMEOUT_MS — otherwise a continuous
+  // session emits less often than the gap and the downstream window is dropped
+  // (guarded by a test in interaction-monitor.test.ts).
+  //
+  // This is independent of the debounce values above: debounce controls when a
+  // session is considered *finished*, while this caps how long a *running* session
+  // goes between emits. When a user-configured debounce exceeds this (the UI allows
+  // up to 10s), a long session is intentionally split into interim sub-windows —
+  // each stamped at receipt time, with no events lost or double-counted — because
+  // honoring a debounce longer than the gap would let the window die.
   MAX_SESSION_MS: 4000,
 }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,6 +14,11 @@ export const INTERACTION_MONITOR_CONFIG = {
   CLICK_DEBOUNCE_MS: 3000, // Wait for clicking to stop before emitting event (500-5000ms)
   TYPING_DEBOUNCE_MS: 2000, // Wait for typing to stop before emitting event (500-5000ms)
   SCROLL_DEBOUNCE_MS: 2000, // Wait for scrolling to stop before emitting event (200-2000ms)
+  // Force-emit an interim event when a continuous session runs longer than this,
+  // so long scroll/typing keeps the event-capturer's window alive instead of
+  // being cut by its idle gap. MUST be > the longest debounce above and
+  // < EVENT_CAPTURER_CONFIG.GAP_TIMEOUT_MS.
+  MAX_SESSION_MS: 4000,
 }
 
 // App Watcher Configuration (platform-native subprocess for app/window change detection)


### PR DESCRIPTION
Hardens interaction-session handling and activity-boundary detection in the capture pipeline, and adds debug tooling. Summarizes the 7 commits on this branch.

## Boundary & session correctness
- **interaction-monitor:** stamp sessions at occurrence time and keep long typing/scroll sessions alive (`e56098c`); enforce the real keep-alive invariant (`ee8ace4`). Includes a substantial `interaction-monitor.ts` refactor + tests.
- **event-capturer:** finalize event windows in close (chronological) order so a later window can't jump ahead of an earlier one still in its late-event grace (`ecdacb9`); late-events test.
- **activity-producer:** finalize the trailing pending activity when its successor is an incompatible no-frame window, so the last frame-backed window of a session isn't stranded/lost (`6c2a238`).
- **app-watcher:** emit the initial frontmost app on startup so the first activity inherits its real identity instead of falling back to 'Unknown' (`05d0fe4`).

## Debug tooling
- Dump interaction events into the debug pipeline (`7566cf7`).
- Under `DEBUG_PIPELINE`: retain screenshots (skip per-activity cleanup + the stale sweep) and capture dev file logs (`6ef6a67`).

## Tests
Adds/updates `activity-producer`, `event-capturer.late-events`, `interaction-monitor`, `pipeline-harness`, and `interaction-event-debug-dump` tests. 14 files, +907/-184.

---

> **Related:** #152 (`petr/deu-33-better-clipping-of-activities`) also touches activity boundaries — coordinate merge order. **#158** (screenshot app-leak fix) is stacked on this branch and will retarget to `main` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)