### PR TITLE
refactor(eval): slim eval CLIs to model/fixture/pipeline + dedup pipelines

### DIFF
--- a/scripts/eval-summaries.ts
+++ b/scripts/eval-summaries.ts
@@ -8,8 +8,9 @@
  * the same as the target?). Writes a findings-style Markdown scorecard + JSON.
  *
  * Deterministic upstream of the LLM (see replay-harness.ts); only the model and
- * producer config are variables. Needs no live app — just capture-settings.json
- * / vendor-credentials.json + an API key.
+ * pipeline are variables — everything else runs against code defaults. Reads the
+ * app's own settings/credentials (active vendor, API key from env); needs no
+ * live app.
  *
  * Benchmarks run in the VIDEO pipeline by default (production's default), each
  * model in isolation (no preset fallback). Pass `--pipeline image` to benchmark
@@ -17,10 +18,10 @@
  * image-vs-image — a model that can't serve the lane shows as an empty summary.
  *
  * Usage:
- *   npm run eval-summaries -- --fixtures vscode-debug --models google/gemini-2.5-flash
- *   npm run eval-summaries -- --fixtures a,b --models m1,m2 --judge-model google/gemini-2.5-pro
- *   npm run eval-summaries -- --fixtures X --no-llm-judge          (deterministic only, free)
- *   npm run eval-summaries -- --fixtures-dir evals/semantic-summary/fixtures --pipeline image
+ *   npm run eval-summaries                                  (all fixtures, default model, no judge)
+ *   npm run eval-summaries -- --fixture vscode-debug
+ *   npm run eval-summaries -- --model google/gemini-2.5-flash --judge
+ *   npm run eval-summaries -- --pipeline image              (benchmark snapshot models)
  */
 
 import { config as loadEnv } from 'dotenv'
@@ -29,10 +30,7 @@ loadEnv()
 import * as fs from 'fs'
 import * as path from 'path'
 import { VENDOR_PRESETS } from '../src/shared/vendor-defaults'
-import {
-  SemanticFileDebugDumper,
-  type SemanticPipelinePreference,
-} from '../src/main/activity-semantic-service'
+import type { SemanticPipelinePreference } from '../src/main/activity-semantic-service'
 import { scoreDeterministic } from '../src/main/eval/deterministic'
 import { judgeSummary, judgeEquivalence } from '../src/main/eval/judge'
 import { priceUsd, sumCosts } from '../src/main/eval/cost'
@@ -50,43 +48,21 @@ import { replayCell } from './replay-cell'
 import { loadCliInferenceProvider, type CliInferenceProviderHandle } from './cli-inference-provider'
 
 const FIXTURES_ROOT = path.resolve('evals/semantic-summary/fixtures')
-const DEFAULT_RESULTS_DIR = path.resolve('evals/semantic-summary/results')
+const RESULTS_DIR = path.resolve('evals/semantic-summary/results')
+const FIXTURE_FILE = 'event-windows.jsonl'
+const CONCURRENCY = 4
 
 interface CliArgs {
   fixtures: string[]
-  fixturesDir: string | null
   models: string[]
   pipeline: SemanticPipelinePreference
-  judgeModel: string | null
-  noLlmJudge: boolean
-  ocr: boolean
-  concurrency: number
-  dumpRoundTrips: string | null
-  out: string
-  apiKey: string | undefined
-  userDataPath: string | undefined
-  vendorOverride: string | undefined
+  judge: boolean
 }
 
 function parseArgs(): CliArgs {
   const args = process.argv.slice(2)
-  const a: CliArgs = {
-    fixtures: [],
-    fixturesDir: null,
-    models: [],
-    // Video is the production default pipeline, so benchmark there by default.
-    // Pass `--pipeline image` to benchmark snapshot models instead.
-    pipeline: 'video',
-    judgeModel: null,
-    noLlmJudge: false,
-    ocr: false,
-    concurrency: 4,
-    dumpRoundTrips: null,
-    out: DEFAULT_RESULTS_DIR,
-    apiKey: undefined,
-    userDataPath: undefined,
-    vendorOverride: undefined,
-  }
+  // Video is the production default pipeline, so benchmark there by default.
+  const a: CliArgs = { fixtures: [], models: [], pipeline: 'video', judge: false }
   const list = (s: string): string[] =>
     s
       .split(',')
@@ -106,9 +82,6 @@ function parseArgs(): CliArgs {
       case '--fixtures':
         i = take((v) => a.fixtures.push(...list(v)), i)
         break
-      case '--fixtures-dir':
-        i = take((v) => (a.fixturesDir = v), i)
-        break
       case '--models':
       case '--model':
         i = take((v) => (a.models = list(v)), i)
@@ -118,32 +91,8 @@ function parseArgs(): CliArgs {
           if (v === 'auto' || v === 'video' || v === 'image') a.pipeline = v
         }, i)
         break
-      case '--judge-model':
-        i = take((v) => (a.judgeModel = v), i)
-        break
-      case '--no-llm-judge':
-        a.noLlmJudge = true
-        break
-      case '--ocr':
-        a.ocr = true
-        break
-      case '--concurrency':
-        i = take((v) => (a.concurrency = Math.max(1, parseInt(v, 10))), i)
-        break
-      case '--dump-roundtrips':
-        i = take((v) => (a.dumpRoundTrips = v), i)
-        break
-      case '--out':
-        i = take((v) => (a.out = path.resolve(v)), i)
-        break
-      case '--api-key':
-        i = take((v) => (a.apiKey = v), i)
-        break
-      case '--user-data':
-        i = take((v) => (a.userDataPath = v), i)
-        break
-      case '--vendor':
-        i = take((v) => (a.vendorOverride = v), i)
+      case '--judge':
+        a.judge = true
         break
     }
   }
