### PR TITLE
fix(app-watcher): emit initial frontmost app so the first activity isn't 'Unknown'

### DIFF
--- a/src/main/recorder/swift/app-watcher.swift
+++ b/src/main/recorder/swift/app-watcher.swift
@@ -352,5 +352,15 @@ emit([
     "timestamp": nowMs(),
 ])
 
+// Emit the current frontmost app as the initial app_change so the first activity
+// inherits its real identity instead of falling back to 'Unknown'. NSWorkspace
+// only notifies on focus *changes*, so the app already focused at launch would
+// otherwise never be announced. (The Windows watcher already emits the initial
+// foreground window on startup — see native/windows/app-watcher/src/main.rs.)
+if let frontmost = NSWorkspace.shared.frontmostApplication {
+    let title = windowTitle(forPid: frontmost.processIdentifier) ?? ""
+    emit(buildEvent(type: "app_change", app: frontmost, title: title))
+}
+
 // Keep the process alive
 RunLoop.main.run()


### PR DESCRIPTION
## Summary

The app-watcher now emits the frontmost app once on startup, so the first activity of a session gets a real app context instead of "Unknown". Verified safe without AX permission; the restart double-fire is deduped downstream.

**Scope note:** this PR originally also carried grab-time app stamping of frames (`screenshot.swift` FrontmostAppTracker). That was dropped after manual testing showed the NSWorkspace-based stamp lags the actual screen content by 1–2s during quick app switches — the exact window where it needed to be accurate — so it could not fix the cross-app frame leak and added complexity for nothing. #163 (the filter built on those stamps) is closed for the same reason.

## Test plan

- [x] `npm run test`
- [x] `npm run build:swift`
- [ ] Manual: start capture fresh → first activity carries the real frontmost app, not "Unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)