### PR TITLE
fix(sidebar): hide logo when sidebar is collapsed

### DIFF
--- a/src/renderer/pages/main-window/components/shell/Sidebar.tsx
+++ b/src/renderer/pages/main-window/components/shell/Sidebar.tsx
@@ -76,10 +76,7 @@ export function Sidebar({
   return (
     <div className="flex flex-col h-full p-3 gap-3">
       {collapsed ? (
-        <div className="flex flex-col items-center gap-1">
-          <Logo size="sm" iconOnly />
-          {toggleButton}
-        </div>
+        <div className="flex flex-col items-center gap-1">{toggleButton}</div>
       ) : (
         <div className="flex items-center justify-between pl-1.75">
           <Logo size="sm" />


### PR DESCRIPTION
When the sidebar is collapsed, only the expand toggle button is shown. The logo no longer renders in the collapsed state; it still appears when expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)