### PR TITLE
feat(debug): retain screenshots and capture dev file logs under DEBUG_PIPELINE

### DIFF
--- a/src/main/logger-electron.ts
+++ b/src/main/logger-electron.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron'
+import * as path from 'path'
 import { setLogger } from './logger'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -6,8 +7,20 @@ const electronLog = require('electron-log/main')
 const isDev = !app.isPackaged
 const level = isDev ? 'debug' : 'info'
 
-electronLog.transports.file.level = isDev ? false : level
+// File logging is normally off in dev (console is primary). Enable it when
+// debugging the pipeline so the run's logs — including otherwise console-only
+// extractor dead-letters — are captured to a file for inspection, written next
+// to the dev DB and screenshots. Packaged builds always log to file.
+const devFileLogging =
+  isDev && Boolean(process.env.DEBUG_PIPELINE || process.env.MEMORYLANE_DEV_FILE_LOG)
+
+electronLog.transports.file.level = isDev ? (devFileLogging ? level : false) : level
 electronLog.transports.console.level = level
 electronLog.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}] [{level}] {text}'
+
+if (devFileLogging) {
+  electronLog.transports.file.resolvePathFn = (): string =>
+    path.join(app.getPath('userData'), 'memorylane-dev.log')
+}
 
 setLogger(electronLog)

--- a/src/main/pipeline-harness.test.ts
+++ b/src/main/pipeline-harness.test.ts
@@ -71,6 +71,16 @@ vi.mock('./recorder/native-screenshot', () => ({
   }),
 }))
 
+const { cleanupSpy, sweepSpy } = vi.hoisted(() => ({
+  cleanupSpy: vi.fn(),
+  sweepSpy: vi.fn(),
+}))
+
+vi.mock('./activity-cleanup', () => ({
+  cleanupActivityFiles: cleanupSpy,
+  sweepStaleFiles: sweepSpy,
+}))
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -101,6 +111,8 @@ describe('pipeline harness', () => {
       clearInterval(mockBackendState.frameTimer)
       mockBackendState.frameTimer = null
     }
+    cleanupSpy.mockClear()
+    sweepSpy.mockClear()
     for (const sub of subscriptions.splice(0)) {
       sub.unsubscribe()
     }
@@ -275,6 +287,80 @@ describe('pipeline harness', () => {
     expect(transformedActivityIds).toHaveLength(1)
     expect(persistedActivityIds).toEqual(transformedActivityIds)
     expect(extractor.getStats().succeeded).toBe(1)
+
+    // Default behavior: each completed activity has its frames/video cleaned up.
+    await waitFor(
+      () => cleanupSpy.mock.calls.length === 1,
+      'Expected cleanupActivityFiles to run for the completed activity',
+    )
+    expect(cleanupSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: transformedActivityIds[0] }),
+      expect.any(String),
+    )
+
+    await harness.stop()
+  })
+
+  it('retains screenshots (skips per-activity cleanup) when retainScreenshots is set', async () => {
+    const persistedActivityIds: string[] = []
+
+    const harness = createPipelineHarness({
+      outputDir: path.join(process.cwd(), '.tmp-harness-retain'),
+      frameIntervalMs: 10,
+      retainScreenshots: true,
+      activityProducerConfig: {
+        frameJoinGraceMs: 0,
+        maxFrameWaitMs: 0,
+        minActivityDurationMs: 0,
+        eventConsumerId: 'harness:event:retain',
+        frameConsumerId: 'harness:frame:retain',
+      },
+      activityExtractorConfig: {
+        consumerId: 'harness:activity-extractor:retain',
+        maxConcurrent: 1,
+        maxRetries: 0,
+        retryBackoffMs: 0,
+      },
+      extractorTransformer: {
+        transform: async (activity): Promise<ExtractedActivity> => ({
+          activityId: activity.id,
+          startTimestamp: activity.startTimestamp,
+          endTimestamp: activity.endTimestamp,
+          appName: activity.context.appName,
+          windowTitle: activity.context.windowTitle ?? '',
+          tld: activity.context.tld,
+          summary: `summary:${activity.id}`,
+          summaryModel: '',
+          ocrText: `ocr:${activity.id}`,
+          vector: [0.1, 0.2, 0.3],
+        }),
+      },
+      extractorSink: {
+        persist: async ({ activity }) => {
+          persistedActivityIds.push(activity.id)
+        },
+      },
+    })
+
+    await harness.start()
+
+    harness.handleEvent({
+      type: 'app_change',
+      timestamp: Date.now(),
+      activeWindow: {
+        title: 'Retain Window',
+        processName: 'Code',
+        bundleId: 'com.microsoft.VSCode',
+      },
+    })
+    await sleep(60)
+    harness.handleEvent({ type: 'keyboard', timestamp: Date.now(), keyCount: 2, durationMs: 60 })
+    harness.eventCapturer.flush()
+
+    await waitFor(() => persistedActivityIds.length >= 1, 'Expected the activity to persist')
+    // Let onTaskComplete run; with retention on it must NOT clean up files.
+    await sleep(50)
+    expect(cleanupSpy).not.toHaveBeenCalled()
 
     await harness.stop()
   })