@@ -152,23 +101,21 @@ function parseArgs(): CliArgs {
 
 function resolveFixtureDir(nameOrPath: string): string {
   const asPath = path.resolve(nameOrPath)
-  if (fs.existsSync(path.join(asPath, 'event-windows.jsonl'))) return asPath
+  if (fs.existsSync(path.join(asPath, FIXTURE_FILE))) return asPath
   const asName = path.join(FIXTURES_ROOT, nameOrPath)
-  if (fs.existsSync(path.join(asName, 'event-windows.jsonl'))) return asName
+  if (fs.existsSync(path.join(asName, FIXTURE_FILE))) return asName
   throw new Error(`Fixture not found: "${nameOrPath}"`)
 }
 
+/** Named fixtures, or every fixture in the standard root when none are named. */
 function resolveFixtureDirs(a: CliArgs): string[] {
-  const dirs = a.fixtures.map(resolveFixtureDir)
-  if (a.fixturesDir) {
-    const root = path.resolve(a.fixturesDir)
-    for (const entry of fs.readdirSync(root)) {
-      const dir = path.join(root, entry)
-      if (fs.existsSync(path.join(dir, 'event-windows.jsonl'))) dirs.push(dir)
-    }
-  }
-  if (dirs.length === 0) throw new Error('No fixtures. Use --fixtures or --fixtures-dir.')
-  return [...new Set(dirs)]
+  if (a.fixtures.length) return [...new Set(a.fixtures.map(resolveFixtureDir))]
+  const dirs = fs
+    .readdirSync(FIXTURES_ROOT)
+    .map((entry) => path.join(FIXTURES_ROOT, entry))
+    .filter((dir) => fs.existsSync(path.join(dir, FIXTURE_FILE)))
+  if (dirs.length === 0) throw new Error(`No fixtures in ${FIXTURES_ROOT}.`)
+  return dirs
 }
 
 function defaultJudgeModel(handle: CliInferenceProviderHandle): string | null {
@@ -208,32 +155,18 @@ const mean = (xs: number[]): number => xs.reduce((x, y) => x + y, 0) / xs.length
 async function main() {
   const a = parseArgs()
   const fixtureDirs = resolveFixtureDirs(a)
-  const handle = loadCliInferenceProvider({
-    apiKey: a.apiKey,
-    userDataPath: a.userDataPath,
-    vendorOverride: a.vendorOverride,
-  })
+  const handle = loadCliInferenceProvider()
   const presets = VENDOR_PRESETS[handle.vendor]
-  const judgeModel = a.noLlmJudge ? null : (a.judgeModel ?? defaultJudgeModel(handle))
+  const judgeModel = a.judge ? defaultJudgeModel(handle) : null
 
   // Default model matches the pipeline: the video model for video/auto, the
-  // snapshot model for image — so `--models` can be omitted for a quick run.
+  // snapshot model for image — so `--model` can be omitted for a quick run.
   const defaultModel =
     a.pipeline === 'image'
       ? (presets.semanticSnapshot[0]?.id ?? handle.semanticSnapshotModel)
       : (presets.semanticVideo[0]?.id ?? handle.semanticVideoModel)
   const models = a.models.length ? a.models : [defaultModel].filter(Boolean)
-  if (models.length === 0) throw new Error('No models. Pass --models <id,...>.')
-
-  // Round-trip dumping (optional) clobbers a shared dir, so it forces serial runs.
-  const dumper = a.dumpRoundTrips
-    ? new SemanticFileDebugDumper({
-        rootDir: path.resolve(a.dumpRoundTrips),
-        cleanRootDir: true,
-        copyMediaAssets: true,
-      })
-    : undefined
-  const concurrency = dumper ? 1 : a.concurrency
+  if (models.length === 0) throw new Error('No models. Pass --model <id>.')
 
   const cells: Cell[] = []
   for (const dir of fixtureDirs)
@@ -244,7 +177,7 @@ async function main() {
     `=== Eval ===  vendor=${handle.vendor} cells=${cells.length} judge=${judgeModel ?? 'none'}`,
   )
 
-  const fixtures: FixtureScore[] = await runWithConcurrency(cells, concurrency, async (cell) => {
+  const fixtures: FixtureScore[] = await runWithConcurrency(cells, CONCURRENCY, async (cell) => {
     const {
       activities,
       producerStats,
@@ -255,8 +188,6 @@ async function main() {
       fixtureDir: cell.fixtureDir,
       model: cell.model,
       pipeline: a.pipeline,
-      dumper,
-      ocr: a.ocr,
     })
     const goldens = loadGoldenMd(path.join(cell.fixtureDir, 'golden.md'))
 
@@ -312,11 +243,11 @@ async function main() {
   if (judgeModel && fixtures.every((f) => f.avgJudge10 === null)) {
     console.warn(
       `⚠  Judge "${judgeModel}" returned no scores for any summary — it likely can't ` +
-        `accept images, or every call failed. Pass --judge-model <multimodal-model> or --no-llm-judge.`,
+        `accept images, or every call failed. Drop --judge to skip the judge.`,
     )
   }
 
-  const { runDir, comparePath } = writeReport(a.out, report)
+  const { runDir, comparePath } = writeReport(RESULTS_DIR, report)
   console.log('')
   console.log(renderMarkdown(report).split('\n## Summaries')[0])
   console.log(`Wrote ${runDir}/`)

--- a/scripts/eval-tasks.ts
+++ b/scripts/eval-tasks.ts
@@ -8,15 +8,14 @@
  *
  * Each fixture is a whole real day exported from the dev DB (realistic volume),
  * with a hand-authored golden.md listing its useful tasks; see
- * evals/task-mining/README.md. Needs no live app — just capture-settings.json /
- * vendor-credentials.json + an API key.
+ * evals/task-mining/README.md. Reads the app's own settings/credentials (active
+ * vendor, API key from env); needs no live app.
  *
  * Usage:
- *   npm run eval-tasks -- --fixtures 2026-06-10 --label   (append found sightings to golden.md to thumbs)
- *   npm run eval-tasks -- --fixtures 2026-06-10           (score against your keep/reject labels)
- *   npm run eval-tasks -- --fixtures a,b --models m1,m2 --judge-model X
- *   npm run eval-tasks -- --fixtures X --no-llm-judge     (deterministic only, free)
- *   npm run eval-tasks -- --fixtures-dir evals/task-mining/fixtures
+ *   npm run eval-tasks                                    (all fixtures, default model, no judge)
+ *   npm run eval-tasks -- --fixture 2026-06-10 --label   (append found sightings to golden.md to thumbs)
+ *   npm run eval-tasks -- --fixture 2026-06-10           (score against your keep/reject labels)
+ *   npm run eval-tasks -- --model m1 --judge             (semantic-equivalence judge, paid)
  */
 
 import { config as loadEnv } from 'dotenv'
@@ -29,6 +28,7 @@ import { PATTERN_DETECTION_CONFIG } from '../src/shared/constants'
 import { loadTaskFixture, runTaskFixture } from '../src/main/eval/task-replay'
 import { scoreTaskFixture, bestDetectedForGolden } from '../src/main/eval/task-score'
 import { renderLabelBlocks } from '../src/main/eval/task-golden-md'
+import { renderTaskMarkdown, writeTaskReport } from '../src/main/eval/task-report'
 import { judgeSighting } from '../src/main/eval/task-judge'
 import { priceUsd } from '../src/main/eval/cost'
 import type {
@@ -40,37 +40,19 @@ import type {
 import { loadCliInferenceProvider } from './cli-inference-provider'
 
 const FIXTURES_ROOT = path.resolve('evals/task-mining/fixtures')
-const DEFAULT_RESULTS_DIR = path.resolve('evals/task-mining/results')
+const RESULTS_DIR = path.resolve('evals/task-mining/results')
+const LOOKBACK_DAYS = PATTERN_DETECTION_CONFIG.LOOKBACK_DAYS
 
 interface CliArgs {
   fixtures: string[]
-  fixturesDir: string | null
   models: string[]
-  lookback: number
-  judgeModel: string | null
-  noLlmJudge: boolean
+  judge: boolean
   label: boolean
-  out: string
-  apiKey: string | undefined
-  userDataPath: string | undefined
-  vendorOverride: string | undefined
 }
 
 function parseArgs(): CliArgs {
   const args = process.argv.slice(2)
-  const a: CliArgs = {
-    fixtures: [],
-    fixturesDir: null,
-    models: [],
-    lookback: PATTERN_DETECTION_CONFIG.LOOKBACK_DAYS,
-    judgeModel: null,
-    noLlmJudge: false,
-    label: false,
-    out: DEFAULT_RESULTS_DIR,
-    apiKey: undefined,
-    userDataPath: undefined,
-    vendorOverride: undefined,
-  }
+  const a: CliArgs = { fixtures: [], models: [], judge: false, label: false }
   const list = (s: string): string[] =>
     s
       .split(',')
@@ -90,114 +72,28 @@ function parseArgs(): CliArgs {
       case '--fixtures':
         i = take((v) => a.fixtures.push(...list(v)), i)
         break
-      case '--fixtures-dir':
-        i = take((v) => (a.fixturesDir = v), i)
-        break
       case '--models':
       case '--model':
         i = take((v) => (a.models = list(v)), i)
         break
-      case '--lookback':
-        i = take((v) => (a.lookback = parseInt(v, 10)), i)
-        break
-      case '--judge-model':
-        i = take((v) => (a.judgeModel = v), i)
-        break
-      case '--no-llm-judge':
-        a.noLlmJudge = true
+      case '--judge':
+        a.judge = true
         break
       case '--label':
         a.label = true
-        break
-      case '--out':
-        i = take((v) => (a.out = path.resolve(v)), i)
-        break
-      case '--api-key':
-        i = take((v) => (a.apiKey = v), i)
-        break
-      case '--user-data':
-        i = take((v) => (a.userDataPath = v), i)
-        break
-      case '--vendor':
-        i = take((v) => (a.vendorOverride = v), i)
         break
     }
   }
   return a
 }
 
+/** Named fixtures, or every fixture in the standard root when none are named. */
 function resolveFixtureDirs(a: CliArgs): string[] {
-  if (a.fixturesDir) {
-    const root = path.resolve(a.fixturesDir)
-    return fs
-      .readdirSync(root)
-      .map((name) => path.join(root, name))
-      .filter((p) => fs.existsSync(path.join(p, 'manifest.json')))
-  }
-  return a.fixtures.map((name) => path.join(FIXTURES_ROOT, name))
-}
-
-// ---------------------------------------------------------------------------
-// Report rendering (findings-style, mirrors src/main/eval/report.ts)
-// ---------------------------------------------------------------------------
-
-const pct = (x: number | null): string => (x == null ? '—' : `${Math.round(x * 100)}%`)
-const num = (x: number | null, d = 2): string => (x == null ? '—' : x.toFixed(d))
-const usd = (x: number | null): string => (x == null ? '—' : `$${x.toFixed(4)}`)
-
-function renderMarkdown(report: TaskEvalReport): string {
-  const lines: string[] = []
-  lines.push(`# Task-Mining Eval — ${report.generatedAt}`)
-  lines.push('')
-  lines.push(`- Vendor: ${report.vendor}`)
-  lines.push(`- Judge: ${report.judgeModel ?? '(none)'}`)
-  lines.push('')
-  lines.push('## Scorecard')
-  lines.push('')
-  lines.push(
-    '| Fixture | Model | Found (keep) | Recall | Reject reproduced | New | Grounding | Equiv | Cost |',
-  )
-  lines.push('|---|---|--:|--:|--:|--:|--:|--:|--:|')
-  for (const f of report.fixtures) {
-    lines.push(
-      `| ${f.fixture} | ${f.model} | ${f.foundCount}/${f.positiveCount} | ${pct(f.recall)} | ` +
-        `${f.rejectedReproducedCount}/${f.negativeCount} | ${f.newCount} | ` +
-        `${pct(f.avgGroundingRecall)} | ${num(f.avgEquivalence)} | ${usd(f.costUsd)} |`,
-    )
-  }
-  lines.push('')
-  lines.push('## Detail')
-  for (const f of report.fixtures) {
-    lines.push('')
-    lines.push(`### ${f.fixture} | ${f.model}`)
-    lines.push(
-      `> ${f.detectedCount} sighting(s) detected; ${f.foundCount}/${f.positiveCount} keep tasks found; ` +
-        `${f.rejectedReproducedCount} reject(s) reproduced; ${f.newCount} new`,
-    )
-    if (f.rejectedReproducedTitles.length)
-      lines.push(`> ⚠ reproduced rejects: ${f.rejectedReproducedTitles.join('; ')}`)
-    if (f.bundledSightingIds.length)
-      lines.push(`> ⚠ ${f.bundledSightingIds.length} sighting(s) bundled multiple keep tasks`)
-    for (const g of f.goldenScores) {
-      const mark = g.found ? '✅' : '❌'
-      lines.push('')
-      lines.push(`- ${mark} **${g.goldenTitle}** → ${g.matchedTitle ?? '(missed)'}`)
-      lines.push(
-        `  - grounding: recall ${pct(g.grounding.recall)}, precision ${pct(g.grounding.precision)}, ` +
-          `IoU ${pct(g.grounding.iou)} (${g.grounding.matchedIds.length} ids)`,
-      )
-      if (g.equivalence != null) {
-        lines.push(`  - judge: equiv ${num(g.equivalence)}`)
-      }
-    }
-    if (f.newSightings.length) {
-      lines.push('')
-      lines.push('New (unlabeled — thumbs these with `--label`):')
-      for (const n of f.newSightings) lines.push(`  - ${n.title} (${n.activityIds.length} ids)`)
-    }
-  }
-  lines.push('')
-  return lines.join('\n')
+  if (a.fixtures.length) return a.fixtures.map((name) => path.join(FIXTURES_ROOT, name))
+  return fs
+    .readdirSync(FIXTURES_ROOT)
+    .map((name) => path.join(FIXTURES_ROOT, name))
+    .filter((p) => fs.existsSync(path.join(p, 'manifest.json')))
 }
 
 // ---------------------------------------------------------------------------
@@ -208,26 +104,22 @@ async function main() {
   const a = parseArgs()
   const dirs = resolveFixtureDirs(a)
   if (dirs.length === 0) {
-    console.error('No fixtures. Pass --fixtures <name,...> or --fixtures-dir <dir>.')
+    console.error(`No fixtures in ${FIXTURES_ROOT}. Pass --fixture <name> or add fixtures there.`)
     process.exit(1)
   }
 
-  const handle = loadCliInferenceProvider({
-    apiKey: a.apiKey,
-    userDataPath: a.userDataPath,
-    vendorOverride: a.vendorOverride,
-  })
+  const handle = loadCliInferenceProvider()
   const models =
     a.models.length > 0
       ? a.models
       : [handle.patternDetectionModel || PATTERN_DETECTION_CONFIG.MODEL]
-  const judgeModel = a.judgeModel ?? models[0]
+  const judgeModel = models[0]
 
   console.log('=== Task-Mining Eval ===')
   console.log(`Vendor:   ${handle.vendor}${handle.baseURL ? ` (${handle.baseURL})` : ''}`)
   console.log(`Models:   ${models.join(', ')}`)
-  console.log(`Judge:    ${a.noLlmJudge ? '(disabled)' : judgeModel}`)
-  console.log(`Lookback: ${a.lookback}d`)
+  console.log(`Judge:    ${a.judge ? judgeModel : '(disabled)'}`)
+  console.log(`Lookback: ${LOOKBACK_DAYS}d`)
   console.log(`Fixtures: ${dirs.map((d) => path.basename(d)).join(', ')}`)
   console.log('')
 
@@ -254,7 +146,7 @@ async function main() {
         provider: handle.provider,
         fixture,
         model,
-        lookbackDays: a.lookback,
+        lookbackDays: LOOKBACK_DAYS,
         embedder,
         onProgress: (msg) => console.log(`  ${msg}`),
       })
@@ -262,7 +154,7 @@ async function main() {
       const judge = new Map<string, TaskJudgeScore>()
       let judgeTokensIn = 0
       let judgeTokensOut = 0
-      if (!a.noLlmJudge) {
+      if (a.judge) {
         for (const g of fixture.golden.sightings) {
           if (g.verdict !== 'keep') continue
           const best = bestDetectedForGolden(g.activityIds, run.detected)
@@ -286,8 +178,8 @@ async function main() {
         model,
         detected: run.detected,
         tokenUsage: run.tokenUsage,
-        judge: a.noLlmJudge ? undefined : judge,
-        judgeCostUsd: a.noLlmJudge ? null : priceUsd(judgeModel, judgeTokensIn, judgeTokensOut),
+        judge: a.judge ? judge : undefined,
+        judgeCostUsd: a.judge ? priceUsd(judgeModel, judgeTokensIn, judgeTokensOut) : null,
       })
       scores.push(score)
       for (const n of score.newSightings) {
@@ -314,19 +206,13 @@ async function main() {
   const report: TaskEvalReport = {
     generatedAt: new Date().toISOString(),
     vendor: handle.vendor,
-    judgeModel: a.noLlmJudge ? null : judgeModel,
+    judgeModel: a.judge ? judgeModel : null,
     fixtures: scores,
   }
 
-  fs.mkdirSync(a.out, { recursive: true })
-  const stamp = report.generatedAt.replace(/[:.]/g, '-')
-  const jsonPath = path.join(a.out, `${stamp}.json`)
-  const mdPath = path.join(a.out, `${stamp}.md`)
-  fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2), 'utf8')
-  fs.writeFileSync(mdPath, renderMarkdown(report), 'utf8')
-
+  const mdPath = writeTaskReport(RESULTS_DIR, report)
   console.log('\n=== Scorecard ===')
-  console.log(renderMarkdown(report))
+  console.log(renderTaskMarkdown(report))
   console.log(`\nWrote ${path.relative(process.cwd(), mdPath)}`)
 }
 

--- a/src/main/eval/format.ts
+++ b/src/main/eval/format.ts
@@ -1,0 +1,21 @@
+/** Shared Markdown-scorecard formatting helpers for the eval reports. */
+
+/** Fixed-decimal number, or `—` for null/NaN. */
+export function num(n: number | null, digits = 2): string {
+  return n === null || Number.isNaN(n) ? '—' : n.toFixed(digits)
+}
+
+/** A 0..1 ratio as a percentage, or `—` for null/NaN. */
+export function pct(x: number | null, digits = 0): string {
+  return x === null || Number.isNaN(x) ? '—' : `${(x * 100).toFixed(digits)}%`
+}
+
+/** A USD amount as `$0.0000`, or `—` for null. */
+export function usd(x: number | null): string {
+  return x === null ? '—' : `$${x.toFixed(4)}`
+}
+
+/** Escapes free text for a Markdown table cell (pipes, newlines → <br>). */
+export function cell(text: string): string {
+  return text.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>').trim()
+}

--- a/src/main/eval/golden-md.ts
+++ b/src/main/eval/golden-md.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import { splitMarkdownBlocks } from './markdown-blocks'
 import type { ReplayActivity } from './types'
 
 /**
@@ -109,22 +110,8 @@ export function renderGoldenMd(
 
 /** Parses a golden.md back into structured activities. Lenient on whitespace. */
 export function parseGoldenMd(text: string): GoldenActivity[] {
-  const stripped = text.replace(/<!--[\s\S]*?-->/g, '')
   const out: GoldenActivity[] = []
-
-  // Split into blocks on `## ` headers.
-  const blocks: string[][] = []
-  let current: string[] | null = null
-  for (const rawLine of stripped.split('\n')) {
-    if (HEADER_RE.test(rawLine)) {
-      current = [rawLine]
-      blocks.push(current)
-    } else if (current) {
-      current.push(rawLine)
-    }
-  }
-
-  for (const block of blocks) {
+  for (const block of splitMarkdownBlocks(text, HEADER_RE)) {
     const headerMatch = block[0].match(HEADER_RE)
     if (!headerMatch) continue
     const appName = headerMatch[2].trim()

--- a/src/main/eval/judge.ts
+++ b/src/main/eval/judge.ts
@@ -1,9 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import { generateText } from 'ai'
-import log from '../logger'
 import type { InferenceProvider } from '../llm'
-import { extractJsonObject } from '../services/pattern-detector/helpers'
+import { callJsonJudge, type JudgeContent } from './llm-judge'
 import type { JudgeResult } from './types'
 
 /**
@@ -84,47 +82,31 @@ function buildPrompt(params: JudgeParams): string {
 }
 
 export async function judgeSummary(params: JudgeParams): Promise<JudgeResult | null> {
-  const promptText = buildPrompt(params)
-  const content: Array<
-    { type: 'text'; text: string } | { type: 'file'; data: string; mediaType: string }
-  > = [{ type: 'text', text: promptText }]
-
+  const content: JudgeContent[] = [{ type: 'text', text: buildPrompt(params) }]
   for (const p of sampleEvenly(params.imagePaths, params.maxImages ?? DEFAULT_MAX_IMAGES)) {
     const img = encodeImage(p)
     if (img) content.push(img)
   }
 
-  let result
-  try {
-    result = await generateText({
-      model: params.provider.languageModel(params.judgeModel),
-      messages: [{ role: 'user', content }],
-      abortSignal: params.signal,
-    })
-  } catch (err) {
-    log.warn('[judge] call failed:', err instanceof Error ? err.message : String(err))
-    return null
-  }
+  const res = await callJsonJudge<{ score?: number; notes?: string; flaggedClaims?: string[] }>({
+    provider: params.provider,
+    model: params.judgeModel,
+    content,
+    tag: 'judge',
+    signal: params.signal,
+  })
+  if (!res || typeof res.parsed.score !== 'number') return null
 
-  const parsed = extractJsonObject<{
-    score?: number
-    notes?: string
-    flaggedClaims?: string[]
-  }>(result.text)
-  if (!parsed || typeof parsed.score !== 'number') {
-    log.warn('[judge] could not parse judge JSON; raw text:', result.text.slice(0, 200))
-    return null
-  }
-
+  const { parsed } = res
   return {
-    score10: Math.max(0, Math.min(10, Math.round(parsed.score * 100) / 100)),
+    score10: Math.max(0, Math.min(10, Math.round(parsed.score! * 100) / 100)),
     notes: typeof parsed.notes === 'string' ? parsed.notes : '',
     flaggedClaims: Array.isArray(parsed.flaggedClaims)
       ? parsed.flaggedClaims.filter((c): c is string => typeof c === 'string')
       : [],
     judgeModel: params.judgeModel,
-    tokensIn: result.usage.inputTokens ?? 0,
-    tokensOut: result.usage.outputTokens ?? 0,
+    tokensIn: res.tokensIn,
+    tokensOut: res.tokensOut,
   }
 }
 
@@ -155,21 +137,17 @@ export async function judgeEquivalence(params: {
     'Respond with ONLY JSON: {"equivalence": <0.0-1.0>}',
   ].join('\n')
 
-  try {
-    const result = await generateText({
-      model: params.provider.languageModel(params.model),
-      messages: [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
-      abortSignal: params.signal,
-    })
-    const parsed = extractJsonObject<{ equivalence?: number }>(result.text)
-    if (!parsed || typeof parsed.equivalence !== 'number') return null
-    return {
-      equivalence: Math.max(0, Math.min(1, parsed.equivalence)),
-      tokensIn: result.usage.inputTokens ?? 0,
-      tokensOut: result.usage.outputTokens ?? 0,
-    }
-  } catch (err) {
-    log.warn('[judge] equivalence call failed:', err instanceof Error ? err.message : String(err))
-    return null
+  const res = await callJsonJudge<{ equivalence?: number }>({
+    provider: params.provider,
+    model: params.model,
+    content: [{ type: 'text', text: prompt }],
+    tag: 'judge:equivalence',
+    signal: params.signal,
+  })
+  if (!res || typeof res.parsed.equivalence !== 'number') return null
+  return {
+    equivalence: Math.max(0, Math.min(1, res.parsed.equivalence)),
+    tokensIn: res.tokensIn,
+    tokensOut: res.tokensOut,
   }
 }

--- a/src/main/eval/llm-judge.ts
+++ b/src/main/eval/llm-judge.ts
@@ -1,0 +1,53 @@
+import { generateText } from 'ai'
+import log from '../logger'
+import type { InferenceProvider } from '../llm'
+import { extractJsonObject } from '../services/pattern-detector/helpers'
+
+/** A user-message content part the judge prompt can carry (text, or an image). */
+export type JudgeContent =
+  | { type: 'text'; text: string }
+  | { type: 'file'; data: string; mediaType: string }
+
+export interface JudgeCallResult<T> {
+  parsed: T
+  tokensIn: number
+  tokensOut: number
+}
+
+/**
+ * Shared scaffold for an LLM judge call that returns parsed JSON: runs
+ * `generateText`, extracts a JSON object from the reply, and reports token usage.
+ * Returns null (logged under `tag`) when the call throws or the reply doesn't
+ * parse — every judge in the eval treats that as "no score". Callers build the
+ * prompt (text-only or multimodal) and validate the parsed shape.
+ */
+export async function callJsonJudge<T extends object>(params: {
+  provider: InferenceProvider
+  model: string
+  content: JudgeContent[]
+  tag: string
+  signal?: AbortSignal
+}): Promise<JudgeCallResult<T> | null> {
+  let result
+  try {
+    result = await generateText({
+      model: params.provider.languageModel(params.model),
+      messages: [{ role: 'user', content: params.content }],
+      abortSignal: params.signal,
+    })
+  } catch (err) {
+    log.warn(`[${params.tag}] call failed:`, err instanceof Error ? err.message : String(err))
+    return null
+  }
+
+  const parsed = extractJsonObject<T>(result.text)
+  if (!parsed) {
+    log.warn(`[${params.tag}] could not parse judge JSON; raw:`, result.text.slice(0, 200))
+    return null
+  }
+  return {
+    parsed,
+    tokensIn: result.usage.inputTokens ?? 0,
+    tokensOut: result.usage.outputTokens ?? 0,
+  }
+}

--- a/src/main/eval/markdown-blocks.ts
+++ b/src/main/eval/markdown-blocks.ts
@@ -1,0 +1,20 @@
+/**
+ * Splits a golden.md (or similar) into `## ` blocks. Both golden parsers
+ * (activity-summary and task-mining) share this: strip HTML comments, then start
+ * a new block at each line matching `headerRe`. Lines before the first header are
+ * dropped. Returns each block as its lines, header line first.
+ */
+export function splitMarkdownBlocks(text: string, headerRe: RegExp): string[][] {
+  const stripped = text.replace(/<!--[\s\S]*?-->/g, '')
+  const blocks: string[][] = []
+  let current: string[] | null = null
+  for (const rawLine of stripped.split('\n')) {
+    if (headerRe.test(rawLine)) {
+      current = [rawLine]
+      blocks.push(current)
+    } else if (current) {
+      current.push(rawLine)
+    }
+  }
+  return blocks
+}

--- a/src/main/eval/report.ts
+++ b/src/main/eval/report.ts
@@ -1,18 +1,10 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { formatOffset } from './golden-md'
+import { num as fmt, pct, usd, cell } from './format'
 import type { EvalReport, FixtureScore, ScoredSummary } from './types'
 
 /** Renders an EvalReport into a findings-style Markdown scorecard + raw JSON. */
-
-function fmt(n: number | null, digits = 2): string {
-  return n === null || Number.isNaN(n) ? '—' : n.toFixed(digits)
-}
-
-/** Escapes free text for a Markdown table cell (pipes, newlines → <br>). */
-function cell(text: string): string {
-  return text.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>').trim()
-}
 
 /**
  * The model label for a variant, surfacing model-chain fallback: when the model
@@ -48,11 +40,11 @@ export function renderMarkdown(report: EvalReport): string {
   )
   lines.push('|---|---|--:|--:|--:|--:|--:|--:|--:|')
   for (const f of report.fixtures) {
-    const seg = f.segmentation ? `${fmt(f.segmentation.coverage * 100, 0)}%` : '—'
+    const seg = f.segmentation ? pct(f.segmentation.coverage) : '—'
     lines.push(
       `| ${f.fixture} | ${modelLabel(f)} | ${f.summaries.length} | ` +
-        `${fmt(f.detPassRate * 100, 0)}% | ${f.hardFails} | ${fmt(f.avgJudge10)} | ` +
-        `${seg} | ${fmt(f.avgEquivalence, 2)} | ${f.costUsd != null ? `$${fmt(f.costUsd, 4)}` : '—'} |`,
+        `${pct(f.detPassRate)} | ${f.hardFails} | ${fmt(f.avgJudge10)} | ` +
+        `${seg} | ${fmt(f.avgEquivalence, 2)} | ${usd(f.costUsd)} |`,
     )
   }
   lines.push('')
@@ -144,11 +136,11 @@ export function renderComparisonMarkdown(report: EvalReport): string | null {
     lines.push('| Variant | Acts | Det pass% | Hard fails | Judge/10 | Seg% | Equiv | Cost (USD) |')
     lines.push('|---|--:|--:|--:|--:|--:|--:|--:|')
     for (const s of scores) {
-      const seg = s.segmentation ? `${fmt(s.segmentation.coverage * 100, 0)}%` : '—'
+      const seg = s.segmentation ? pct(s.segmentation.coverage) : '—'
       lines.push(
-        `| ${modelLabel(s)} | ${s.summaries.length} | ${fmt(s.detPassRate * 100, 0)}% | ` +
+        `| ${modelLabel(s)} | ${s.summaries.length} | ${pct(s.detPassRate)} | ` +
           `${s.hardFails} | ${fmt(s.avgJudge10)} | ${seg} | ${fmt(s.avgEquivalence, 2)} | ` +
-          `${s.costUsd != null ? `$${fmt(s.costUsd, 4)}` : '—'} |`,
+          `${usd(s.costUsd)} |`,
       )
     }
     lines.push('')

--- a/src/main/eval/task-golden-md.ts
+++ b/src/main/eval/task-golden-md.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import { splitMarkdownBlocks } from './markdown-blocks'
 import type {
   GoldenSighting,
   GoldenVerdict,
@@ -119,21 +120,8 @@ export function renderLabelBlocks(sightings: NewSighting[]): string {
 
 /** Parses golden.md into labeled sightings. Lenient on whitespace. */
 export function parseTaskGoldenMd(text: string): TaskGolden {
-  const stripped = text.replace(/<!--[\s\S]*?-->/g, '')
-
-  const blocks: string[][] = []
-  let current: string[] | null = null
-  for (const rawLine of stripped.split('\n')) {
-    if (HEADER_RE.test(rawLine)) {
-      current = [rawLine]
-      blocks.push(current)
-    } else if (current) {
-      current.push(rawLine)
-    }
-  }
-
   const sightings: GoldenSighting[] = []
-  for (const block of blocks) {
+  for (const block of splitMarkdownBlocks(text, HEADER_RE)) {
     const headerMatch = block[0].match(HEADER_RE)
     if (!headerMatch) continue
     const title = headerMatch[1].trim()

--- a/src/main/eval/task-judge.ts
+++ b/src/main/eval/task-judge.ts
@@ -1,7 +1,5 @@
-import { generateText } from 'ai'
-import log from '../logger'
 import type { InferenceProvider } from '../llm'
-import { extractJsonObject } from '../services/pattern-detector/helpers'
+import { callJsonJudge } from './llm-judge'
 import type { DetectedSighting, GoldenSighting } from './task-types'
 
 /**
@@ -51,24 +49,18 @@ export async function judgeSighting(params: {
     'Respond with ONLY JSON: {"equivalence": <0.0-1.0>, "notes": "<short>"}',
   ].join('\n')
 
-  try {
-    const result = await generateText({
-      model: params.provider.languageModel(params.model),
-      messages: [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
-      abortSignal: params.signal,
-    })
-    const parsed = extractJsonObject<{ equivalence?: number; notes?: string }>(result.text)
-    if (!parsed) {
-      log.warn('[task-judge] could not parse JSON; raw:', result.text.slice(0, 200))
-      return null
-    }
-    return {
-      equivalence: typeof parsed.equivalence === 'number' ? clamp(0, 1, parsed.equivalence) : null,
-      tokensIn: result.usage.inputTokens ?? 0,
-      tokensOut: result.usage.outputTokens ?? 0,
-    }
-  } catch (err) {
-    log.warn('[task-judge] call failed:', err instanceof Error ? err.message : String(err))
-    return null
+  const res = await callJsonJudge<{ equivalence?: number; notes?: string }>({
+    provider: params.provider,
+    model: params.model,
+    content: [{ type: 'text', text: prompt }],
+    tag: 'task-judge',
+    signal: params.signal,
+  })
+  if (!res) return null
+  return {
+    equivalence:
+      typeof res.parsed.equivalence === 'number' ? clamp(0, 1, res.parsed.equivalence) : null,
+    tokensIn: res.tokensIn,
+    tokensOut: res.tokensOut,
   }
 }

--- a/src/main/eval/task-report.ts
+++ b/src/main/eval/task-report.ts
@@ -1,0 +1,73 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { num, pct, usd } from './format'
+import type { TaskEvalReport } from './task-types'
+
+/** Renders a TaskEvalReport into a findings-style Markdown scorecard. */
+export function renderTaskMarkdown(report: TaskEvalReport): string {
+  const lines: string[] = []
+  lines.push(`# Task-Mining Eval — ${report.generatedAt}`)
+  lines.push('')
+  lines.push(`- Vendor: ${report.vendor}`)
+  lines.push(`- Judge: ${report.judgeModel ?? '(none)'}`)
+  lines.push('')
+  lines.push('## Scorecard')
+  lines.push('')
+  lines.push(
+    '| Fixture | Model | Found (keep) | Recall | Reject reproduced | New | Grounding | Equiv | Cost |',
+  )
+  lines.push('|---|---|--:|--:|--:|--:|--:|--:|--:|')
+  for (const f of report.fixtures) {
+    lines.push(
+      `| ${f.fixture} | ${f.model} | ${f.foundCount}/${f.positiveCount} | ${pct(f.recall)} | ` +
+        `${f.rejectedReproducedCount}/${f.negativeCount} | ${f.newCount} | ` +
+        `${pct(f.avgGroundingRecall)} | ${num(f.avgEquivalence)} | ${usd(f.costUsd)} |`,
+    )
+  }
+  lines.push('')
+  lines.push('## Detail')
+  for (const f of report.fixtures) {
+    lines.push('')
+    lines.push(`### ${f.fixture} | ${f.model}`)
+    lines.push(
+      `> ${f.detectedCount} sighting(s) detected; ${f.foundCount}/${f.positiveCount} keep tasks found; ` +
+        `${f.rejectedReproducedCount} reject(s) reproduced; ${f.newCount} new`,
+    )
+    if (f.rejectedReproducedTitles.length)
+      lines.push(`> ⚠ reproduced rejects: ${f.rejectedReproducedTitles.join('; ')}`)
+    if (f.bundledSightingIds.length)
+      lines.push(`> ⚠ ${f.bundledSightingIds.length} sighting(s) bundled multiple keep tasks`)
+    for (const g of f.goldenScores) {
+      const mark = g.found ? '✅' : '❌'
+      lines.push('')
+      lines.push(`- ${mark} **${g.goldenTitle}** → ${g.matchedTitle ?? '(missed)'}`)
+      lines.push(
+        `  - grounding: recall ${pct(g.grounding.recall)}, precision ${pct(g.grounding.precision)}, ` +
+          `IoU ${pct(g.grounding.iou)} (${g.grounding.matchedIds.length} ids)`,
+      )
+      if (g.equivalence != null) {
+        lines.push(`  - judge: equiv ${num(g.equivalence)}`)
+      }
+    }
+    if (f.newSightings.length) {
+      lines.push('')
+      lines.push('New (unlabeled — thumbs these with `--label`):')
+      for (const n of f.newSightings) lines.push(`  - ${n.title} (${n.activityIds.length} ids)`)
+    }
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+/**
+ * Writes a task-mining run as a timestamped `<stamp>.json` + `<stamp>.md` pair
+ * under `resultsDir`. Returns the Markdown path.
+ */
+export function writeTaskReport(resultsDir: string, report: TaskEvalReport): string {
+  fs.mkdirSync(resultsDir, { recursive: true })
+  const stamp = report.generatedAt.replace(/[:.]/g, '-')
+  fs.writeFileSync(path.join(resultsDir, `${stamp}.json`), JSON.stringify(report, null, 2), 'utf8')
+  const mdPath = path.join(resultsDir, `${stamp}.md`)
+  fs.writeFileSync(mdPath, renderTaskMarkdown(report), 'utf8')
+  return mdPath
+}


### PR DESCRIPTION
## What

The two eval runners (`eval-summaries`, `eval-tasks`) had grown ~12 CLI flags each — custom output/db/user-data/vendor dirs, `--judge-model`, `--concurrency`, `--dump-roundtrips`, `--lookback`, etc. This cuts them to the inputs that actually vary run-to-run; everything else uses code defaults.

| Input | `eval-summaries` | `eval-tasks` |
|---|---|---|
| `--fixture <name>` | one fixture (default: **all**) | one fixture (default: **all**) |
| `--model <id>` | override default model | override default model |
| `--pipeline video\|image` | summarizer lane | — |
| `--judge` | enable paid LLM judge (off by default) | enable paid equivalence judge |
| `--label` | — | append found sightings to `golden.md` to thumbs |

### Behavior changes
- **Omitting `--fixture` runs every fixture** in the standard dir (replaces `--fixtures-dir`; "all" is now the default).
- **Judge is off by default** — free deterministic/golden runs while tweaking constants/prompts; `--judge` opts into the paid LLM judge.
- **No custom dirs/dbs/keys** — reports always write to the standard `results/` dir, credentials come from the app's own settings + env API key. Task fixtures still seed their own isolated temp DB (the reproducibility mechanism, not a knob).

## Dedup

Both pipelines duplicated rendering/judge/parsing infra. Extracted into shared helpers:
- `format.ts` — `num`/`pct`/`usd`/`cell` scorecard formatters
- `llm-judge.ts` — `callJsonJudge()` (generateText + JSON extract + token accounting + error logging); `judgeSummary`/`judgeEquivalence`/`judgeSighting` share it
- `markdown-blocks.ts` — `splitMarkdownBlocks()` shared by both `golden.md` parsers
- `task-report.ts` — task scorecard renderer moved out of the `eval-tasks` script onto the shared formatters

## Result

Net **−246 lines** of source. Public function signatures unchanged, so report/golden/score tests are untouched: **41/41 eval tests pass**, lint clean.

> Internal `evals/*` docs (gitignored) were also consolidated into one `evals/README.md` reflecting the new flags — not part of this diff since the dir is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)