### PR TITLE
fix: keep long interaction sessions alive, finalize windows in close order, flush sessions on app switch

### DIFF
--- a/src/main/activity-producer.test.ts
+++ b/src/main/activity-producer.test.ts
@@ -492,6 +492,81 @@ describe('ActivityProducer', () => {
     expect(noContextOffset).toBeLessThan(noFrameOffset)
   })
 
+  it('does not split an activity on a frameless incompatible window (quick bounce)', async () => {
+    // Pins the quick-bounce merge: a cmd-tab bounce into another app that
+    // produces no frames must not finalize the surrounding activity. (A
+    // frameless-window finalize was tried and reverted — it split activities
+    // and double-penalized the previous one; see activity-boundary-fixes-v2.)
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    const codeWindowContext = {
+      title: 'Repo',
+      processName: 'Code',
+      bundleId: 'com.microsoft.VSCode',
+    }
+
+    // App A with frames.
+    await frameStream.append(makeFrame(1_000, 0))
+    await frameStream.append(makeFrame(1_400, 1))
+    await eventStream.append(
+      makeWindow({
+        id: 'code-1',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        events: [
+          makeEvent(900, 'app_change', { activeWindow: codeWindowContext }),
+          makeEvent(1_250, 'keyboard'),
+        ],
+      }),
+    )
+
+    // Frameless bounce into app B: no frame falls in its range.
+    await eventStream.append(
+      makeWindow({
+        id: 'mail-bounce',
+        startTimestamp: 2_000,
+        endTimestamp: 2_100,
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: { title: 'Inbox', processName: 'Mail', bundleId: 'com.apple.mail' },
+          }),
+        ],
+      }),
+    )
+
+    // Back in app A with another frame; flush-closed to finalize.
+    await frameStream.append(makeFrame(3_000, 2))
+    const lastOffset = await eventStream.append(
+      makeWindow({
+        id: 'code-2',
+        startTimestamp: 2_900,
+        endTimestamp: 3_100,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_900, 'app_change', { activeWindow: codeWindowContext }),
+          makeEvent(3_000, 'keyboard'),
+        ],
+      }),
+    )
+
+    await waitFor(
+      async () => (await eventStream.getAck('test:event')) === lastOffset,
+      'Expected all windows to be processed and acked',
+    )
+    expect(activities).toHaveLength(1)
+    expect(activities[0].context.appName).toBe('Code')
+    expect(activities[0].frames).toHaveLength(3)
+    expect(producer.getStats().droppedNoFrameWindows).toBe(1)
+  })
+
   it('enforces max activity duration while keeping each emitted activity frame-backed', async () => {
     const { producer, frameStream, eventStream, activityStream } = createProducer({
       maxActivityDurationMs: 60_000,

--- a/src/main/event-capturer.late-events.test.ts
+++ b/src/main/event-capturer.late-events.test.ts
@@ -92,4 +92,52 @@ describe('EventCapturer late event handling', () => {
     expect(windows[1].startTimestamp).toBe(2_000)
     expect(windows[1].endTimestamp).toBe(2_000)
   })
+
+  it('emits windows in close order when capture stops while an earlier window is still in grace', async () => {
+    const appOf = (window: EventWindow): string | undefined =>
+      [...window.events].reverse().find((event) => event.activeWindow)?.activeWindow?.processName
+
+    // W1 (Unknown): keyboard, closed by the switch to Ghostty.
+    capturer.handleEvent(makeEvent({ type: 'keyboard', timestamp: 1_000 }))
+    capturer.handleEvent(
+      makeEvent({
+        type: 'app_change',
+        timestamp: 2_000,
+        activeWindow: { title: 'term', processName: 'ghostty' },
+      }),
+    )
+    // Let W1 finalize through its grace so it has the lowest offset.
+    vi.advanceTimersByTime(80)
+    await flushAsyncAppends()
+    expect(windows).toHaveLength(1)
+
+    // W2 (Ghostty): scroll, then switch to Electron — closes W2 and starts its grace.
+    capturer.handleEvent(makeEvent({ type: 'scroll', timestamp: 3_000 }))
+    capturer.handleEvent(
+      makeEvent({
+        type: 'app_change',
+        timestamp: 4_000,
+        activeWindow: { title: 'MemoryLane', processName: 'electron' },
+      }),
+    )
+
+    // Capture stops while W2 (Ghostty) is STILL in its late-event grace. The flush
+    // window (Electron) must not jump ahead of the not-yet-finalized Ghostty window.
+    capturer.flush()
+    // Drain the async append chain (the fix emits both Ghostty and Electron here).
+    for (let i = 0; i < 10 && windows.length < 3; i++) {
+      vi.advanceTimersByTime(80)
+      await flushAsyncAppends()
+    }
+    expect(windows).toHaveLength(3)
+
+    const ghosttyIdx = windows.findIndex((window) => appOf(window) === 'ghostty')
+    const electronIdx = windows.findIndex((window) => appOf(window) === 'electron')
+
+    expect(ghosttyIdx).toBeGreaterThanOrEqual(0)
+    expect(electronIdx).toBeGreaterThanOrEqual(0)
+    // Ghostty (closed first) must be emitted before the Electron flush window, so
+    // the producer processes it before Electron's frame-ack trims its frames.
+    expect(ghosttyIdx).toBeLessThan(electronIdx)
+  })
 })

--- a/src/main/event-capturer.ts
+++ b/src/main/event-capturer.ts
@@ -252,7 +252,21 @@ export class EventCapturer {
     const index = this.pendingWindows.findIndex((window) => window.id === windowId)
     if (index < 0) return
 
-    const [pendingWindow] = this.pendingWindows.splice(index, 1)
+    // Finalize this window AND every earlier still-pending one, oldest first, so
+    // windows always reach the stream in close (chronological) order. Otherwise a
+    // window finalized with no grace delay — e.g. the flush window on
+    // capture-stop — can jump ahead of an earlier app_change window still in its
+    // late-event grace. The producer would then process the later window first
+    // and advance its frame ack past the earlier window's range, dropping that
+    // earlier window for "no frames" even though it had screenshots.
+    for (let i = 0; i <= index; i++) {
+      const pendingWindow = this.pendingWindows.shift()
+      if (pendingWindow === undefined) break
+      this.emitPendingWindow(pendingWindow)
+    }
+  }
+
+  private emitPendingWindow(pendingWindow: PendingWindow): void {
     if (pendingWindow.finalizeTimer !== null) {
       clearTimeout(pendingWindow.finalizeTimer)
       pendingWindow.finalizeTimer = null

--- a/src/main/interaction-event-debug-dump.test.ts
+++ b/src/main/interaction-event-debug-dump.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { InteractionEventDebugDumper } from './interaction-event-debug-dump'
+import type { InteractionContext } from '../shared/types'
+
+describe('InteractionEventDebugDumper', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ml-interaction-dump-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('appends one JSONL record per event, carrying dumpedAt and lagMs', () => {
+    const dumper = new InteractionEventDebugDumper(dir)
+    const scroll: InteractionContext = {
+      type: 'scroll',
+      timestamp: 1000,
+      scrollAmount: 5,
+      durationMs: 200,
+    }
+    const appChange: InteractionContext = { type: 'app_change', timestamp: 2000 }
+
+    dumper.dump(scroll)
+    dumper.dump(appChange)
+
+    const lines = fs.readFileSync(dumper.getFilePath(), 'utf8').trim().split('\n')
+    expect(lines).toHaveLength(2)
+
+    const first = JSON.parse(lines[0])
+    expect(first).toMatchObject({
+      type: 'scroll',
+      timestamp: 1000,
+      scrollAmount: 5,
+      durationMs: 200,
+    })
+    expect(typeof first.dumpedAt).toBe('number')
+    expect(first.lagMs).toBe(first.dumpedAt - 1000)
+
+    const second = JSON.parse(lines[1])
+    expect(second).toMatchObject({ type: 'app_change', timestamp: 2000 })
+    expect(second.lagMs).toBe(second.dumpedAt - 2000)
+  })
+
+  it('creates the target directory if it does not exist', () => {
+    const nested = path.join(dir, 'a', 'b')
+    const dumper = new InteractionEventDebugDumper(nested)
+    dumper.dump({ type: 'click', timestamp: 1 })
+    expect(fs.existsSync(dumper.getFilePath())).toBe(true)
+  })
+})

--- a/src/main/interaction-event-debug-dump.ts
+++ b/src/main/interaction-event-debug-dump.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import log from './logger'
+import type { InteractionContext } from '../shared/types'
+
+/**
+ * Appends every emitted InteractionContext to a JSONL file in the debug-pipeline
+ * directory, for inspecting the raw interaction stream (timestamps, durations,
+ * interim scroll/typing sub-windows, app changes).
+ *
+ * Dev-only: wired in runtime.ts behind the same `DEBUG_PIPELINE` gate as the
+ * semantic round-trip dumper, and only for events that pass the capture
+ * blacklist — excluded window titles/URLs (incl. private browsing) must never
+ * reach this plaintext file. Each record carries `dumpedAt` (wall-clock at dump
+ * time) and `lagMs` (dumpedAt - event.timestamp) so the debounce delay between
+ * when an interaction occurred and when it was emitted is visible at a glance.
+ */
+export class InteractionEventDebugDumper {
+  private readonly filePath: string
+
+  constructor(rootDir: string, fileName = 'interaction-events.jsonl') {
+    fs.mkdirSync(rootDir, { recursive: true })
+    this.filePath = path.join(rootDir, fileName)
+    log.info(`[InteractionEventDebugDumper] Writing interaction events to ${this.filePath}`)
+  }
+
+  getFilePath(): string {
+    return this.filePath
+  }
+
+  dump(event: InteractionContext): void {
+    try {
+      const dumpedAt = Date.now()
+      const record = { dumpedAt, lagMs: dumpedAt - event.timestamp, ...event }
+      fs.appendFileSync(this.filePath, `${JSON.stringify(record)}\n`, 'utf8')
+    } catch (error) {
+      log.warn(
+        '[InteractionEventDebugDumper] Failed to write interaction event',
+        error instanceof Error ? error.message : String(error),
+      )
+    }
+  }
+}

--- a/src/main/recorder/interaction-monitor.test.ts
+++ b/src/main/recorder/interaction-monitor.test.ts
@@ -6,7 +6,7 @@ import type { InteractionContext } from '../../shared/types'
 // Defined via vi.hoisted so they are initialized before the hoisted vi.mock
 // factories (and the top-level import of the module under test) run.
 
-const { mockScreen, handlers, mockUiohook } = vi.hoisted(() => {
+const { mockScreen, handlers, mockUiohook, appWatcher } = vi.hoisted(() => {
   const handlers: Record<string, (event: unknown) => void> = {}
   return {
     mockScreen: { getDisplayNearestPoint: vi.fn(() => ({ id: 1 })) },
@@ -19,6 +19,7 @@ const { mockScreen, handlers, mockUiohook } = vi.hoisted(() => {
       stop: vi.fn(),
       removeAllListeners: vi.fn(),
     },
+    appWatcher: { listener: null as ((event: unknown) => void) | null },
   }
 })
 
@@ -29,7 +30,14 @@ vi.mock('uiohook-napi', () => ({
   UiohookWheelEvent: class {},
 }))
 
-vi.mock('./app-watcher', () => ({ addAppWatcherListener: vi.fn(() => () => {}) }))
+vi.mock('./app-watcher', () => ({
+  addAppWatcherListener: vi.fn((listener: (event: unknown) => void) => {
+    appWatcher.listener = listener
+    return () => {
+      appWatcher.listener = null
+    }
+  }),
+}))
 vi.mock('./app-watcher-display', () => ({
   resolveAppWatcherDisplay: vi.fn(() => ({ displayId: 1, source: 'window' })),
 }))
@@ -47,6 +55,10 @@ function wheel(rotation = 1): void {
 
 function key(): void {
   handlers['keydown']?.({})
+}
+
+function appChange(app: string, title: string, timestamp: number): void {
+  appWatcher.listener?.({ type: 'app_change', app, title, timestamp })
 }
 
 describe('interaction-monitor session emission', () => {
@@ -151,6 +163,45 @@ describe('interaction-monitor session emission', () => {
     monitor.stopInteractionMonitoring()
     vi.advanceTimersByTime(60_000)
     expect(emitted).toHaveLength(0)
+  })
+
+  it('flushes a pending typing session on app_change, before the switch context', () => {
+    appChange('Editor', 'Editor — file.ts', 0)
+    vi.advanceTimersByTime(1000) // now = 1000
+    key()
+    vi.advanceTimersByTime(300) // now = 1300, before TYPING_DEBOUNCE_MS elapses
+    appChange('Browser', 'Example — Browser', 1300)
+
+    // Order: initial app_change, then the flushed keyboard session, then the
+    // app_change that triggered the flush.
+    expect(emitted.map((c) => c.type)).toEqual(['app_change', 'keyboard', 'app_change'])
+
+    const keyboard = emitted[1]
+    // Stamped at occurrence time (the raw keydown), not flush time.
+    expect(keyboard.timestamp).toBe(1000)
+    // Carries the pre-switch window title, not the new app's.
+    expect(keyboard.windowTitle).toBe('Editor — file.ts')
+    expect(keyboard.keyCount).toBe(1)
+
+    // The debounce timer was cancelled: no duplicate emit later.
+    vi.advanceTimersByTime(INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS + 1000)
+    expect(emitted).toHaveLength(3)
+  })
+
+  it('does not flush sessions on a deduplicated app_change re-fire', () => {
+    appChange('Editor', 'Editor — file.ts', 0)
+    vi.advanceTimersByTime(1000) // now = 1000
+    key()
+    // Same app/title/display again (e.g. watcher restart double-fire): deduped,
+    // so the pending typing session must NOT be flushed early.
+    appChange('Editor', 'Editor — file.ts', 1100)
+
+    expect(emitted.map((c) => c.type)).toEqual(['app_change'])
+
+    // The session still emits normally once the debounce elapses.
+    vi.advanceTimersByTime(INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS)
+    expect(emitted.map((c) => c.type)).toEqual(['app_change', 'keyboard'])
+    expect(emitted[1].timestamp).toBe(1000)
   })
 })
 

--- a/src/main/recorder/interaction-monitor.test.ts
+++ b/src/main/recorder/interaction-monitor.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { INTERACTION_MONITOR_CONFIG } from '@constants'
+import type { InteractionContext } from '../../shared/types'
+
+// --- Mocks -----------------------------------------------------------------
+// Defined via vi.hoisted so they are initialized before the hoisted vi.mock
+// factories (and the top-level import of the module under test) run.
+
+const { mockScreen, handlers, mockUiohook } = vi.hoisted(() => {
+  const handlers: Record<string, (event: unknown) => void> = {}
+  return {
+    mockScreen: { getDisplayNearestPoint: vi.fn(() => ({ id: 1 })) },
+    handlers,
+    mockUiohook: {
+      on: vi.fn((event: string, handler: (event: unknown) => void) => {
+        handlers[event] = handler
+      }),
+      start: vi.fn(),
+      stop: vi.fn(),
+      removeAllListeners: vi.fn(),
+    },
+  }
+})
+
+vi.mock('electron', () => ({ screen: mockScreen }))
+vi.mock('uiohook-napi', () => ({
+  uIOhook: mockUiohook,
+  UiohookMouseEvent: class {},
+  UiohookWheelEvent: class {},
+}))
+
+vi.mock('./app-watcher', () => ({ addAppWatcherListener: vi.fn(() => () => {}) }))
+vi.mock('./app-watcher-display', () => ({
+  resolveAppWatcherDisplay: vi.fn(() => ({ displayId: 1, source: 'window' })),
+}))
+vi.mock('../logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+import * as monitor from './interaction-monitor'
+
+// --- Helpers ---------------------------------------------------------------
+
+function wheel(rotation = 1): void {
+  handlers['wheel']?.({ rotation, direction: 3, x: 0, y: 0 })
+}
+
+function key(): void {
+  handlers['keydown']?.({})
+}
+
+describe('interaction-monitor session emission', () => {
+  // Registered once; the interaction-callback list is module-level and not
+  // cleared by stop(), so we reuse a single buffer and reset it per test.
+  const emitted: InteractionContext[] = []
+
+  beforeAll(() => {
+    monitor.onInteraction((c) => emitted.push(c))
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const k of Object.keys(handlers)) delete handlers[k]
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    emitted.length = 0
+    monitor.startInteractionMonitoring()
+  })
+
+  afterEach(() => {
+    monitor.stopInteractionMonitoring()
+    vi.useRealTimers()
+  })
+
+  it('emits interim events during a long continuous scroll (instead of one late event)', () => {
+    // 20 wheel events, one every 500ms => 10s of continuous scrolling, which
+    // exceeds MAX_SESSION_MS (4000) and the gap window several times over.
+    for (let i = 0; i < 20; i++) {
+      wheel(1)
+      vi.advanceTimersByTime(500)
+    }
+    // Stop scrolling and let the debounce flush the final sub-window.
+    vi.advanceTimersByTime(INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS)
+
+    // Old behavior emitted exactly one event at the very end; the fix emits
+    // interim sub-windows so the downstream window stays alive.
+    expect(emitted.length).toBeGreaterThan(1)
+    expect(emitted.every((c) => c.type === 'scroll')).toBe(true)
+
+    // An interim must land mid-session, well before the final emit.
+    expect(emitted[0].timestamp).toBeLessThan(emitted[emitted.length - 1].timestamp)
+
+    // Every raw event is accounted for exactly once across sub-windows
+    // (accumulation resets per emit; nothing double-counted or dropped).
+    const totalScroll = emitted.reduce((sum, c) => sum + (c.scrollAmount ?? 0), 0)
+    expect(totalScroll).toBe(20)
+
+    // Each sub-window carries a non-negative duration and a receipt-time stamp.
+    for (const c of emitted) {
+      expect(c.durationMs).toBeGreaterThanOrEqual(0)
+      expect(c.timestamp).toBeGreaterThan(0)
+      expect(c.scrollDirection).toBe('vertical')
+    }
+  })
+
+  it('stamps a short scroll session at the last event receipt time', () => {
+    vi.advanceTimersByTime(1000) // now = 1000
+    wheel(3)
+    vi.advanceTimersByTime(INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS)
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]).toMatchObject({
+      type: 'scroll',
+      timestamp: 1000, // receipt time of the only raw event
+      scrollAmount: 3,
+      durationMs: 0,
+    })
+  })
+
+  it('honors a runtime debounce change without restart (config read lazily)', () => {
+    const original = INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS
+    try {
+      INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS = 500
+      vi.advanceTimersByTime(1000) // now = 1000
+      wheel(2)
+      // With the new 500ms debounce the final emit fires at 1500. If the value
+      // were captured at construction (the regression), nothing emits here.
+      vi.advanceTimersByTime(500)
+      expect(emitted).toHaveLength(1)
+      expect(emitted[0]).toMatchObject({ type: 'scroll', timestamp: 1000, scrollAmount: 2 })
+    } finally {
+      INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS = original
+    }
+  })
+
+  it('emits interim events during a long continuous typing session', () => {
+    for (let i = 0; i < 20; i++) {
+      key()
+      vi.advanceTimersByTime(500)
+    }
+    vi.advanceTimersByTime(INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS)
+
+    expect(emitted.length).toBeGreaterThan(1)
+    expect(emitted.every((c) => c.type === 'keyboard')).toBe(true)
+    const totalKeys = emitted.reduce((sum, c) => sum + (c.keyCount ?? 0), 0)
+    expect(totalKeys).toBe(20)
+  })
+
+  it('cancels pending session timers on stop (no emit after stop)', () => {
+    wheel(1) // opens a session with pending debounce + max-session timers
+    monitor.stopInteractionMonitoring()
+    vi.advanceTimersByTime(60_000)
+    expect(emitted).toHaveLength(0)
+  })
+})

--- a/src/main/recorder/interaction-monitor.test.ts
+++ b/src/main/recorder/interaction-monitor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { INTERACTION_MONITOR_CONFIG } from '@constants'
+import { EVENT_CAPTURER_CONFIG, INTERACTION_MONITOR_CONFIG } from '@constants'
 import type { InteractionContext } from '../../shared/types'
 
 // --- Mocks -----------------------------------------------------------------
@@ -151,5 +151,17 @@ describe('interaction-monitor session emission', () => {
     monitor.stopInteractionMonitoring()
     vi.advanceTimersByTime(60_000)
     expect(emitted).toHaveLength(0)
+  })
+})
+
+describe('interaction-monitor keep-alive invariant', () => {
+  // The interim flush only keeps the downstream event-capturer window alive if a
+  // continuous session emits more often than the gap timer closes it. If this
+  // regresses (e.g. MAX_SESSION_MS bumped to >= GAP_TIMEOUT_MS), long scroll/typing
+  // sessions are silently dropped again — the exact bug this module fixes.
+  it('emits interim sub-windows faster than the event-capturer gap closes the window', () => {
+    expect(INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS).toBeLessThan(
+      EVENT_CAPTURER_CONFIG.GAP_TIMEOUT_MS,
+    )
   })
 })

--- a/src/main/recorder/interaction-monitor.ts
+++ b/src/main/recorder/interaction-monitor.ts
@@ -9,19 +9,6 @@ import log from '../logger'
 // State
 let isRunning = false
 
-// Typing session accumulation (counters only; timers/lifecycle live in `typingSession`)
-let typingSessionKeyCount = 0
-
-// Scroll session accumulation
-let scrollSessionAmount = 0
-let scrollSessionEventCount = 0
-let scrollSessionDirection: 'vertical' | 'horizontal' = 'vertical'
-
-// Click session accumulation
-let clickSessionCount = 0
-let lastClickPosition: { x: number; y: number } | null = null
-let lastClickDisplayId: number | undefined
-
 // App change state
 let previousWindow: NonNullable<InteractionContext['activeWindow']> | null = null
 let previousWindowDisplayId: number | null = null
@@ -70,13 +57,18 @@ function notifyInteraction(context: InteractionContext): void {
  *
  * Each emitted sub-window is timestamped at the receipt time of its last raw
  * event (occurrence time) — not at the moment a timer happens to fire.
+ *
+ * The session owns its accumulation state (`A`): it is reset on session start,
+ * after every emit, and on reset(), so callers only fold raw events in via
+ * record()'s accumulate callback.
  */
-class DebouncedSession {
+class DebouncedSession<A> {
   private active = false
   private debounceTimer: NodeJS.Timeout | null = null
   private maxTimer: NodeJS.Timeout | null = null
   private subWindowStart = 0
   private lastEventTime = 0
+  private accumulation: A
 
   constructor(
     // Read lazily so runtime settings changes (capture-settings-manager
@@ -84,39 +76,41 @@ class DebouncedSession {
     private readonly debounceMs: () => number,
     private readonly maxSessionMs: () => number,
     private readonly handlers: {
-      hasActivity: () => boolean
-      emit: (subWindowStart: number, lastEventTime: number) => void
-      resetAccumulation: () => void
+      initialAccumulation: () => A
+      hasActivity: (accumulation: A) => boolean
+      emit: (accumulation: A, subWindowStart: number, lastEventTime: number) => void
       onStart?: () => void
     },
-  ) {}
+  ) {
+    this.accumulation = handlers.initialAccumulation()
+  }
 
-  /** Call synchronously from the raw event handler, with the receipt time. */
-  record(now: number): void {
+  /**
+   * Call synchronously from the raw event handler, with the receipt time.
+   * `accumulate` folds the raw event into the session's accumulation.
+   */
+  record(now: number, accumulate: (accumulation: A) => void): void {
     if (!this.active) {
       this.active = true
       this.subWindowStart = now
-      this.handlers.resetAccumulation()
+      this.accumulation = this.handlers.initialAccumulation()
       this.handlers.onStart?.()
       this.maxTimer = setTimeout(() => this.flushInterim(), this.maxSessionMs())
     }
     this.lastEventTime = now
+    accumulate(this.accumulation)
     if (this.debounceTimer) clearTimeout(this.debounceTimer)
-    this.debounceTimer = setTimeout(() => this.flushFinal(), this.debounceMs())
+    this.debounceTimer = setTimeout(() => this.flush(), this.debounceMs())
   }
 
   private flushInterim(): void {
-    if (this.handlers.hasActivity()) {
-      this.handlers.emit(this.subWindowStart, this.lastEventTime)
-      this.handlers.resetAccumulation()
+    if (this.handlers.hasActivity(this.accumulation)) {
+      this.handlers.emit(this.accumulation, this.subWindowStart, this.lastEventTime)
+      this.accumulation = this.handlers.initialAccumulation()
       this.subWindowStart = this.lastEventTime
     }
     // Re-arm: continuous input keeps emitting at most maxSessionMs apart.
     this.maxTimer = setTimeout(() => this.flushInterim(), this.maxSessionMs())
-  }
-
-  private flushFinal(): void {
-    this.flush()
   }
 
   /**
@@ -126,16 +120,16 @@ class DebouncedSession {
    * the debounce timer with post-switch cached context.
    */
   flush(): void {
-    if (this.active && this.handlers.hasActivity()) {
-      this.handlers.emit(this.subWindowStart, this.lastEventTime)
-      this.handlers.resetAccumulation()
+    if (this.active && this.handlers.hasActivity(this.accumulation)) {
+      this.handlers.emit(this.accumulation, this.subWindowStart, this.lastEventTime)
     }
     this.reset()
   }
 
-  /** Cancel timers and clear lifecycle state without emitting (used on stop). */
+  /** Cancel timers and clear all session state without emitting (used on stop). */
   reset(): void {
     this.active = false
+    this.accumulation = this.handlers.initialAccumulation()
     if (this.maxTimer) {
       clearTimeout(this.maxTimer)
       this.maxTimer = null
@@ -147,24 +141,32 @@ class DebouncedSession {
   }
 }
 
+interface ClickAccumulation {
+  count: number
+  position: { x: number; y: number } | null
+  displayId: number | undefined
+}
+
 const clickSession = new DebouncedSession(
   () => INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS,
   () => INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS,
   {
-    hasActivity: () => clickSessionCount > 0,
-    resetAccumulation: () => {
-      clickSessionCount = 0
-    },
+    initialAccumulation: (): ClickAccumulation => ({
+      count: 0,
+      position: null,
+      displayId: undefined,
+    }),
+    hasActivity: (accumulation) => accumulation.count > 0,
     onStart: () => log.info('[Interaction Monitor] Click session started'),
-    emit: (subWindowStart, lastEventTime) => {
+    emit: (accumulation, subWindowStart, lastEventTime) => {
       log.info(
-        `[Interaction Monitor] Click session: ${clickSessionCount} clicks over ${lastEventTime - subWindowStart}ms`,
+        `[Interaction Monitor] Click session: ${accumulation.count} clicks over ${lastEventTime - subWindowStart}ms`,
       )
       notifyInteraction({
         type: 'click',
         timestamp: lastEventTime,
-        displayId: lastClickDisplayId,
-        clickPosition: lastClickPosition ?? undefined,
+        displayId: accumulation.displayId,
+        clickPosition: accumulation.position ?? undefined,
       })
     },
   },
@@ -174,20 +176,18 @@ const typingSession = new DebouncedSession(
   () => INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS,
   () => INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS,
   {
-    hasActivity: () => typingSessionKeyCount > 0,
-    resetAccumulation: () => {
-      typingSessionKeyCount = 0
-    },
+    initialAccumulation: () => ({ keyCount: 0 }),
+    hasActivity: (accumulation) => accumulation.keyCount > 0,
     onStart: () => log.info('[Interaction Monitor] Typing session started'),
-    emit: (subWindowStart, lastEventTime) => {
+    emit: (accumulation, subWindowStart, lastEventTime) => {
       log.info(
-        `[Interaction Monitor] Typing session: ${typingSessionKeyCount} keys over ${lastEventTime - subWindowStart}ms`,
+        `[Interaction Monitor] Typing session: ${accumulation.keyCount} keys over ${lastEventTime - subWindowStart}ms`,
       )
       notifyInteraction({
         type: 'keyboard',
         timestamp: lastEventTime,
         displayId: cachedDisplayId ?? undefined,
-        keyCount: typingSessionKeyCount,
+        keyCount: accumulation.keyCount,
         durationMs: Math.max(0, lastEventTime - subWindowStart),
         windowTitle: cachedWindowTitle ?? undefined,
       })
@@ -195,26 +195,33 @@ const typingSession = new DebouncedSession(
   },
 )
 
+interface ScrollAccumulation {
+  amount: number
+  eventCount: number
+  direction: 'vertical' | 'horizontal'
+}
+
 const scrollSession = new DebouncedSession(
   () => INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS,
   () => INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS,
   {
-    hasActivity: () => scrollSessionEventCount > 0,
-    resetAccumulation: () => {
-      scrollSessionAmount = 0
-      scrollSessionEventCount = 0
-    },
+    initialAccumulation: (): ScrollAccumulation => ({
+      amount: 0,
+      eventCount: 0,
+      direction: 'vertical',
+    }),
+    hasActivity: (accumulation) => accumulation.eventCount > 0,
     onStart: () => log.info('[Interaction Monitor] Scroll session started'),
-    emit: (subWindowStart, lastEventTime) => {
+    emit: (accumulation, subWindowStart, lastEventTime) => {
       log.info(
-        `[Interaction Monitor] Scroll session: ${scrollSessionAmount} rotation over ${lastEventTime - subWindowStart}ms`,
+        `[Interaction Monitor] Scroll session: ${accumulation.amount} rotation over ${lastEventTime - subWindowStart}ms`,
       )
       notifyInteraction({
         type: 'scroll',
         timestamp: lastEventTime,
         displayId: cachedDisplayId ?? undefined,
-        scrollDirection: scrollSessionDirection,
-        scrollAmount: scrollSessionAmount,
+        scrollDirection: accumulation.direction,
+        scrollAmount: accumulation.amount,
         durationMs: Math.max(0, lastEventTime - subWindowStart),
       })
     },
@@ -231,10 +238,11 @@ function handleMouseClick(event: UiohookMouseEvent): void {
     return
   }
 
-  clickSession.record(Date.now())
-  clickSessionCount++
-  lastClickPosition = { x: event.x, y: event.y }
-  lastClickDisplayId = getDisplayIdForPoint(event.x, event.y)
+  clickSession.record(Date.now(), (accumulation) => {
+    accumulation.count++
+    accumulation.position = { x: event.x, y: event.y }
+    accumulation.displayId = getDisplayIdForPoint(event.x, event.y)
+  })
 }
 
 /**
@@ -246,8 +254,9 @@ function handleKeyboard(): void {
     return
   }
 
-  typingSession.record(Date.now())
-  typingSessionKeyCount++
+  typingSession.record(Date.now(), (accumulation) => {
+    accumulation.keyCount++
+  })
 }
 
 /**
@@ -259,10 +268,11 @@ function handleScroll(event: UiohookWheelEvent): void {
     return
   }
 
-  scrollSession.record(Date.now())
-  scrollSessionAmount += event.rotation
-  scrollSessionEventCount++
-  scrollSessionDirection = event.direction === 3 ? 'vertical' : 'horizontal' // WheelDirection.VERTICAL = 3
+  scrollSession.record(Date.now(), (accumulation) => {
+    accumulation.amount += event.rotation
+    accumulation.eventCount++
+    accumulation.direction = event.direction === 3 ? 'vertical' : 'horizontal' // WheelDirection.VERTICAL = 3
+  })
 }
 
 /**
@@ -416,12 +426,6 @@ export function stopInteractionMonitoring(): void {
     clickSession.reset()
     typingSession.reset()
     scrollSession.reset()
-    typingSessionKeyCount = 0
-    scrollSessionAmount = 0
-    scrollSessionEventCount = 0
-    clickSessionCount = 0
-    lastClickPosition = null
-    lastClickDisplayId = undefined
     previousWindow = null
     previousWindowDisplayId = null
     cachedDisplayId = null

--- a/src/main/recorder/interaction-monitor.ts
+++ b/src/main/recorder/interaction-monitor.ts
@@ -116,7 +116,17 @@ class DebouncedSession {
   }
 
   private flushFinal(): void {
-    if (this.handlers.hasActivity()) {
+    this.flush()
+  }
+
+  /**
+   * Emit any pending accumulation now (stamped at occurrence time) and end the
+   * session, cancelling both timers. Called synchronously on app_change so the
+   * sub-window is attributed to the app it happened in — not emitted later by
+   * the debounce timer with post-switch cached context.
+   */
+  flush(): void {
+    if (this.active && this.handlers.hasActivity()) {
       this.handlers.emit(this.subWindowStart, this.lastEventTime)
       this.handlers.resetAccumulation()
     }
@@ -282,9 +292,6 @@ function handleAppWatcherEvent(event: AppWatcherEvent): void {
     ...(event.url && { url: event.url }),
   }
 
-  // Cache window title for keyboard context enrichment
-  cachedWindowTitle = current.title
-
   const resolvedDisplay = resolveAppWatcherDisplay(event)
   if (resolvedDisplay.source === 'cursor_fallback' && event.windowBounds) {
     log.warn(
@@ -305,6 +312,15 @@ function handleAppWatcherEvent(event: AppWatcherEvent): void {
     return
   }
 
+  // Flush pending sessions before the cached context below is overwritten, so
+  // their emits carry the pre-switch windowTitle/displayId and reach downstream
+  // consumers ahead of the app_change (no late, misattributed sub-windows).
+  clickSession.flush()
+  typingSession.flush()
+  scrollSession.flush()
+
+  // Cache window title for keyboard context enrichment
+  cachedWindowTitle = current.title
   cachedDisplayId = resolvedDisplayId
 
   log.info(

--- a/src/main/recorder/interaction-monitor.ts
+++ b/src/main/recorder/interaction-monitor.ts
@@ -8,22 +8,17 @@ import log from '../logger'
 
 // State
 let isRunning = false
-let typingSessionTimeoutId: NodeJS.Timeout | null = null
-let isTyping = false
+
+// Typing session accumulation (counters only; timers/lifecycle live in `typingSession`)
 let typingSessionKeyCount = 0
-let typingSessionStartTime = 0
 
-// Scroll state
-let scrollSessionTimeoutId: NodeJS.Timeout | null = null
-let isScrolling = false
+// Scroll session accumulation
 let scrollSessionAmount = 0
+let scrollSessionEventCount = 0
 let scrollSessionDirection: 'vertical' | 'horizontal' = 'vertical'
-let scrollSessionStartTime = 0
 
-// Click debounce state
-let clickSessionTimeoutId: NodeJS.Timeout | null = null
+// Click session accumulation
 let clickSessionCount = 0
-let clickSessionStartTime = 0
 let lastClickPosition: { x: number; y: number } | null = null
 let lastClickDisplayId: number | undefined
 
@@ -51,6 +46,171 @@ function getDisplayIdForPoint(x: number, y: number): number {
 type OnInteractionCallback = (context: InteractionContext) => void
 const interactionCallbacks: OnInteractionCallback[] = []
 
+function notifyInteraction(context: InteractionContext): void {
+  interactionCallbacks.forEach((callback) => {
+    try {
+      callback(context)
+    } catch (error) {
+      log.error('Error in interaction callback:', error)
+    }
+  })
+}
+
+/**
+ * Manages a debounced interaction "session" — a burst of same-type raw events
+ * (clicks, keystrokes, scroll) coalesced into emitted InteractionContexts.
+ *
+ * Two timers drive emission:
+ * - a debounce timer, reset on every raw event, emits the final sub-window once
+ *   input stops; and
+ * - a max-session timer that emits an interim sub-window during *continuous*
+ *   input, so a long session (e.g. a 30s scroll) keeps emitting and the
+ *   downstream event-capturer window stays alive instead of being cut by its
+ *   idle/gap timer.
+ *
+ * Each emitted sub-window is timestamped at the receipt time of its last raw
+ * event (occurrence time) — not at the moment a timer happens to fire.
+ */
+class DebouncedSession {
+  private active = false
+  private debounceTimer: NodeJS.Timeout | null = null
+  private maxTimer: NodeJS.Timeout | null = null
+  private subWindowStart = 0
+  private lastEventTime = 0
+
+  constructor(
+    // Read lazily so runtime settings changes (capture-settings-manager
+    // mutates INTERACTION_MONITOR_CONFIG) take effect without a restart.
+    private readonly debounceMs: () => number,
+    private readonly maxSessionMs: () => number,
+    private readonly handlers: {
+      hasActivity: () => boolean
+      emit: (subWindowStart: number, lastEventTime: number) => void
+      resetAccumulation: () => void
+      onStart?: () => void
+    },
+  ) {}
+
+  /** Call synchronously from the raw event handler, with the receipt time. */
+  record(now: number): void {
+    if (!this.active) {
+      this.active = true
+      this.subWindowStart = now
+      this.handlers.resetAccumulation()
+      this.handlers.onStart?.()
+      this.maxTimer = setTimeout(() => this.flushInterim(), this.maxSessionMs())
+    }
+    this.lastEventTime = now
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => this.flushFinal(), this.debounceMs())
+  }
+
+  private flushInterim(): void {
+    if (this.handlers.hasActivity()) {
+      this.handlers.emit(this.subWindowStart, this.lastEventTime)
+      this.handlers.resetAccumulation()
+      this.subWindowStart = this.lastEventTime
+    }
+    // Re-arm: continuous input keeps emitting at most maxSessionMs apart.
+    this.maxTimer = setTimeout(() => this.flushInterim(), this.maxSessionMs())
+  }
+
+  private flushFinal(): void {
+    if (this.handlers.hasActivity()) {
+      this.handlers.emit(this.subWindowStart, this.lastEventTime)
+      this.handlers.resetAccumulation()
+    }
+    this.reset()
+  }
+
+  /** Cancel timers and clear lifecycle state without emitting (used on stop). */
+  reset(): void {
+    this.active = false
+    if (this.maxTimer) {
+      clearTimeout(this.maxTimer)
+      this.maxTimer = null
+    }
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+      this.debounceTimer = null
+    }
+  }
+}
+
+const clickSession = new DebouncedSession(
+  () => INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS,
+  () => INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS,
+  {
+    hasActivity: () => clickSessionCount > 0,
+    resetAccumulation: () => {
+      clickSessionCount = 0
+    },
+    onStart: () => log.info('[Interaction Monitor] Click session started'),
+    emit: (subWindowStart, lastEventTime) => {
+      log.info(
+        `[Interaction Monitor] Click session: ${clickSessionCount} clicks over ${lastEventTime - subWindowStart}ms`,
+      )
+      notifyInteraction({
+        type: 'click',
+        timestamp: lastEventTime,
+        displayId: lastClickDisplayId,
+        clickPosition: lastClickPosition ?? undefined,
+      })
+    },
+  },
+)
+
+const typingSession = new DebouncedSession(
+  () => INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS,
+  () => INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS,
+  {
+    hasActivity: () => typingSessionKeyCount > 0,
+    resetAccumulation: () => {
+      typingSessionKeyCount = 0
+    },
+    onStart: () => log.info('[Interaction Monitor] Typing session started'),
+    emit: (subWindowStart, lastEventTime) => {
+      log.info(
+        `[Interaction Monitor] Typing session: ${typingSessionKeyCount} keys over ${lastEventTime - subWindowStart}ms`,
+      )
+      notifyInteraction({
+        type: 'keyboard',
+        timestamp: lastEventTime,
+        displayId: cachedDisplayId ?? undefined,
+        keyCount: typingSessionKeyCount,
+        durationMs: Math.max(0, lastEventTime - subWindowStart),
+        windowTitle: cachedWindowTitle ?? undefined,
+      })
+    },
+  },
+)
+
+const scrollSession = new DebouncedSession(
+  () => INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS,
+  () => INTERACTION_MONITOR_CONFIG.MAX_SESSION_MS,
+  {
+    hasActivity: () => scrollSessionEventCount > 0,
+    resetAccumulation: () => {
+      scrollSessionAmount = 0
+      scrollSessionEventCount = 0
+    },
+    onStart: () => log.info('[Interaction Monitor] Scroll session started'),
+    emit: (subWindowStart, lastEventTime) => {
+      log.info(
+        `[Interaction Monitor] Scroll session: ${scrollSessionAmount} rotation over ${lastEventTime - subWindowStart}ms`,
+      )
+      notifyInteraction({
+        type: 'scroll',
+        timestamp: lastEventTime,
+        displayId: cachedDisplayId ?? undefined,
+        scrollDirection: scrollSessionDirection,
+        scrollAmount: scrollSessionAmount,
+        durationMs: Math.max(0, lastEventTime - subWindowStart),
+      })
+    },
+  },
+)
+
 /**
  * Handle mouse click events
  * Debounced: accumulates clicks and emits a single event when clicking stops,
@@ -61,51 +221,10 @@ function handleMouseClick(event: UiohookMouseEvent): void {
     return
   }
 
-  const now = Date.now()
-
-  if (clickSessionTimeoutId) {
-    clearTimeout(clickSessionTimeoutId)
-  }
-
-  if (clickSessionCount === 0) {
-    clickSessionStartTime = now
-    log.info('[Interaction Monitor] Click session started')
-  }
-
+  clickSession.record(Date.now())
   clickSessionCount++
   lastClickPosition = { x: event.x, y: event.y }
   lastClickDisplayId = getDisplayIdForPoint(event.x, event.y)
-
-  clickSessionTimeoutId = setTimeout(() => {
-    if (clickSessionCount === 0) return
-
-    const endTime = Date.now() - INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS
-    const durationMs = endTime - clickSessionStartTime
-
-    log.info(
-      `[Interaction Monitor] Click session ended: ${clickSessionCount} clicks over ${durationMs}ms`,
-    )
-
-    const context: InteractionContext = {
-      type: 'click',
-      timestamp: endTime,
-      displayId: lastClickDisplayId,
-      clickPosition: lastClickPosition ?? undefined,
-    }
-
-    interactionCallbacks.forEach((callback) => {
-      try {
-        callback(context)
-      } catch (error) {
-        log.error('Error in interaction callback:', error)
-      }
-    })
-
-    clickSessionCount = 0
-    clickSessionStartTime = 0
-    lastClickPosition = null
-    lastClickDisplayId = undefined
-  }, INTERACTION_MONITOR_CONFIG.CLICK_DEBOUNCE_MS)
 }
 
 /**
@@ -117,58 +236,8 @@ function handleKeyboard(): void {
     return
   }
 
-  const now = Date.now()
-
-  // Clear any existing typing session timeout
-  if (typingSessionTimeoutId) {
-    clearTimeout(typingSessionTimeoutId)
-  }
-
-  // Mark that user is typing and track session
-  if (!isTyping) {
-    isTyping = true
-    typingSessionKeyCount = 0
-    typingSessionStartTime = now
-    log.info('[Interaction Monitor] Typing session started')
-  }
-
-  // Increment key count
+  typingSession.record(Date.now())
   typingSessionKeyCount++
-
-  // Set timeout to detect when typing stops
-  typingSessionTimeoutId = setTimeout(() => {
-    if (!isTyping) return
-
-    isTyping = false
-    const endTime = Date.now() - INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS
-    const durationMs = Math.max(0, endTime - typingSessionStartTime)
-
-    log.info(
-      `[Interaction Monitor] Typing session ended: ${typingSessionKeyCount} keys over ${durationMs}ms`,
-    )
-
-    const context: InteractionContext = {
-      type: 'keyboard',
-      timestamp: endTime,
-      displayId: cachedDisplayId ?? undefined,
-      keyCount: typingSessionKeyCount,
-      durationMs: durationMs,
-      windowTitle: cachedWindowTitle ?? undefined,
-    }
-
-    // Notify all callbacks
-    interactionCallbacks.forEach((callback) => {
-      try {
-        callback(context)
-      } catch (error) {
-        log.error('Error in interaction callback:', error)
-      }
-    })
-
-    // Reset session tracking
-    typingSessionKeyCount = 0
-    typingSessionStartTime = 0
-  }, INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS)
 }
 
 /**
@@ -180,58 +249,10 @@ function handleScroll(event: UiohookWheelEvent): void {
     return
   }
 
-  const now = Date.now()
-
-  // Clear any existing scroll session timeout
-  if (scrollSessionTimeoutId) {
-    clearTimeout(scrollSessionTimeoutId)
-  }
-
-  // Mark that user is scrolling and track session
-  if (!isScrolling) {
-    isScrolling = true
-    scrollSessionAmount = 0
-    scrollSessionStartTime = now
-    scrollSessionDirection = event.direction === 3 ? 'vertical' : 'horizontal' // WheelDirection.VERTICAL = 3
-    log.info('[Interaction Monitor] Scroll session started')
-  }
-
-  // Accumulate scroll amount
+  scrollSession.record(Date.now())
   scrollSessionAmount += event.rotation
-
-  // Set timeout to detect when scrolling stops
-  scrollSessionTimeoutId = setTimeout(() => {
-    if (!isScrolling) return
-
-    isScrolling = false
-    const endTime = Date.now() - INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS
-    const durationMs = endTime - scrollSessionStartTime
-
-    log.info(
-      `[Interaction Monitor] Scroll session ended: ${scrollSessionAmount} rotation over ${durationMs}ms`,
-    )
-
-    const context: InteractionContext = {
-      type: 'scroll',
-      timestamp: endTime,
-      displayId: cachedDisplayId ?? undefined,
-      scrollDirection: scrollSessionDirection,
-      scrollAmount: scrollSessionAmount,
-    }
-
-    // Notify all callbacks
-    interactionCallbacks.forEach((callback) => {
-      try {
-        callback(context)
-      } catch (error) {
-        log.error('Error in interaction callback:', error)
-      }
-    })
-
-    // Reset session tracking
-    scrollSessionAmount = 0
-    scrollSessionStartTime = 0
-  }, INTERACTION_MONITOR_CONFIG.SCROLL_DEBOUNCE_MS)
+  scrollSessionEventCount++
+  scrollSessionDirection = event.direction === 3 ? 'vertical' : 'horizontal' // WheelDirection.VERTICAL = 3
 }
 
 /**
@@ -374,38 +395,21 @@ export function stopInteractionMonitoring(): void {
   try {
     log.info('[Interaction Monitor] Stopping')
     isRunning = false
-    isTyping = false
+
+    // Cancel pending session timers and clear accumulation
+    clickSession.reset()
+    typingSession.reset()
+    scrollSession.reset()
     typingSessionKeyCount = 0
-    typingSessionStartTime = 0
-    isScrolling = false
     scrollSessionAmount = 0
-    scrollSessionStartTime = 0
+    scrollSessionEventCount = 0
     clickSessionCount = 0
-    clickSessionStartTime = 0
     lastClickPosition = null
     lastClickDisplayId = undefined
     previousWindow = null
     previousWindowDisplayId = null
     cachedDisplayId = null
     cachedWindowTitle = null
-
-    // Clear any pending typing session timeout
-    if (typingSessionTimeoutId) {
-      clearTimeout(typingSessionTimeoutId)
-      typingSessionTimeoutId = null
-    }
-
-    // Clear any pending scroll session timeout
-    if (scrollSessionTimeoutId) {
-      clearTimeout(scrollSessionTimeoutId)
-      scrollSessionTimeoutId = null
-    }
-
-    // Clear any pending click session timeout
-    if (clickSessionTimeoutId) {
-      clearTimeout(clickSessionTimeoutId)
-      clickSessionTimeoutId = null
-    }
 
     // Stop the native app-watcher process (only our listener; others may still be attached)
     if (appWatcherUnsubscribe) {

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -18,6 +18,7 @@ import { SqliteActivitySink } from './sqlite-activity-sink'
 import { FfmpegVideoStitcher } from './video/video-stitcher'
 import { ActivitySemanticService, SemanticFileDebugDumper } from './activity-semantic-service'
 import type { SemanticPipelinePreference } from './activity-semantic-service'
+import { InteractionEventDebugDumper } from './interaction-event-debug-dump'
 import { InferenceProviderImpl, type InferenceProvider } from './llm'
 import type { Vendor } from '../shared/types'
 import { VENDOR_PRESETS, buildModelChain } from '../shared/vendor-defaults'
@@ -80,14 +81,19 @@ export async function createMainRuntime(params: {
   applyMigrations(storage.getDatabase())
   const usageTracker = new UsageTracker()
 
+  const debugPipelineDir = path.join(app.getAppPath(), '.debug-pipeline')
   const debugDumper =
     !app.isPackaged && process.env.DEBUG_PIPELINE
       ? new SemanticFileDebugDumper({
-          rootDir: path.join(app.getAppPath(), '.debug-pipeline'),
+          rootDir: debugPipelineDir,
           cleanRootDir: true,
           copyMediaAssets: true,
         })
       : undefined
+  // Created after the semantic dumper so its cleanRootDir has already run.
+  const interactionDumper = debugDumper
+    ? new InteractionEventDebugDumper(debugPipelineDir)
+    : undefined
 
   // Debug-only: keep screenshots (skip per-activity cleanup + the stale sweep)
   // so frames survive for inspection. On by default whenever the debug pipeline
@@ -170,6 +176,9 @@ export async function createMainRuntime(params: {
     initialExcludePrivateBrowsing: params.excludePrivateBrowsing,
     onPrivacyBlockingChanged: params.onPrivacyBlockingChanged,
     forwardInteraction: (event) => {
+      // Dump only events that passed the blacklist — excluded window
+      // titles/URLs must never reach the plaintext JSONL.
+      interactionDumper?.dump(event)
       harness.handleEvent(event)
     },
     flushEvents: () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -16,8 +16,17 @@ export const INTERACTION_MONITOR_CONFIG = {
   SCROLL_DEBOUNCE_MS: 2000, // Wait for scrolling to stop before emitting event (200-2000ms)
   // Force-emit an interim event when a continuous session runs longer than this,
   // so long scroll/typing keeps the event-capturer's window alive instead of
-  // being cut by its idle gap. MUST be > the longest debounce above and
-  // < EVENT_CAPTURER_CONFIG.GAP_TIMEOUT_MS.
+  // being cut by its idle gap. The binding invariant is
+  // MAX_SESSION_MS < EVENT_CAPTURER_CONFIG.GAP_TIMEOUT_MS — otherwise a continuous
+  // session emits less often than the gap and the downstream window is dropped
+  // (guarded by a test in interaction-monitor.test.ts).
+  //
+  // This is independent of the debounce values above: debounce controls when a
+  // session is considered *finished*, while this caps how long a *running* session
+  // goes between emits. When a user-configured debounce exceeds this (the UI allows
+  // up to 10s), a long session is intentionally split into interim sub-windows —
+  // each stamped at receipt time, with no events lost or double-counted — because
+  // honoring a debounce longer than the gap would let the window die.
   MAX_SESSION_MS: 4000,
 }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,6 +14,11 @@ export const INTERACTION_MONITOR_CONFIG = {
   CLICK_DEBOUNCE_MS: 3000, // Wait for clicking to stop before emitting event (500-5000ms)
   TYPING_DEBOUNCE_MS: 2000, // Wait for typing to stop before emitting event (500-5000ms)
   SCROLL_DEBOUNCE_MS: 2000, // Wait for scrolling to stop before emitting event (200-2000ms)
+  // Force-emit an interim event when a continuous session runs longer than this,
+  // so long scroll/typing keeps the event-capturer's window alive instead of
+  // being cut by its idle gap. MUST be > the longest debounce above and
+  // < EVENT_CAPTURER_CONFIG.GAP_TIMEOUT_MS.
+  MAX_SESSION_MS: 4000,
 }
 
 // App Watcher Configuration (platform-native subprocess for app/window change detection)


### PR DESCRIPTION
## Summary

Part 1 of 3 rebuilding the activity-boundary fixes from #159 (closed unmerged) per the reviewed v2 spec. This PR carries the verified-correct, pure-TS fixes — no native rebuild needed.

- **Interaction monitor: `DebouncedSession` with interim emits** (ported from #159, verified sound). Long continuous typing/scroll used to emit only after input stopped, so the event-capturer's 5s gap timer killed the window mid-session and all its frames were lost. Sessions now force-emit interim sub-windows every `MAX_SESSION_MS` (4s) and every emit is stamped at occurrence time, not timer-fire time. A test guards the `MAX_SESSION_MS < GAP_TIMEOUT_MS` keep-alive invariant.
- **EventCapturer: finalize pending windows in close order** (ported from #159, verified). A no-grace flush window could finalize ahead of an earlier in-grace window, letting the producer's frame ack prune the earlier window's frames. Windows now reach the stream in chronological close order.
- **NEW: flush pending sessions synchronously on app_change.** Closes the residual late-final race (debounce raised >3.5s + switch within 500ms of last input) and fixes flush-time `windowTitle`/`displayId` misattribution — flushed emits carry the pre-switch context and arrive ahead of the app_change.
- **Debug dumper for interaction events** (`DEBUG_PIPELINE` only), ported with a privacy fix: the dump moved to the blacklist coordinator's forward path, so excluded window titles/URLs (incl. private browsing) never reach the plaintext JSONL.
- **Regression pin:** a frameless incompatible window (quick cmd-tab bounce) must not split the surrounding activity — pins the revert of the frameless-finalize commit from #159.

## Test plan

- [x] `npm run test` — 713 passed (new: flush-on-app_change, dedupe-no-flush, quick-bounce merge pin, dumper tests)
- [x] `npm run lint` — clean (pre-existing warnings only)
- [ ] Manual: 30s continuous scroll → one activity with ~30 frames; `interaction-events.jsonl` lagMs ≤ ~4s (full acceptance after part 3)

Part 2 will add native grab-time app stamping; part 3 the frame-app filter, bounded trailing-frame drop, and producer stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)