--- a/src/main/pipeline-harness.ts
+++ b/src/main/pipeline-harness.ts
@@ -12,6 +12,7 @@ import type {
 import { InMemoryStream } from './streams/in-memory-stream'
 import { ScreenCapturer, type Frame } from './recorder/screen-capturer'
 import { cleanupActivityFiles, sweepStaleFiles } from './activity-cleanup'
+import log from './logger'
 
 export interface PipelineHarness {
   frameStream: InMemoryStream<Frame>
@@ -38,7 +39,12 @@ export function createPipelineHarness(params: {
   activityExtractorConfig?: Partial<ActivityExtractorConfig>
   extractorTransformer?: ActivityTransformer
   extractorSink?: ActivitySink
+  // Debug-only: when true, processed activities' frames/videos are NOT deleted
+  // and the periodic stale-file sweep is disabled, so screenshots survive for
+  // inspection. Lets the screenshots dir grow unbounded — dev use only.
+  retainScreenshots?: boolean
 }): PipelineHarness {
+  const retainScreenshots = params.retainScreenshots ?? false
   const frameStream = new InMemoryStream<Frame>()
   const eventStream = new InMemoryStream<EventWindow>()
   const activityStream = new InMemoryStream<Activity>()
@@ -72,7 +78,9 @@ export function createPipelineHarness(params: {
           config: {
             ...params.activityExtractorConfig,
             onTaskComplete: (activity) => {
-              cleanupActivityFiles(activity, params.outputDir)
+              if (!retainScreenshots) {
+                cleanupActivityFiles(activity, params.outputDir)
+              }
             },
           },
         })
@@ -102,9 +110,16 @@ export function createPipelineHarness(params: {
           await screenCapturer.start()
         }
 
-        cleanupTimer = setInterval(() => {
-          sweepStaleFiles(params.outputDir)
-        }, SCREENSHOT_CLEANUP_CONFIG.CLEANUP_INTERVAL_MS)
+        if (retainScreenshots) {
+          log.warn(
+            '[PipelineHarness] retainScreenshots enabled — activity frames/videos are kept and the ' +
+              'stale-file sweep is disabled. The screenshots dir will grow unbounded (debug only).',
+          )
+        } else {
+          cleanupTimer = setInterval(() => {
+            sweepStaleFiles(params.outputDir)
+          }, SCREENSHOT_CLEANUP_CONFIG.CLEANUP_INTERVAL_MS)
+        }
       } catch (error) {
         running = false
         throw error

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -89,6 +89,17 @@ export async function createMainRuntime(params: {
         })
       : undefined
 
+  // Debug-only: keep screenshots (skip per-activity cleanup + the stale sweep)
+  // so frames survive for inspection. On by default whenever the debug pipeline
+  // is active, and independently togglable via MEMORYLANE_RETAIN_SCREENSHOTS.
+  const retainScreenshots =
+    dev && Boolean(process.env.DEBUG_PIPELINE || process.env.MEMORYLANE_RETAIN_SCREENSHOTS)
+  if (retainScreenshots) {
+    log.info(
+      '[Runtime] Screenshot retention enabled — captured frames will not be cleaned up (debug only)',
+    )
+  }
+
   const presets = VENDOR_PRESETS[params.getActiveVendor()]
   const initialVideoModels = buildModelChain(params.initialVideoModel ?? '', presets.semanticVideo)
   const initialSnapshotModels = buildModelChain(
@@ -142,6 +153,7 @@ export async function createMainRuntime(params: {
     outputDir,
     extractorTransformer: transformer,
     extractorSink: sink,
+    retainScreenshots,
   })
 
   const capture: RuntimeCaptureController = createCaptureController({


### PR DESCRIPTION
## What

Debug-only plumbing to inspect the capture pipeline. Gated behind `DEBUG_PIPELINE` (or independent overrides) — no effect on normal dev or packaged builds.

- **Retain screenshots**: skips per-activity file cleanup and disables the periodic stale-file sweep, so frames and activity videos survive for inspection. Auto-on under `DEBUG_PIPELINE`; togglable via `MEMORYLANE_RETAIN_SCREENSHOTS`. Logs a warning that the screenshots dir grows unbounded (dev only).
- **Dev file logging**: file logging is normally off in dev (console is primary). Under the same flag (or `MEMORYLANE_DEV_FILE_LOG`) it's enabled and written next to the dev DB at `memorylane-dev.log`, so otherwise console-only logs (e.g. extractor dead-letters) are captured.

## Why

Lets us inspect retained frames and full run logs while debugging the pipeline — notably the activity/app-frame-leak investigation, where eyeballing the actual PNGs against each activity's labeled context is the only way to confirm mislabeling.

## Scope

`retainScreenshots` flag threaded through `runtime.ts` → `pipeline-harness.ts`; logger gate in `logger-electron.ts`. Default behavior unchanged. Test added asserting cleanup runs by default and is skipped when retention is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)