### PR TITLE
fix(activity-producer): trim trailing frames that leak across app boundaries

### DIFF
--- a/src/main/activity-producer.test.ts
+++ b/src/main/activity-producer.test.ts
@@ -16,6 +16,29 @@ vi.mock('./logger', () => ({
   },
 }))
 
+const { nullLuminance, luminanceDiffs } = vi.hoisted(() => ({
+  nullLuminance: new Set<string>(),
+  luminanceDiffs: new Map<string, number>(),
+}))
+
+// Luminance profile = the filepath itself, with a per-test pair diff table.
+// Unknown pairs default to 50/50: equidistant from both sides of a boundary,
+// so the relative trim rule keeps them and existing tests are unaffected.
+vi.mock('./semantic/visual-diff', () => ({
+  loadImageLuminance: vi.fn(async (filepath: string) => {
+    return nullLuminance.has(filepath) ? null : filepath
+  }),
+  luminanceL1DifferencePercent: vi.fn((left: string, right: string) => {
+    if (left === right) return 0
+    const pair = [left, right].sort().join('|')
+    return luminanceDiffs.get(pair) ?? 50
+  }),
+}))
+
+function setLuminanceDiff(left: string, right: string, value: number): void {
+  luminanceDiffs.set([left, right].sort().join('|'), value)
+}
+
 function makeFrame(timestamp: number, sequenceNumber: number): Frame {
   return {
     filepath: `frame-${sequenceNumber}.png`,
@@ -79,6 +102,8 @@ describe('ActivityProducer', () => {
   afterEach(async () => {
     ACTIVITY_CONFIG.MIN_ACTIVITY_DURATION_MS = originalActivityConfig.min
     ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS = originalActivityConfig.max
+    nullLuminance.clear()
+    luminanceDiffs.clear()
     for (const sub of subscriptions.splice(0)) {
       sub.unsubscribe()
     }
@@ -756,6 +781,181 @@ describe('ActivityProducer', () => {
       'Expected short window to be processed',
     )
     expect(activities).toHaveLength(0)
+  })
+
+  describe('boundary trimming', () => {
+    const codeWindow = {
+      title: 'Repo',
+      processName: 'Code',
+      bundleId: 'com.microsoft.VSCode',
+    }
+    const slackWindow = {
+      title: 'Inbox',
+      processName: 'Slack',
+      bundleId: 'com.tinyspeck.slackmacgap',
+    }
+
+    async function runAppSwitch(producerParams?: { enableBoundaryTrim?: boolean }) {
+      const { producer, frameStream, eventStream, activityStream } = createProducer(producerParams)
+      const activities: Activity[] = []
+      subscriptions.push(
+        activityStream.subscribe({
+          startAt: { type: 'now' },
+          onRecord: (record) => activities.push(record.payload),
+        }),
+      )
+
+      await producer.start()
+      // App A frames; frame-2 is the leak (visually shows app B already).
+      await frameStream.append(makeFrame(1_000, 0))
+      await frameStream.append(makeFrame(1_400, 1))
+      await frameStream.append(makeFrame(1_450, 2))
+      // App B frame.
+      await frameStream.append(makeFrame(2_000, 3))
+
+      await eventStream.append(
+        makeWindow({
+          id: 'code',
+          startTimestamp: 900,
+          endTimestamp: 1_500,
+          closedBy: 'app_change',
+          events: [makeEvent(900, 'app_change', { activeWindow: codeWindow })],
+        }),
+      )
+      await eventStream.append(
+        makeWindow({
+          id: 'slack',
+          startTimestamp: 1_600,
+          endTimestamp: 2_500,
+          closedBy: 'flush',
+          events: [makeEvent(1_600, 'app_change', { activeWindow: slackWindow })],
+        }),
+      )
+
+      await waitFor(() => activities.length === 2, 'Expected two activities')
+      return { producer, activities }
+    }
+
+    it('trims trailing frames closer to the successor on app switch', async () => {
+      // frame-2 is near the successor frame-3 and far (default 50) from its
+      // own activity's frame-0 reference => leaked.
+      setLuminanceDiff('frame-2.png', 'frame-3.png', 5)
+
+      const { producer, activities } = await runAppSwitch()
+
+      const codeActivity = activities.find((a) => a.context.appName === 'Code')!
+      expect(codeActivity.frames.map((f) => f.frame.filepath)).toEqual([
+        'frame-0.png',
+        'frame-1.png',
+      ])
+      expect(codeActivity.provenance.frameOffsets).toEqual([0, 1])
+      expect(codeActivity.endTimestamp).toBe(1_500)
+      expect(producer.getStats().trailingFramesTrimmed).toBe(1)
+    })
+
+    it('keeps all frames when the kill-switch is off', async () => {
+      setLuminanceDiff('frame-2.png', 'frame-3.png', 5)
+
+      const { producer, activities } = await runAppSwitch({ enableBoundaryTrim: false })
+
+      const codeActivity = activities.find((a) => a.context.appName === 'Code')!
+      expect(codeActivity.frames).toHaveLength(3)
+      expect(producer.getStats().trailingFramesTrimmed).toBe(0)
+    })
+
+    it('keeps all frames when the successor luminance is unavailable', async () => {
+      nullLuminance.add('frame-3.png')
+      setLuminanceDiff('frame-2.png', 'frame-3.png', 5)
+
+      const { producer, activities } = await runAppSwitch()
+
+      const codeActivity = activities.find((a) => a.context.appName === 'Code')!
+      expect(codeActivity.frames).toHaveLength(3)
+      expect(producer.getStats().trailingFramesTrimmed).toBe(0)
+    })
+
+    it('does not trim same-app max_duration splits', async () => {
+      // All frames near-identical: same-app splits have no after-boundary
+      // reference, so the trim must not run at all.
+      for (let left = 0; left < 4; left++) {
+        for (let right = left + 1; right < 4; right++) {
+          setLuminanceDiff(`frame-${left}.png`, `frame-${right}.png`, 2)
+        }
+      }
+
+      const { producer, frameStream, eventStream, activityStream } = createProducer({
+        maxActivityDurationMs: 60_000,
+      })
+      const activities: Activity[] = []
+      subscriptions.push(
+        activityStream.subscribe({
+          startAt: { type: 'now' },
+          onRecord: (record) => activities.push(record.payload),
+        }),
+      )
+
+      await producer.start()
+      await frameStream.append(makeFrame(1_000, 0))
+      await frameStream.append(makeFrame(30_000, 1))
+      await frameStream.append(makeFrame(61_000, 2))
+      await frameStream.append(makeFrame(90_000, 3))
+
+      await eventStream.append(
+        makeWindow({
+          id: 'long-window',
+          startTimestamp: 0,
+          endTimestamp: 120_000,
+          closedBy: 'flush',
+          events: [makeEvent(0, 'app_change', { activeWindow: codeWindow })],
+        }),
+      )
+
+      await waitFor(() => activities.length >= 2, 'Expected split activities')
+      const totalFrames = activities.reduce((sum, a) => sum + a.frames.length, 0)
+      expect(totalFrames).toBe(4)
+      expect(producer.getStats().trailingFramesTrimmed).toBe(0)
+    })
+
+    it('trims a leaked tail on flush using buffered post-boundary frames as references', async () => {
+      // Window covers frames 0-4; frame-5 lands after the window end and
+      // stays in the frame buffer => serves as the after-boundary reference.
+      setLuminanceDiff('frame-4.png', 'frame-5.png', 5)
+      setLuminanceDiff('frame-3.png', 'frame-5.png', 8)
+
+      const { producer, frameStream, eventStream, activityStream } = createProducer()
+      const activities: Activity[] = []
+      subscriptions.push(
+        activityStream.subscribe({
+          startAt: { type: 'now' },
+          onRecord: (record) => activities.push(record.payload),
+        }),
+      )
+
+      await producer.start()
+      for (let i = 0; i < 5; i++) {
+        await frameStream.append(makeFrame(1_000 + i * 1_000, i))
+      }
+      await frameStream.append(makeFrame(6_000, 5))
+
+      await eventStream.append(
+        makeWindow({
+          id: 'flushed',
+          startTimestamp: 900,
+          endTimestamp: 5_100,
+          closedBy: 'flush',
+          events: [makeEvent(900, 'app_change', { activeWindow: codeWindow })],
+        }),
+      )
+
+      await waitFor(() => activities.length === 1, 'Expected one activity')
+      expect(activities[0].frames.map((f) => f.frame.filepath)).toEqual([
+        'frame-0.png',
+        'frame-1.png',
+        'frame-2.png',
+      ])
+      expect(activities[0].provenance.frameOffsets).toEqual([0, 1, 2])
+      expect(producer.getStats().trailingFramesTrimmed).toBe(2)
+    })
   })
 
   it('applies updated activity window config at runtime', async () => {

--- a/src/main/activity-producer.ts
+++ b/src/main/activity-producer.ts
@@ -12,6 +12,8 @@ import {
   type ActivityFrame,
   type ActivityProducerConfig,
 } from './activity-types'
+import { detectTrailingLeakFrames } from './boundary-trim'
+import { BOUNDARY_TRIM_CONFIG } from '../shared/constants'
 
 const ACTIVITY_ID_NAMESPACE = uuidv5('memorylane:v2-activity', uuidv5.DNS)
 
@@ -19,6 +21,7 @@ export interface ActivityProducerStats {
   emittedActivities: number
   droppedNoFrameWindows: number
   droppedUnknownContextWindows: number
+  trailingFramesTrimmed: number
 }
 
 interface ChunkContext {
@@ -65,6 +68,7 @@ export class ActivityProducer {
     emittedActivities: 0,
     droppedNoFrameWindows: 0,
     droppedUnknownContextWindows: 0,
+    trailingFramesTrimmed: 0,
   }
 
   constructor(params: {
@@ -278,14 +282,13 @@ export class ActivityProducer {
       return
     }
 
+    const contextsCompatible = this.canMergeContexts(this.pendingActivity.context, chunk.context)
     const combinedDuration = chunk.endTimestamp - this.pendingActivity.startTimestamp
-    const compatible =
-      this.canMergeContexts(this.pendingActivity.context, chunk.context) &&
-      combinedDuration <= this.config.maxActivityDurationMs
 
-    if (!compatible) {
+    if (!contextsCompatible || combinedDuration > this.config.maxActivityDurationMs) {
       await this.finalizePendingActivity(
         combinedDuration > this.config.maxActivityDurationMs ? 'max_duration' : 'context_change',
+        contextsCompatible ? undefined : { successorFrames: chunk.frames },
       )
       await this.flushDeferredEventAck()
       this.pendingActivity = this.createPendingActivity(chunk)
@@ -350,6 +353,7 @@ export class ActivityProducer {
 
   private async finalizePendingActivity(
     reason: 'context_change' | 'max_duration' | 'flush',
+    options?: { successorFrames?: ActivityFrame[] },
   ): Promise<void> {
     if (this.pendingActivity === null) return
 
@@ -366,9 +370,60 @@ export class ActivityProducer {
       return
     }
 
+    await this.trimTrailingLeakFrames(activityToEmit, reason, options?.successorFrames)
+
     await this.activityStream.append(activityToEmit)
     this.stats.emittedActivities++
     this.deferAckOffsets(eventOffsetsToAck)
+  }
+
+  private async trimTrailingLeakFrames(
+    activity: Activity,
+    reason: 'context_change' | 'max_duration' | 'flush',
+    successorFrames?: ActivityFrame[],
+  ): Promise<void> {
+    if (!this.config.enableBoundaryTrim) return
+    if (activity.frames.length <= 1) return
+
+    // After-boundary reference frames: the successor chunk on a context
+    // change, or buffered post-boundary frames on flush (capture stop / app
+    // quit still delivers a frame or two past the window end). Same-app
+    // max_duration splits get neither — there is no boundary to trim.
+    const afterFrames =
+      successorFrames ?? (reason === 'flush' ? this.getBufferedFramesAfter(activity) : [])
+    if (afterFrames.length === 0) return
+
+    try {
+      const { framesToDrop } = await detectTrailingLeakFrames({
+        frames: activity.frames,
+        afterFrames,
+      })
+      if (framesToDrop.length === 0) return
+
+      const droppedOffsets = new Set(framesToDrop.map((frame) => frame.offset))
+      activity.frames = activity.frames.filter((frame) => !droppedOffsets.has(frame.offset))
+      activity.provenance.frameOffsets = activity.provenance.frameOffsets.filter(
+        (offset) => !droppedOffsets.has(offset),
+      )
+      this.stats.trailingFramesTrimmed += framesToDrop.length
+      log.info(
+        `[ActivityProducer] Trimmed ${framesToDrop.length} trailing boundary frame(s) from activity ${activity.id} (${activity.context.appName}, reason: ${reason}): ${framesToDrop.map((f) => f.frame.filepath).join(', ')}`,
+      )
+    } catch (err) {
+      log.warn('[ActivityProducer] Boundary trim failed; keeping all frames:', err)
+    }
+  }
+
+  private getBufferedFramesAfter(activity: Activity): ActivityFrame[] {
+    const cutoff = activity.endTimestamp + BOUNDARY_TRIM_CONFIG.AFTER_REFERENCE_WINDOW_MS
+    return this.frameBuffer
+      .filter(
+        (record) =>
+          record.payload.timestamp > activity.endTimestamp && record.payload.timestamp <= cutoff,
+      )
+      .sort((a, b) => a.payload.timestamp - b.payload.timestamp)
+      .slice(0, BOUNDARY_TRIM_CONFIG.REFERENCE_COUNT)
+      .map((record) => ({ offset: record.offset, frame: record.payload }))
   }
 
   private deferAckOffsets(offsets: Offset[]): void {

--- a/src/main/activity-types.ts
+++ b/src/main/activity-types.ts
@@ -1,7 +1,7 @@
 import type { EventWindow, InteractionContext } from '../shared/types'
 import type { Frame } from './recorder/screen-capturer'
 import type { Offset } from './streams/stream'
-import { ACTIVITY_CONFIG } from '../shared/constants'
+import { ACTIVITY_CONFIG, BOUNDARY_TRIM_CONFIG } from '../shared/constants'
 
 export interface ActivityFrame {
   offset: Offset
@@ -42,6 +42,7 @@ export interface ActivityProducerConfig {
   frameBufferRetentionMs: number
   eventConsumerId: string
   frameConsumerId: string
+  enableBoundaryTrim: boolean
 }
 
 export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
@@ -53,5 +54,6 @@ export function createDefaultActivityProducerConfig(): ActivityProducerConfig {
     frameBufferRetentionMs: ACTIVITY_CONFIG.MAX_ACTIVITY_DURATION_MS * 2,
     eventConsumerId: 'activity-producer:event-stream',
     frameConsumerId: 'activity-producer:frame-stream',
+    enableBoundaryTrim: BOUNDARY_TRIM_CONFIG.ENABLED,
   }
 }

--- a/src/main/boundary-trim.test.ts
+++ b/src/main/boundary-trim.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ActivityFrame } from './activity-types'
+import { detectTrailingLeakFrames } from './boundary-trim'
+
+const { nullLuminance, diffs } = vi.hoisted(() => ({
+  nullLuminance: new Set<string>(),
+  diffs: new Map<string, number>(),
+}))
+
+// Luminance profile = the filepath itself; L1 difference comes from a
+// per-test pair table. Unknown pairs default to 50/50 (equidistant => kept).
+vi.mock('./semantic/visual-diff', () => ({
+  loadImageLuminance: vi.fn(async (filepath: string) => {
+    return nullLuminance.has(filepath) ? null : filepath
+  }),
+  luminanceL1DifferencePercent: vi.fn((left: string, right: string) => {
+    if (left === right) return 0
+    const pair = [left, right].sort().join('|')
+    return diffs.get(pair) ?? 50
+  }),
+}))
+
+function setDiff(left: string, right: string, value: number): void {
+  diffs.set([left, right].sort().join('|'), value)
+}
+
+function makeFrame(filepath: string, sequenceNumber: number): ActivityFrame {
+  return {
+    offset: sequenceNumber,
+    frame: {
+      filepath,
+      timestamp: 1_000 + sequenceNumber * 1_000,
+      width: 1280,
+      height: 720,
+      displayId: 1,
+      sequenceNumber,
+    },
+  }
+}
+
+function filepaths(frames: ActivityFrame[]): string[] {
+  return frames.map((f) => f.frame.filepath)
+}
+
+describe('detectTrailingLeakFrames', () => {
+  afterEach(() => {
+    nullLuminance.clear()
+    diffs.clear()
+  })
+
+  it('drops a contiguous tail that is closer to the after-boundary frames than to its own activity', async () => {
+    // candidates a3-a5, own references a1-a2
+    const frames = ['a1', 'a2', 'a3', 'a4', 'a5'].map(makeFrame)
+    const afterFrames = [makeFrame('g1', 10), makeFrame('g2', 11)]
+    setDiff('a5', 'g1', 5)
+    setDiff('a5', 'a2', 30)
+    setDiff('a4', 'g2', 10)
+    setDiff('a4', 'a1', 25)
+    setDiff('a3', 'g1', 40)
+    setDiff('a3', 'a2', 5)
+
+    const result = await detectTrailingLeakFrames({ frames, afterFrames })
+
+    expect(filepaths(result.framesToDrop)).toEqual(['a4', 'a5'])
+  })
+
+  it('stops at the first candidate that is closer to its own activity', async () => {
+    const frames = ['a1', 'a2', 'a3', 'a4', 'a5'].map(makeFrame)
+    const afterFrames = [makeFrame('g1', 10)]
+    setDiff('a5', 'g1', 5)
+    setDiff('a5', 'a1', 40)
+    setDiff('a4', 'g1', 40)
+    setDiff('a4', 'a1', 5)
+    setDiff('a3', 'g1', 5)
+    setDiff('a3', 'a1', 40)
+
+    const result = await detectTrailingLeakFrames({ frames, afterFrames })
+
+    expect(filepaths(result.framesToDrop)).toEqual(['a5'])
+  })
+
+  it('keeps an equidistant candidate (ties are not leaks)', async () => {
+    const frames = ['a1', 'a2', 'a3'].map(makeFrame)
+    const afterFrames = [makeFrame('g1', 10)]
+    setDiff('a3', 'g1', 20)
+    setDiff('a3', 'a1', 20)
+
+    const result = await detectTrailingLeakFrames({ frames, afterFrames })
+
+    expect(result.framesToDrop).toEqual([])
+  })
+
+  it('keeps a candidate whose margin is below the evidence threshold', async () => {
+    const frames = ['a1', 'a2', 'a3'].map(makeFrame)
+    const afterFrames = [makeFrame('g1', 10)]
+    // 0.3 closer to the after side, but not by enough
+    // (MIN_LEAK_MARGIN_PERCENT = 0.5).
+    setDiff('a3', 'g1', 20)
+    setDiff('a3', 'a1', 20.3)
+
+    const result = await detectTrailingLeakFrames({ frames, afterFrames })
+
+    expect(result.framesToDrop).toEqual([])
+  })
+
+  it('uses the closest reference on each side', async () => {
+    const frames = ['a1', 'a2', 'a3'].map(makeFrame)
+    const afterFrames = [makeFrame('g1', 10), makeFrame('g2', 11)]
+    // far from g1 but close to g2; own side stays far
+    setDiff('a3', 'g1', 45)
+    setDiff('a3', 'g2', 5)
+    setDiff('a3', 'a1', 40)
+
+    const result = await detectTrailingLeakFrames({ frames, afterFrames })
+
+    expect(filepaths(result.framesToDrop)).toEqual(['a3'])
+  })
+
+  it('never empties the activity even when every frame matches the after side', async () => {
+    const frames = ['a1', 'a2'].map(makeFrame)
+    const afterFrames = [makeFrame('g1', 10)]
+    setDiff('a2', 'g1', 0)
+    setDiff('a2', 'a1', 40)
+    setDiff('a1', 'g1', 0)
+
+    const result = await detectTrailingLeakFrames({ frames, afterFrames })
+
+    expect(filepaths(result.framesToDrop)).toEqual(['a2'])
+  })
+
+  it('keeps a frame whose luminance cannot be loaded', async () => {
+    const frames = ['a1', 'a2', 'a3'].map(makeFrame)
+    const afterFrames = [makeFrame('g1', 10)]
+    nullLuminance.add('a3')
+    setDiff('a3', 'g1', 0)
+
+    const result = await detectTrailingLeakFrames({ frames, afterFrames })
+
+    expect(result.framesToDrop).toEqual([])
+  })
+
+  it('trims nothing when no after-reference can be loaded', async () => {
+    const frames = ['a1', 'a2', 'a3'].map(makeFrame)
+    const afterFrames = [makeFrame('g1', 10), makeFrame('g2', 11)]
+    nullLuminance.add('g1')
+    nullLuminance.add('g2')
+    setDiff('a3', 'g1', 0)
+
+    const result = await detectTrailingLeakFrames({ frames, afterFrames })
+
+    expect(result.framesToDrop).toEqual([])
+  })
+
+  it('trims nothing without after-boundary frames', async () => {
+    const frames = ['a1', 'a2', 'a3', 'a4', 'a5'].map(makeFrame)
+    setDiff('a5', 'a2', 90)
+
+    const result = await detectTrailingLeakFrames({ frames, afterFrames: [] })
+
+    expect(result.framesToDrop).toEqual([])
+  })
+
+  it('does nothing for activities with one or zero frames', async () => {
+    const single = await detectTrailingLeakFrames({
+      frames: [makeFrame('a1', 0)],
+      afterFrames: [makeFrame('g1', 10)],
+    })
+    expect(single.framesToDrop).toEqual([])
+
+    const empty = await detectTrailingLeakFrames({
+      frames: [],
+      afterFrames: [makeFrame('g1', 10)],
+    })
+    expect(empty.framesToDrop).toEqual([])
+  })
+})

--- a/src/main/boundary-trim.ts
+++ b/src/main/boundary-trim.ts
@@ -1,0 +1,97 @@
+import { BOUNDARY_TRIM_CONFIG } from '../shared/constants'
+import { loadImageLuminance, luminanceL1DifferencePercent } from './semantic/visual-diff'
+import type { ActivityFrame } from './activity-types'
+
+export interface BoundaryTrimResult {
+  framesToDrop: ActivityFrame[]
+}
+
+export interface BoundaryTrimParams {
+  frames: ActivityFrame[]
+  afterFrames: ActivityFrame[]
+  candidateCount?: number
+  referenceCount?: number
+  minLeakMarginPercent?: number
+}
+
+// Comparison resolution. Small enough that a resize is cheap, large enough
+// that window layout survives; calibration on real boundary captures gave
+// identical verdicts from 32x18 up to 160x90.
+const LUMINANCE_WIDTH = 96
+const LUMINANCE_HEIGHT = 54
+
+const NO_TRIM: BoundaryTrimResult = { framesToDrop: [] }
+
+/**
+ * Detects trailing frames that leaked across an app boundary. The real app
+ * switch precedes the observer notification, so the last frame(s) of an
+ * activity can visually show the next app while falling inside this
+ * activity's time range.
+ *
+ * Decision rule is purely relative — absolute similarity thresholds don't
+ * work because in-app visual churn varies wildly by app (a scrolling
+ * terminal changes more per second than an app switch changes some screens).
+ * A trailing frame is dropped iff its downsampled-luminance L1 distance to
+ * the frames captured after the boundary (which reliably show the new app)
+ * is meaningfully smaller than its distance to the frames in the body of its
+ * own activity. dHash is deliberately not used here: its comparator bits are
+ * JPEG-noise coin flips on flat dark UI regions, so two captures of the same
+ * dark-themed screen can hash ~50% apart.
+ *
+ * Only a contiguous tail is trimmed, the activity is never emptied, and any
+ * load failure fails open (frame kept).
+ */
+export async function detectTrailingLeakFrames(
+  params: BoundaryTrimParams,
+): Promise<BoundaryTrimResult> {
+  const { frames, afterFrames } = params
+  const candidateCount = params.candidateCount ?? BOUNDARY_TRIM_CONFIG.CANDIDATE_COUNT
+  const referenceCount = params.referenceCount ?? BOUNDARY_TRIM_CONFIG.REFERENCE_COUNT
+  const minLeakMarginPercent =
+    params.minLeakMarginPercent ?? BOUNDARY_TRIM_CONFIG.MIN_LEAK_MARGIN_PERCENT
+
+  if (frames.length <= 1) return NO_TRIM
+  if (afterFrames.length === 0) return NO_TRIM
+
+  const luminanceCache = new Map<string, Promise<Uint8Array | null>>()
+  const luminanceOf = (frame: ActivityFrame): Promise<Uint8Array | null> => {
+    let cached = luminanceCache.get(frame.frame.filepath)
+    if (cached === undefined) {
+      cached = loadImageLuminance(frame.frame.filepath, LUMINANCE_WIDTH, LUMINANCE_HEIGHT)
+      luminanceCache.set(frame.frame.filepath, cached)
+    }
+    return cached
+  }
+
+  const minDistance = async (
+    candidateLuminance: Uint8Array,
+    references: ActivityFrame[],
+  ): Promise<number | null> => {
+    let min: number | null = null
+    for (const reference of references) {
+      const referenceLuminance = await luminanceOf(reference)
+      if (referenceLuminance === null) continue
+      const difference = luminanceL1DifferencePercent(candidateLuminance, referenceLuminance)
+      if (difference === null) continue
+      if (min === null || difference < min) min = difference
+    }
+    return min
+  }
+
+  const candidates = frames.slice(-Math.min(candidateCount, frames.length - 1))
+  const ownReferences = frames.slice(0, frames.length - candidates.length).slice(-referenceCount)
+  const afterReferences = afterFrames.slice(0, referenceCount)
+  if (ownReferences.length === 0) return NO_TRIM
+
+  const framesToDrop: ActivityFrame[] = []
+  for (const candidate of [...candidates].reverse()) {
+    const candidateLuminance = await luminanceOf(candidate)
+    if (candidateLuminance === null) break
+    const distanceToAfter = await minDistance(candidateLuminance, afterReferences)
+    const distanceToOwn = await minDistance(candidateLuminance, ownReferences)
+    if (distanceToAfter === null || distanceToOwn === null) break
+    if (distanceToAfter - distanceToOwn >= -minLeakMarginPercent) break
+    framesToDrop.unshift(candidate)
+  }
+  return framesToDrop.length > 0 ? { framesToDrop } : NO_TRIM
+}

--- a/src/main/semantic/visual-diff.ts
+++ b/src/main/semantic/visual-diff.ts
@@ -29,6 +29,51 @@ export async function loadImageDHash(filepath: string): Promise<string | null> {
   }
 }
 
+// Downsampled grayscale luminance profile. Unlike a dHash — whose
+// adjacent-pixel comparator bits degenerate to JPEG-noise coin flips on the
+// flat dark regions that dominate dark-themed apps — raw luminance compared
+// via L1 distance separates "same screen" from "different screen" cleanly.
+export async function loadImageLuminance(
+  filepath: string,
+  width: number,
+  height: number,
+): Promise<Uint8Array | null> {
+  try {
+    const { data, info } = await sharp(filepath)
+      .ensureAlpha()
+      .resize(width, height, { fit: 'fill' })
+      .raw()
+      .toBuffer({ resolveWithObject: true })
+
+    if (!info.channels || info.channels < 3) {
+      return null
+    }
+
+    const grayscale = new Uint8Array(info.width * info.height)
+    for (let pixel = 0, i = 0; pixel < grayscale.length; pixel++, i += info.channels) {
+      const r = data[i]
+      const g = data[i + 1]
+      const b = data[i + 2]
+      grayscale[pixel] = Math.floor(0.299 * r + 0.587 * g + 0.114 * b)
+    }
+    return grayscale
+  } catch {
+    return null
+  }
+}
+
+// Mean absolute luminance difference as a percentage of full scale (0-100).
+export function luminanceL1DifferencePercent(left: Uint8Array, right: Uint8Array): number | null {
+  if (left.length === 0 || right.length === 0) return null
+  if (left.length !== right.length) return null
+
+  let total = 0
+  for (let i = 0; i < left.length; i++) {
+    total += Math.abs(left[i] - right[i])
+  }
+  return (total / left.length / 255) * 100
+}
+
 export function dHashDifferencePercent(leftHash: string, rightHash: string): number | null {
   if (leftHash.length === 0 || rightHash.length === 0) return null
   if (leftHash.length !== rightHash.length) return null

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -4,6 +4,17 @@ export const VISUAL_DETECTOR_CONFIG = {
   DHASH_THRESHOLD_PERCENT: 8, // Threshold for baseline comparison (1-20%)
 }
 
+// Trailing-frame leak trimming at activity boundaries (ActivityProducer).
+// The real app switch precedes the observer notification (observed 0.5-2s), so
+// the last frame(s) of an activity can visually show the NEXT app.
+export const BOUNDARY_TRIM_CONFIG = {
+  ENABLED: true,
+  CANDIDATE_COUNT: 3, // Trailing frames inspected per finalization
+  REFERENCE_COUNT: 2, // Frames used on each side (own activity / after boundary)
+  AFTER_REFERENCE_WINDOW_MS: 5_000, // Buffered frames this close after the boundary may serve as after-references on flush
+  MIN_LEAK_MARGIN_PERCENT: 0.5, // L1 luminance %: a frame must be this much closer to the after side to be dropped
+}
+
 // User Interaction Monitoring Configuration
 export const INTERACTION_MONITOR_CONFIG = {
   ENABLED: true,


### PR DESCRIPTION
## Problem

The real app switch precedes the app-watcher's NSWorkspace notification by 0.1–2s, so frames grabbed in that gap visually show the **next** app but fall inside the old app's event window. `ActivityProducer` joins frames by timestamp only, so activity videos end with 1–2 frames of the wrong app. The earlier grab-time app-stamp attempt (#163) was abandoned because the stamp source has the same observer lag.

## Approach

At activity finalization, inspect the last 3 frames and drop a contiguous tail that is visually **closer to the frames captured after the boundary than to the activity's own body** (`src/main/boundary-trim.ts`):

- Distance = mean absolute difference of 96×54 grayscale luminance (L1). dHash was tried first and rejected: its comparator bits are JPEG-noise coin flips on flat dark UI regions, so two captures of the same dark-themed screen can hash ~50% apart.
- Purely relative rule with a 0.5% margin — absolute thresholds don't survive per-app churn differences (idle Electron ~2%/s vs scrolling terminal ~35%/s).
- After-boundary references: the successor chunk on a context change, or buffered post-boundary frames (≤5s) on flush. Same-app `max_duration` splits are never trimmed.
- Never empties an activity; any image-load failure fails open (frame kept). Kill-switch `enableBoundaryTrim`, constants in `BOUNDARY_TRIM_CONFIG`, diagnostic counter `trailingFramesTrimmed`.

## Validation

- 13/13 correct on ground-truthed boundary frames from two live runs (leak margins −1.8…−5.5 vs legitimate +1.9…+8.1; verdicts stable from 32×18 to 160×90).
- Unit tests for the decision logic + producer integration tests (trim, kill-switch, same-app split, flush path, fail-open).

## Known limitation

Fails when the next app's content churns faster than the two apps visually differ (e.g. switching between a dark file list and a streaming dark terminal) — the leaked frame then measures closer to its own activity. Closing that gap needs a pixel-synchronous identity signal (window-server z-order at grab time), out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)