### PR TITLE
fix: filter leaked frames by grab-time app stamp, drop boundary bleed frames

### DIFF
--- a/src/main/activity-producer.test.ts
+++ b/src/main/activity-producer.test.ts
@@ -16,7 +16,11 @@ vi.mock('./logger', () => ({
   },
 }))
 
-function makeFrame(timestamp: number, sequenceNumber: number): Frame {
+function makeFrame(
+  timestamp: number,
+  sequenceNumber: number,
+  app?: { appName: string; bundleId?: string },
+): Frame {
   return {
     filepath: `frame-${sequenceNumber}.png`,
     timestamp,
@@ -24,6 +28,7 @@ function makeFrame(timestamp: number, sequenceNumber: number): Frame {
     height: 720,
     displayId: 1,
     sequenceNumber,
+    ...(app ?? {}),
   }
 }
 
@@ -487,9 +492,596 @@ describe('ActivityProducer', () => {
     expect(activities).toHaveLength(1)
     expect(activities[0].context.appName).toBe('Unknown')
     expect(activities[0].provenance.eventWindowOffsets).toEqual([noContextOffset])
-    expect(producer.getStats().droppedUnknownContextWindows).toBe(0)
+    expect(producer.getStats().droppedAllFramesFilteredWindows).toBe(0)
     expect(producer.getStats().droppedNoFrameWindows).toBe(1)
     expect(noContextOffset).toBeLessThan(noFrameOffset)
+  })
+
+  it('excludes a frame whose stamped app does not match the window context', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_000, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_200, 1, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].context.appName).toBe('Code')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(1)
+  })
+
+  it('retains an app-less (unstamped) frame regardless of context', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(makeFrame(1_000, 0)) // no app stamp
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames).toHaveLength(1)
+  })
+
+  it('matches on appName when the frame carries no bundleId', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(makeFrame(1_000, 0, { appName: 'Code' })) // matches by appName
+    await frameStream.append(makeFrame(1_200, 1, { appName: 'Slack' })) // excluded by appName
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+  })
+
+  it('prefers bundleId: excludes a frame whose bundleId differs even if appName matches', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(makeFrame(1_000, 0, { appName: 'Helper', bundleId: 'com.a' }))
+    await frameStream.append(makeFrame(1_200, 1, { appName: 'Helper', bundleId: 'com.b' }))
+    await eventStream.append(
+      makeWindow({
+        id: 'helper-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: { title: 'A', processName: 'Helper', bundleId: 'com.a' },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+  })
+
+  it('counts a window whose only frames are app-mismatched as all-filtered, without splitting the pending activity', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_500, 0, { appName: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }),
+    )
+    // Lands in W2's time range but is stamped with the PREVIOUS app (the leak):
+    // excluded from the Electron window, leaving it frameless.
+    await frameStream.append(
+      makeFrame(2_100, 1, { appName: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }),
+    )
+
+    await eventStream.append(
+      makeWindow({
+        id: 'ghostty',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'session',
+              processName: 'Ghostty',
+              bundleId: 'com.mitchellh.ghostty',
+            },
+          }),
+          makeEvent(1_600, 'scroll'),
+        ],
+      }),
+    )
+
+    await eventStream.append(
+      makeWindow({
+        id: 'electron',
+        startTimestamp: 2_000,
+        endTimestamp: 2_200,
+        closedBy: 'gap',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            displayId: 1,
+            activeWindow: {
+              title: 'MemoryLane',
+              processName: 'Electron',
+              bundleId: 'com.github.Electron',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(
+      () => producer.getStats().droppedAllFramesFilteredWindows === 1,
+      'Expected the all-filtered Electron window to be processed',
+    )
+    // The Electron window had a frame in range but it was app-filtered out, so
+    // it counts as all-filtered, not genuinely no-frame — and being frameless
+    // it must NOT finalize the pending Ghostty activity (a frameless quick
+    // bounce would otherwise split the surrounding activity).
+    expect(producer.getStats().droppedAllFramesFilteredWindows).toBe(1)
+    expect(producer.getStats().droppedNoFrameWindows).toBe(0)
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(1)
+    expect(activities).toHaveLength(0)
+
+    await producer.flush()
+    expect(activities.map((a) => a.context.appName)).toEqual(['Ghostty'])
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+  })
+
+  it('keeps stamped frames in an Unknown-context window (filter fails open on fallback)', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_050, 0, { appName: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'unknown',
+        startTimestamp: 1_000,
+        endTimestamp: 1_100,
+        closedBy: 'flush',
+        events: [makeEvent(1_020, 'keyboard')], // no app_change -> 'Unknown' fallback context
+      }),
+    )
+
+    // The 'Unknown' context isn't backed by a real activeWindow event, so the
+    // filter must not apply — excluding the stamped frame would blank out
+    // activities whenever the app-watcher is down. Mislabeled beats missing.
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].context.appName).toBe('Unknown')
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(0)
+    expect(producer.getStats().droppedAllFramesFilteredWindows).toBe(0)
+  })
+
+  it('keeps mismatched frames when the context is a stale lastKnownContext fallback', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_000, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code',
+        startTimestamp: 900,
+        endTimestamp: 1_100,
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: { title: 'Repo', processName: 'Code', bundleId: 'com.microsoft.VSCode' },
+          }),
+        ],
+      }),
+    )
+
+    // The user actually switched to Slack but the app-watcher missed it: the
+    // window has no activeWindow event, so the context falls back to the stale
+    // lastKnownContext (Code) while the frame is stamped Slack.
+    await frameStream.append(
+      makeFrame(2_050, 1, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'stale',
+        startTimestamp: 2_000,
+        endTimestamp: 2_100,
+        closedBy: 'flush',
+        events: [makeEvent(2_020, 'keyboard')],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one merged activity')
+    // Fail-open: the Slack-stamped frame stays despite mismatching the stale
+    // Code context.
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual([
+      'frame-0.png',
+      'frame-1.png',
+    ])
+    expect(producer.getStats().framesExcludedByAppFilter).toBe(0)
+  })
+
+  it('keeps a mismatched frame when the app filter is disabled', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer({
+      enableFrameAppFilter: false,
+    })
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_000, 0, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code-window',
+        startTimestamp: 900,
+        endTimestamp: 1_500,
+        closedBy: 'flush',
+        events: [
+          makeEvent(900, 'app_change', {
+            activeWindow: {
+              title: 'Repo',
+              processName: 'Code',
+              bundleId: 'com.microsoft.VSCode',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 1, 'Expected one activity')
+    expect(activities[0].frames).toHaveLength(1)
+  })
+
+  it('drops the trailing frame when a different app takes over close to the boundary', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_200, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_800, 1, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(2_500, 2, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+
+    await eventStream.append(
+      makeWindow({
+        id: 'code',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'Repo', processName: 'Code', bundleId: 'com.microsoft.VSCode' },
+          }),
+          makeEvent(1_500, 'scroll'),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'slack',
+        startTimestamp: 2_000,
+        endTimestamp: 3_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: {
+              title: 'general',
+              processName: 'Slack',
+              bundleId: 'com.tinyspeck.slackmacgap',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 2, 'Expected two activities')
+    expect(activities.map((a) => a.context.appName)).toEqual(['Code', 'Slack'])
+    // Code's trailing frame (1_800) is 200ms before the Slack boundary (2_000)
+    // -> within TRAILING_FRAME_DROP_WINDOW_MS -> transition bleed, dropped.
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png'])
+    expect(activities[0].provenance.frameOffsets).toEqual([0])
+    // Slack is finalized by flush (not an app switch), so its frame is kept.
+    expect(activities[1].frames.map((f) => f.frame.filepath)).toEqual(['frame-2.png'])
+    expect(producer.getStats().trailingFramesDropped).toBe(1)
+  })
+
+  it('keeps an old trailing frame when the app switch comes long after it', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_200, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_800, 1, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(10_500, 2, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+
+    // Gap-closed window: the user went idle in Code, then switched to Slack
+    // much later. The trailing Code frame (1_800) is 8.2s before the boundary
+    // (10_000) — it's the activity's most informative "final state" frame, not
+    // transition bleed, and must be kept.
+    await eventStream.append(
+      makeWindow({
+        id: 'code',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'gap',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'Repo', processName: 'Code', bundleId: 'com.microsoft.VSCode' },
+          }),
+          makeEvent(1_500, 'scroll'),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'slack',
+        startTimestamp: 10_000,
+        endTimestamp: 11_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(10_000, 'app_change', {
+            activeWindow: {
+              title: 'general',
+              processName: 'Slack',
+              bundleId: 'com.tinyspeck.slackmacgap',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 2, 'Expected two activities')
+    expect(activities.map((a) => a.context.appName)).toEqual(['Code', 'Slack'])
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual([
+      'frame-0.png',
+      'frame-1.png',
+    ])
+    expect(producer.getStats().trailingFramesDropped).toBe(0)
+  })
+
+  it('keeps the trailing frame when dropAppSwitchTrailingFrame is disabled', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer({
+      dropAppSwitchTrailingFrame: false,
+    })
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    await frameStream.append(
+      makeFrame(1_200, 0, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(1_800, 1, { appName: 'Code', bundleId: 'com.microsoft.VSCode' }),
+    )
+    await frameStream.append(
+      makeFrame(2_500, 2, { appName: 'Slack', bundleId: 'com.tinyspeck.slackmacgap' }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'code',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'Repo', processName: 'Code', bundleId: 'com.microsoft.VSCode' },
+          }),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'slack',
+        startTimestamp: 2_000,
+        endTimestamp: 3_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: {
+              title: 'general',
+              processName: 'Slack',
+              bundleId: 'com.tinyspeck.slackmacgap',
+            },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(
+      () => activities.some((a) => a.context.appName === 'Code'),
+      'Expected the Code activity',
+    )
+    const code = activities.find((a) => a.context.appName === 'Code')!
+    expect(code.frames.map((f) => f.frame.filepath)).toEqual(['frame-0.png', 'frame-1.png'])
+    expect(producer.getStats().trailingFramesDropped).toBe(0)
+  })
+
+  it('does not drop the trailing frame on a same-app tld boundary', async () => {
+    const { producer, frameStream, eventStream, activityStream } = createProducer()
+    const activities: Activity[] = []
+    subscriptions.push(
+      activityStream.subscribe({
+        startAt: { type: 'now' },
+        onRecord: (record) => activities.push(record.payload),
+      }),
+    )
+
+    await producer.start()
+    const chrome = { appName: 'Google Chrome', bundleId: 'com.google.Chrome' }
+    await frameStream.append(makeFrame(1_200, 0, chrome))
+    await frameStream.append(makeFrame(1_800, 1, chrome))
+    await frameStream.append(makeFrame(2_500, 2, chrome)) // lands in the second (other.org) window
+
+    await eventStream.append(
+      makeWindow({
+        id: 'chrome-a',
+        startTimestamp: 1_000,
+        endTimestamp: 2_000,
+        closedBy: 'app_change',
+        events: [
+          makeEvent(1_000, 'app_change', {
+            activeWindow: { title: 'A', ...chrome, url: 'https://example.com/a' },
+          }),
+          makeEvent(1_500, 'scroll'),
+        ],
+      }),
+    )
+    await eventStream.append(
+      makeWindow({
+        id: 'chrome-b',
+        startTimestamp: 2_000,
+        endTimestamp: 3_000,
+        closedBy: 'flush',
+        events: [
+          makeEvent(2_000, 'app_change', {
+            activeWindow: { title: 'B', ...chrome, url: 'https://other.org/b' },
+          }),
+        ],
+      }),
+    )
+
+    await waitFor(() => activities.length === 2, 'Expected two activities split by tld')
+    // Same app across the boundary -> no transition bleed -> both frames kept.
+    expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual([
+      'frame-0.png',
+      'frame-1.png',
+    ])
   })
 
   it('enforces max activity duration while keeping each emitted activity frame-backed', async () => {

--- a/src/main/activity-producer.ts
+++ b/src/main/activity-producer.ts
@@ -1,4 +1,5 @@
 import { isBrowserApp } from '../shared/app-utils'
+import { ACTIVITY_CONFIG } from '../shared/constants'
 import { extractTld } from './recorder/tld-utils'
 import log from './logger'
 import type { EventWindow, InteractionContext } from '../shared/types'
@@ -17,8 +18,29 @@ const ACTIVITY_ID_NAMESPACE = uuidv5('memorylane:v2-activity', uuidv5.DNS)
 
 export interface ActivityProducerStats {
   emittedActivities: number
+  // Windows dropped because no frame fell in their time range at all.
   droppedNoFrameWindows: number
-  droppedUnknownContextWindows: number
+  // Windows that had frames in their time range but every one was excluded by
+  // the grab-time app filter (the leak signature: in-range frames all stamped
+  // with a different app than the window context).
+  droppedAllFramesFilteredWindows: number
+  // Total frames kept out of a window by the grab-time app filter (includes the
+  // ones counted by droppedAllFramesFilteredWindows). A proxy for how often the
+  // leak the filter guards against actually fires in production.
+  framesExcludedByAppFilter: number
+  // Total trailing "transition bleed" frames dropped at app-switch boundaries.
+  trailingFramesDropped: number
+}
+
+// A window's derived context plus how it was derived. The filter in
+// getFramesInRange must only apply to contexts backed by a fresh activeWindow
+// event ('event'): a stale lastKnownContext or the 'Unknown' literal
+// ('fallback') would mismatch every stamped frame and silently blank out
+// activities during an app-watcher outage. The tag lives in this wrapper, not
+// on ActivityContext, so it can't leak into emitted/persisted activities.
+interface DerivedWindowContext {
+  context: ActivityContext
+  source: 'event' | 'fallback'
 }
 
 interface ChunkContext {
@@ -64,7 +86,9 @@ export class ActivityProducer {
   private readonly stats: ActivityProducerStats = {
     emittedActivities: 0,
     droppedNoFrameWindows: 0,
-    droppedUnknownContextWindows: 0,
+    droppedAllFramesFilteredWindows: 0,
+    framesExcludedByAppFilter: 0,
+    trailingFramesDropped: 0,
   }
 
   constructor(params: {
@@ -190,22 +214,27 @@ export class ActivityProducer {
     const window = record.payload
     await this.waitForFramesToSettle(window.endTimestamp)
 
-    const windowContext = this.deriveWindowContext(window.events)
-    if (windowContext === null) {
-      this.stats.droppedUnknownContextWindows++
-      log.info(
-        `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: unknown app context`,
-      )
-      await this.markRecordProcessed(record.offset)
-      await this.advanceFrameAck(window.endTimestamp)
-      return
-    }
+    const derived = this.deriveWindowContext(window.events)
 
-    const candidateFrames = this.getFramesInRange(window.startTimestamp, window.endTimestamp)
+    const { frames: candidateFrames, excludedByAppFilter } = this.getFramesInRange(
+      window.startTimestamp,
+      window.endTimestamp,
+      derived,
+    )
+    this.stats.framesExcludedByAppFilter += excludedByAppFilter
     if (candidateFrames.length === 0) {
-      this.stats.droppedNoFrameWindows++
+      // Distinguish "no frames captured in this window" from "frames were
+      // captured but all belonged to a different app" — the latter is the leak
+      // signature and worth tracking separately for diagnosis.
+      if (excludedByAppFilter > 0) {
+        this.stats.droppedAllFramesFilteredWindows++
+      } else {
+        this.stats.droppedNoFrameWindows++
+      }
       log.info(
-        `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: no frames in ${window.startTimestamp}-${window.endTimestamp}`,
+        `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: ` +
+          `${excludedByAppFilter > 0 ? `all ${excludedByAppFilter} frame(s) app-filtered out` : 'no frames'} ` +
+          `in ${window.startTimestamp}-${window.endTimestamp}`,
       )
       await this.markRecordProcessed(record.offset)
       await this.advanceFrameAck(window.endTimestamp)
@@ -215,7 +244,7 @@ export class ActivityProducer {
     const chunks = this.buildWindowChunks({
       eventWindowRecord: record,
       frames: candidateFrames,
-      context: windowContext,
+      context: derived.context,
     })
 
     for (const chunk of chunks) {
@@ -286,6 +315,7 @@ export class ActivityProducer {
     if (!compatible) {
       await this.finalizePendingActivity(
         combinedDuration > this.config.maxActivityDurationMs ? 'max_duration' : 'context_change',
+        { context: chunk.context, startTimestamp: chunk.startTimestamp },
       )
       await this.flushDeferredEventAck()
       this.pendingActivity = this.createPendingActivity(chunk)
@@ -350,8 +380,11 @@ export class ActivityProducer {
 
   private async finalizePendingActivity(
     reason: 'context_change' | 'max_duration' | 'flush',
+    successor?: { context: ActivityContext; startTimestamp: number },
   ): Promise<void> {
     if (this.pendingActivity === null) return
+
+    this.maybeDropTrailingBoundaryFrame(this.pendingActivity, successor)
 
     const durationMs = this.pendingActivity.endTimestamp - this.pendingActivity.startTimestamp
     const eventOffsetsToAck = [...this.pendingActivity.provenance.eventWindowOffsets]
@@ -417,11 +450,7 @@ export class ActivityProducer {
       return false
     }
 
-    const sameApp =
-      left.bundleId && right.bundleId
-        ? left.bundleId === right.bundleId
-        : left.appName === right.appName
-    if (!sameApp) return false
+    if (!this.appsEqual(left, right)) return false
 
     const browser = isBrowserApp({
       processName: left.appName,
@@ -432,7 +461,85 @@ export class ActivityProducer {
     return left.tld === right.tld
   }
 
-  private deriveWindowContext(events: InteractionContext[]): ActivityContext | null {
+  /** App-identity equality: bundleId-preferred, appName fallback. */
+  private appsEqual(left: ActivityContext, right: ActivityContext): boolean {
+    return left.bundleId && right.bundleId
+      ? left.bundleId === right.bundleId
+      : left.appName === right.appName
+  }
+
+  /**
+   * Drop the activity's last frame when it's finalized because a *different*
+   * app took over AND that frame was captured within
+   * TRAILING_FRAME_DROP_WINDOW_MS of the switch boundary. In the sub-second
+   * skew between screen compositing and the frontmost-app signal, such a frame
+   * tends to already show the next app (a one-frame "transition bleed") — and
+   * because its stamp comes from the same lagging signal, it passes the
+   * grab-time app filter; this drop is the only mechanism that catches it.
+   *
+   * The proximity guard matters: gap-closed windows end at the last
+   * interaction, so the switch can come minutes later — an old trailing frame
+   * is the activity's most informative "final state", not bleed. Never empties
+   * an activity (keeps at least one frame).
+   */
+  private maybeDropTrailingBoundaryFrame(
+    activity: Activity,
+    successor?: { context: ActivityContext; startTimestamp: number },
+  ): void {
+    if (!this.config.dropAppSwitchTrailingFrame) return
+    if (successor === undefined) return
+    if (this.appsEqual(activity.context, successor.context)) return
+    if (activity.frames.length <= 1) return
+
+    // Frames are kept sorted ascending by timestamp, so the latest is the
+    // bleed candidate. A frame stamped after the boundary passes the <= check
+    // too — that is maximal bleed, not a miss.
+    const lastFrame = activity.frames[activity.frames.length - 1]
+    const boundaryGapMs = successor.startTimestamp - lastFrame.frame.timestamp
+    if (boundaryGapMs > ACTIVITY_CONFIG.TRAILING_FRAME_DROP_WINDOW_MS) return
+
+    const dropped = activity.frames.pop()
+    if (dropped === undefined) return
+    this.stats.trailingFramesDropped++
+    activity.provenance.frameOffsets = activity.provenance.frameOffsets.filter(
+      (offset) => offset !== dropped.offset,
+    )
+    log.info(
+      `[ActivityProducer] Dropped trailing boundary frame ${dropped.frame.filepath} from ` +
+        `${activity.context.appName} activity (switch to ${successor.context.appName}, ` +
+        `${boundaryGapMs}ms before boundary)`,
+    )
+  }
+
+  /**
+   * Whether a candidate frame belongs to a window's derived app context.
+   *
+   * The frame carries the frontmost app observed by the native daemon at the
+   * grab instant — an observation independent of the app-watcher's (lagging)
+   * event timeline. Comparing it against the window context catches frames that
+   * fall in a window's time range but were actually captured under a different
+   * app (the "leak" around an app switch).
+   *
+   * Only app identity is compared, mirroring the app half of canMergeContexts
+   * (bundleId-preferred, appName fallback). We deliberately do NOT compare
+   * tld/url (frames carry none; browser tld boundaries are enforced by window
+   * splitting) nor displayId (the frame's displayId is the capture target,
+   * which can differ from the focused-window display on multi-display setups).
+   *
+   * Frames with no app stamp are always kept (backward compatible: pre-fix
+   * frames, platforms that don't stamp yet, and frames the daemon couldn't
+   * resolve). The filter can also be disabled wholesale via config.
+   */
+  private frameAppMatchesContext(frame: Frame, context: ActivityContext): boolean {
+    if (!this.config.enableFrameAppFilter) return true
+    if (frame.appName === undefined && frame.bundleId === undefined) return true
+
+    return frame.bundleId && context.bundleId
+      ? frame.bundleId === context.bundleId
+      : frame.appName === context.appName
+  }
+
+  private deriveWindowContext(events: InteractionContext[]): DerivedWindowContext {
     const recentEvents = [...events].reverse()
     const activeWindowEvent = recentEvents.find((event) => event.activeWindow)
     const latestDisplayId = recentEvents.find((event) => event.displayId !== undefined)?.displayId
@@ -448,29 +555,50 @@ export class ActivityProducer {
         displayId: latestDisplayId ?? undefined,
       }
       this.lastKnownContext = context
-      return context
+      return { context, source: 'event' }
     }
 
     if (this.lastKnownContext === null) {
       return {
-        appName: 'Unknown',
-        displayId: latestDisplayId ?? undefined,
-        windowTitle: latestWindowTitle,
+        context: {
+          appName: 'Unknown',
+          displayId: latestDisplayId ?? undefined,
+          windowTitle: latestWindowTitle,
+        },
+        source: 'fallback',
       }
     }
 
     return {
-      ...this.lastKnownContext,
-      displayId: latestDisplayId ?? this.lastKnownContext.displayId,
-      windowTitle: latestWindowTitle ?? this.lastKnownContext.windowTitle,
+      context: {
+        ...this.lastKnownContext,
+        displayId: latestDisplayId ?? this.lastKnownContext.displayId,
+        windowTitle: latestWindowTitle ?? this.lastKnownContext.windowTitle,
+      },
+      source: 'fallback',
     }
   }
 
-  private getFramesInRange(startTimestamp: number, endTimestamp: number): StreamRecord<Frame>[] {
-    return this.frameBuffer.filter(
+  private getFramesInRange(
+    startTimestamp: number,
+    endTimestamp: number,
+    derived: DerivedWindowContext,
+  ): { frames: StreamRecord<Frame>[]; excludedByAppFilter: number } {
+    const inTimeRange = this.frameBuffer.filter(
       (record) =>
         record.payload.timestamp >= startTimestamp && record.payload.timestamp <= endTimestamp,
     )
+    // Fail open on fallback-derived contexts: a stale lastKnownContext or the
+    // 'Unknown' literal would mismatch every stamped frame, so applying the
+    // filter during an app-watcher outage would black out all activities.
+    // Mislabeled-but-present beats missing.
+    if (derived.source !== 'event') {
+      return { frames: inTimeRange, excludedByAppFilter: 0 }
+    }
+    const frames = inTimeRange.filter((record) =>
+      this.frameAppMatchesContext(record.payload, derived.context),
+    )
+    return { frames, excludedByAppFilter: inTimeRange.length - frames.length }
   }
 
   private async waitForFramesToSettle(windowEndTimestamp: number): Promise<void> {

--- a/src/main/activity-types.ts
+++ b/src/main/activity-types.ts
@@ -42,6 +42,20 @@ export interface ActivityProducerConfig {
   frameBufferRetentionMs: number
   eventConsumerId: string
   frameConsumerId: string
+  // When true, a frame stamped with a frontmost app that doesn't match a
+  // window's derived context is kept out of that window (stops screenshots
+  // leaking across an app boundary). Unstamped frames are always kept, and the
+  // filter never applies to fallback-derived contexts. Kill-switch: set
+  // MEMORYLANE_DISABLE_FRAME_APP_FILTER to disable without a rebuild.
+  enableFrameAppFilter: boolean
+  // When true, drop an activity's last frame when it's finalized because a
+  // different app took over and that frame was captured within
+  // TRAILING_FRAME_DROP_WINDOW_MS of the switch — the sub-second skew between
+  // screen compositing and the frontmost-app signal makes such a frame tend to
+  // already show the *next* app (a one-frame "transition bleed"). Never empties
+  // an activity. Kill-switch: set MEMORYLANE_DISABLE_TRAILING_FRAME_DROP to
+  // disable without a rebuild.
+  dropAppSwitchTrailingFrame: boolean
 }
 
 export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
@@ -53,5 +67,7 @@ export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
     frameBufferRetentionMs: ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS * 2,
     eventConsumerId: 'activity-producer:event-stream',
     frameConsumerId: 'activity-producer:frame-stream',
+    enableFrameAppFilter: !process.env.MEMORYLANE_DISABLE_FRAME_APP_FILTER,
+    dropAppSwitchTrailingFrame: !process.env.MEMORYLANE_DISABLE_TRAILING_FRAME_DROP,
   }
 }

--- a/src/main/pipeline-harness.ts
+++ b/src/main/pipeline-harness.ts
@@ -1,5 +1,5 @@
 import type { InteractionContext, EventWindow } from '../shared/types'
-import { SCREENSHOT_CLEANUP_CONFIG } from '../shared/constants'
+import { ACTIVITY_CONFIG, SCREENSHOT_CLEANUP_CONFIG } from '../shared/constants'
 import { EventCapturer } from './event-capturer'
 import { ActivityProducer } from './activity-producer'
 import type { Activity, ActivityProducerConfig } from './activity-types'
@@ -87,6 +87,7 @@ export function createPipelineHarness(params: {
       : undefined
 
   let cleanupTimer: ReturnType<typeof setInterval> | null = null
+  let statsTimer: ReturnType<typeof setInterval> | null = null
   let running = false
   let frameCaptureSuppressed = false
 
@@ -120,6 +121,12 @@ export function createPipelineHarness(params: {
             sweepStaleFiles(params.outputDir)
           }, SCREENSHOT_CLEANUP_CONFIG.CLEANUP_INTERVAL_MS)
         }
+
+        // Periodic visibility into drop/filter counters — they are the
+        // production signal for how often the boundary-leak mechanisms fire.
+        statsTimer = setInterval(() => {
+          log.info('[PipelineHarness] ActivityProducer stats:', activityProducer.getStats())
+        }, ACTIVITY_CONFIG.STATS_LOG_INTERVAL_MS)
       } catch (error) {
         running = false
         throw error
@@ -132,9 +139,15 @@ export function createPipelineHarness(params: {
         clearInterval(cleanupTimer)
         cleanupTimer = null
       }
+      if (statsTimer) {
+        clearInterval(statsTimer)
+        statsTimer = null
+      }
       await screenCapturer.stop()
       await eventCapturer.flushAndWait()
       await activityProducer.stop()
+      // After producer.stop() so flush-time finalization is included.
+      log.info('[PipelineHarness] ActivityProducer final stats:', activityProducer.getStats())
       if (activityExtractor) {
         await activityExtractor.stop()
       }

--- a/src/main/recorder/native-screenshot.ts
+++ b/src/main/recorder/native-screenshot.ts
@@ -21,6 +21,10 @@ export interface CapturedFrame {
   width: number
   height: number
   displayId: number
+  // Frontmost app at the grab instant, stamped by the native daemon. Absent
+  // when the daemon could not resolve it (or on platforms that don't stamp yet).
+  appName?: string
+  bundleId?: string
 }
 
 export interface CaptureBackendConfig {

--- a/src/main/recorder/screen-capturer.ts
+++ b/src/main/recorder/screen-capturer.ts
@@ -17,6 +17,11 @@ export interface Frame {
   height: number
   displayId: number
   sequenceNumber: number
+  // Frontmost app at the grab instant (carried through from the native daemon).
+  // Used by the ActivityProducer to keep a frame out of a window whose app
+  // doesn't match. Absent for unstamped frames (kept as-is).
+  appName?: string
+  bundleId?: string
 }
 
 export class ScreenCapturer {

--- a/src/main/recorder/swift/screenshot.swift
+++ b/src/main/recorder/swift/screenshot.swift
@@ -28,6 +28,32 @@ func fail(_ message: String, exitCode: Int32 = 1) -> Never {
     exit(exitCode)
 }
 
+/// Filesystem-safe slug for an app name so it can go in a screenshot filename,
+/// e.g. "Google Chrome" -> "google-chrome". Lowercases, replaces any run of
+/// non-alphanumeric characters with a single dash, trims dashes, and caps the
+/// length. Returns nil when nothing usable remains.
+func appSlug(_ name: String?) -> String? {
+    guard let name = name else { return nil }
+    let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789")
+    var slug = ""
+    var lastWasDash = false
+    for scalar in name.lowercased().unicodeScalars {
+        if allowed.contains(scalar) {
+            slug.unicodeScalars.append(scalar)
+            lastWasDash = false
+        } else if !lastWasDash {
+            slug.append("-")
+            lastWasDash = true
+        }
+    }
+    let dashes = CharacterSet(charactersIn: "-")
+    slug = slug.trimmingCharacters(in: dashes)
+    if slug.count > 40 {
+        slug = String(slug.prefix(40)).trimmingCharacters(in: dashes)
+    }
+    return slug.isEmpty ? nil : slug
+}
+
 // MARK: - CLI Argument Parsing
 
 struct DaemonConfig {
@@ -189,6 +215,34 @@ func resolveDisplayId(_ requestedDisplayId: UInt32?) throws -> CGDirectDisplayID
     return displays[0]
 }
 
+// MARK: - Frontmost app tracking
+
+/// Caches the system-wide frontmost app, updated on the main run loop via an
+/// NSWorkspace notification, so the SCStreamOutput callback (which runs on a
+/// background queue) can read it cheaply at the grab instant. Identifiers match
+/// the app-watcher daemon (localizedName + bundleIdentifier) so the downstream
+/// frame/app matching in ActivityProducer compares like-for-like.
+final class FrontmostAppTracker {
+    private let lock = NSLock()
+    private var appName: String?
+    private var bundleId: String?
+
+    func update(_ app: NSRunningApplication?) {
+        lock.lock()
+        defer { lock.unlock() }
+        appName = app?.localizedName
+        bundleId = app?.bundleIdentifier
+    }
+
+    func snapshot() -> (appName: String?, bundleId: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (appName, bundleId)
+    }
+}
+
+let frontmostTracker = FrontmostAppTracker()
+
 // MARK: - Autonomous ScreenCaptureKit Daemon
 
 class AutonomousCapture: NSObject, SCStreamOutput {
@@ -327,6 +381,7 @@ class AutonomousCapture: NSObject, SCStreamOutput {
         let quality = self.config.quality
         let outputDir = self.config.outputDir
         let captureTimestamp = Int(Date().timeIntervalSince1970 * 1000)
+        let frontmost = frontmostTracker.snapshot()
         let droppedFrames = takeDroppedFrameCount()
         shouldReleaseSemaphore = false
 
@@ -335,7 +390,13 @@ class AutonomousCapture: NSObject, SCStreamOutput {
                 self.pendingWriteSemaphore.signal()
             }
 
-            let filename = "frame-\(captureTimestamp).jpg"
+            // Include the grab-time app in the name so raw frames are legible on
+            // disk, e.g. "frame-1781008339005-google-chrome.jpg". Falls back to
+            // the bare timestamped name when the app is unknown.
+            let slug = appSlug(frontmost.appName)
+            let filename =
+                slug.map { "frame-\(captureTimestamp)-\($0).jpg" }
+                ?? "frame-\(captureTimestamp).jpg"
             let filepath = (outputDir as NSString).appendingPathComponent(filename)
 
             do {
@@ -346,13 +407,21 @@ class AutonomousCapture: NSObject, SCStreamOutput {
                     fputs("[daemon] Dropped \(droppedFrames) frame(s) while previous capture was still being written\n", stderr)
                 }
 
-                let payload: [String: Any] = [
+                var payload: [String: Any] = [
                     "filepath": filepath,
                     "timestamp": captureTimestamp,
                     "width": resized.width,
                     "height": resized.height,
                     "displayId": Int(displayId),
                 ]
+                // Stamp the grab-time frontmost app. Omit keys when unknown
+                // (no NSNull) — the consumer treats absent app info as "keep".
+                if let name = frontmost.appName, !name.isEmpty {
+                    payload["appName"] = name
+                }
+                if let bid = frontmost.bundleId, !bid.isEmpty {
+                    payload["bundleId"] = bid
+                }
                 emitJSON(payload)
             } catch {
                 fputs("[daemon] Frame write failed: \(error)\n", stderr)
@@ -411,7 +480,18 @@ try FileManager.default.createDirectory(
 
 let capture = AutonomousCapture(config: config)
 
-let semaphore = DispatchSemaphore(value: 0)
+// Track the frontmost app on the main run loop so every captured frame can be
+// stamped with the app on screen at the grab instant (see FrontmostAppTracker).
+// Same NSWorkspace source as app-watcher.swift, so identifiers match.
+let workspaceCenter = NSWorkspace.shared.notificationCenter
+workspaceCenter.addObserver(forName: NSWorkspace.didActivateApplicationNotification,
+                            object: nil, queue: .main) { notification in
+    let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+    frontmostTracker.update(app ?? NSWorkspace.shared.frontmostApplication)
+}
+// Seed with the app focused at launch — NSWorkspace only notifies on *changes*.
+frontmostTracker.update(NSWorkspace.shared.frontmostApplication)
+
 Task {
     do {
         try await capture.startStream()
@@ -422,4 +502,8 @@ Task {
     // Start listening for stdin commands
     listenForCommands(capture: capture)
 }
-semaphore.wait()
+
+// Keep the process alive AND service the main run loop so the workspace observer
+// above fires — NSWorkspace notifications are delivered on the main run loop, and
+// a bare DispatchSemaphore.wait() would block the thread without running it.
+RunLoop.main.run()

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -39,6 +39,8 @@ export const ACTIVITY_CONFIG = {
   MAX_ACTIVITY_DURATION_MS: 5 * 60 * 1000, // Force-split after 5 minutes
   MAX_SCREENSHOTS_FOR_LLM: 6, // Max images sent to LLM
   SEMANTIC_REQUEST_TIMEOUT_MS: 120_000, // Per-model semantic request timeout
+  TRAILING_FRAME_DROP_WINDOW_MS: 1_500, // Only drop a trailing boundary frame captured this close to the app switch
+  STATS_LOG_INTERVAL_MS: 10 * 60 * 1000, // Periodic ActivityProducer stats snapshot while capturing
 }
 
 // Event Capturer Configuration (gap-based session windowing)


### PR DESCRIPTION
## Summary

Part 3 of 3 rebuilding the activity-boundary fixes from #159 (closed unmerged). Stacked on #162 (needs the frame app stamps). Fixes the app leak — summaries reading "…and then the user switched to <app>" because frames captured around an app switch landed in the previous app's activity (the frame→window join was timestamp-range only, and the app-watcher signal lags the screen).

Two complementary mechanisms, salvaged from #158/#159 **with the guards the multi-agent review mandated**:

- **Frame↔window app filter, failing open on fallback contexts.** A frame whose grab-time app stamp mismatches the window's derived context is kept out of that window — but only when the context comes from a fresh `activeWindow` event. On fallback contexts (stale `lastKnownContext`, the `Unknown` literal) the filter does not apply: as shipped in #159 an app-watcher outage meant every stamped frame mismatched the stale context → silent total activity blackout. Fail-open degrades to mislabeled-but-present instead. Unstamped frames (Windows, pre-fix) are always kept.
- **Trailing-frame drop, bounded to boundary proximity.** On a real app-switch finalize, the last frame tends to already show the next app (its stamp comes from the same lagging signal, so it *passes* the filter — this drop is the only mechanism that catches it). Guard: only dropped when captured within 1.5s of the successor boundary. As shipped in #159 it dropped the last frame of every app-switch-finalized activity — for gap-closed windows that deleted an old, legitimate "final state" frame minutes before the switch.
- **Stats surfaced + kill-switches wired** (both were dead code in #159): `framesExcludedByAppFilter`, `droppedAllFramesFilteredWindows`, `trailingFramesDropped` logged by the pipeline harness every 10 min and on stop (these counters are the decision data for the v3 segmenter question); `MEMORYLANE_DISABLE_FRAME_APP_FILTER` / `MEMORYLANE_DISABLE_TRAILING_FRAME_DROP` env vars disable without a rebuild. The unreachable `droppedUnknownContextWindows` counter is deleted (`deriveWindowContext` never returns null).

The frameless-window finalize from #159 (`6c2a238`) is deliberately **not** ported (quick-bounce regression); the all-filtered-window test pins that a frameless window doesn't split the pending activity.

## Test plan

- [x] `npm run test` — 713 passed (12 new/ported filter + trailing-drop tests, incl. fail-open on Unknown and stale-fallback contexts, and old-trailing-frame-kept)
- [x] `npm run lint` — clean (pre-existing warnings only)
- [ ] Manual acceptance (`DEBUG_PIPELINE=1`, `npm run build:swift`): rapid A→B→A→B → no B frames in A activities (`framesExcludedByAppFilter` > 0); kill app-watcher mid-session → activities keep flowing; idle 2 min then switch → last frame retained

## Known residual gaps (tracked for v3)

Windows frames are unstamped (filter inert there); browser tld/tab bleed; leading-edge bleed into the successor activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)