### PR TITLE
feat(eval): in-app eval recorder + golden review (Developer mode)

### DIFF
--- a/scripts/promote-debug-fixture.ts
+++ b/scripts/promote-debug-fixture.ts
@@ -15,6 +15,9 @@
  * with the persisted rows and we match them by time overlap. You then hand-edit
  * golden.md from a real summary into the target. No LLM is called here.
  *
+ * This is a thin wrapper over `promoteCapture()` (src/main/eval/promote-fixture.ts),
+ * the same logic the in-app eval recorder uses.
+ *
  * IMPORTANT: hand-review the fixture for private content before committing it.
  * Window titles, URLs, and on-screen text are baked into the events and PNGs.
  *
@@ -29,24 +32,9 @@
  *   npm run promote-debug-fixture -- --name X --debug-dir /path/to/.debug-pipeline
  */
 
-import * as fs from 'fs'
 import * as path from 'path'
-import sharp from 'sharp'
-import { SCREEN_CAPTURER_CONFIG } from '../src/shared/constants'
-import { FfmpegVideoStitcher } from '../src/main/video/video-stitcher'
-import { renderGoldenMd } from '../src/main/eval/golden-md'
-import { replayFixture, ScaffoldTransformer } from '../src/main/eval/replay-harness'
-import { readJsonl } from '../src/main/eval/jsonl'
-import {
-  FIXTURE_SCHEMA_VERSION,
-  type DumpedFrame,
-  type FixtureManifest,
-  type ReplayActivity,
-} from '../src/main/eval/types'
-import { StorageService } from '../src/main/storage'
-import type { ActivityDetail } from '../src/main/storage/types'
+import { promoteCapture } from '../src/main/eval/promote-fixture'
 import { getDefaultDbPath } from '../src/main/paths'
-import type { EventWindow } from '../src/shared/types'
 
 const FIXTURES_ROOT = path.resolve('evals/semantic-summary/fixtures')
 
@@ -138,43 +126,6 @@ function parseArgs(): CliArgs {
   return a
 }
 
-async function copyFrame(
-  srcPath: string,
-  destDir: string,
-  downsample: boolean,
-): Promise<{ relPath: string } | null> {
-  if (!fs.existsSync(srcPath)) return null
-  const base = path.basename(srcPath)
-
-  if (!downsample) {
-    fs.copyFileSync(srcPath, path.join(destDir, base))
-    return { relPath: path.posix.join('frames', base) }
-  }
-
-  const jpgName = base.replace(/\.[^.]+$/, '') + '.jpg'
-  await sharp(srcPath)
-    .resize({
-      width: SCREEN_CAPTURER_CONFIG.MAX_DIMENSION_PX,
-      height: SCREEN_CAPTURER_CONFIG.MAX_DIMENSION_PX,
-      fit: 'inside',
-      withoutEnlargement: true,
-    })
-    .jpeg({ quality: 80 })
-    .toFile(path.join(destDir, jpgName))
-  return { relPath: path.posix.join('frames', jpgName) }
-}
-
-function deriveAppMix(windows: EventWindow[]): string[] {
-  const apps = new Set<string>()
-  for (const w of windows) {
-    for (const e of w.events) {
-      const name = e.activeWindow?.processName
-      if (name) apps.add(name)
-    }
-  }
-  return [...apps].sort()
-}
-
 async function main() {
   const a = parseArgs()
   if (!a.name) {
@@ -184,230 +135,65 @@ async function main() {
     process.exit(1)
   }
 
-  const windowsSrc = path.join(a.debugDir, 'event-windows.jsonl')
-  const framesSrc = path.join(a.debugDir, 'frames.jsonl')
-  for (const f of [windowsSrc, framesSrc]) {
-    if (!fs.existsSync(f)) {
-      console.error(`Not found: ${f}. Run \`npm run dev:debug-pipeline\`, interact, then promote.`)
-      process.exit(1)
-    }
+  let result
+  try {
+    result = await promoteCapture({
+      sourceDir: a.debugDir,
+      fixturesRoot: FIXTURES_ROOT,
+      name: a.name,
+      label: a.label ?? undefined,
+      description: a.description,
+      downsample: a.downsample,
+      video: !a.noVideo,
+      seed: !a.noSeed,
+      reseed: a.reseed,
+      expectedActivities: a.expectedActivities,
+      dbSummaries: !a.noDbSummaries,
+      dbPath: a.dbPath,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`${message}. Run \`npm run dev:debug-pipeline\`, interact, then promote.`)
+    process.exit(1)
   }
 
-  const windows = readJsonl<EventWindow>(windowsSrc)
-  const frames = readJsonl<DumpedFrame>(framesSrc)
-
-  const fixtureDir = path.join(FIXTURES_ROOT, a.name)
-  const framesDir = path.join(fixtureDir, 'frames')
-  fs.mkdirSync(framesDir, { recursive: true })
-
-  // Copy event windows verbatim (replay-critical input).
-  fs.copyFileSync(windowsSrc, path.join(fixtureDir, 'event-windows.jsonl'))
-
-  // Copy referenced PNGs, rewrite paths to relative, drop missing ones.
-  const promotedFrames: DumpedFrame[] = []
-  let missing = 0
-  for (const frame of frames) {
-    const copied = await copyFrame(frame.filepath, framesDir, a.downsample)
-    if (!copied) {
-      missing++
-      continue
-    }
-    promotedFrames.push({ ...frame, filepath: copied.relPath })
-  }
-  fs.writeFileSync(
-    path.join(fixtureDir, 'frames.jsonl'),
-    promotedFrames.map((f) => JSON.stringify(f)).join('\n') + '\n',
-    'utf8',
-  )
-
-  const manifest: FixtureManifest = {
-    name: a.name,
-    label: a.label ?? a.name,
-    description: a.description,
-    capturedAt: new Date().toISOString(),
-    platform: process.platform,
-    appMix: deriveAppMix(windows),
-    frameCount: promotedFrames.length,
-    eventWindowCount: windows.length,
-    expectedActivityCount: a.expectedActivities,
-    downsampled: a.downsample || undefined,
-    schemaVersion: FIXTURE_SCHEMA_VERSION,
-  }
-  fs.writeFileSync(
-    path.join(fixtureDir, 'manifest.json'),
-    JSON.stringify(manifest, null, 2),
-    'utf8',
-  )
-
-  console.log(`Promoted fixture "${a.name}" -> ${fixtureDir}`)
-  console.log(`  Event windows: ${windows.length}`)
+  console.log(`Promoted fixture "${a.name}" -> ${result.fixtureDir}`)
+  console.log(`  Event windows: ${result.eventWindowCount}`)
   console.log(
-    `  Frames:        ${promotedFrames.length} copied${missing ? `, ${missing} dropped (source PNG already gone)` : ''}`,
+    `  Frames:        ${result.frameCount} copied${result.missingFrames ? `, ${result.missingFrames} dropped (source PNG already gone)` : ''}`,
   )
-  console.log(`  App mix:       ${manifest.appMix.join(', ') || '(none)'}`)
-  if (a.downsample)
+  console.log(`  App mix:       ${result.appMix.join(', ') || '(none)'}`)
+  if (result.downsampled)
     console.log('  PNGs downsampled to JPEG (affects OCR/snapshot pixels uniformly).')
 
-  // One no-LLM replay feeds both the review video and the golden transcript, so
-  // they share a clock and the video ends exactly where the transcript does.
-  if (!a.noVideo || !a.noSeed) {
-    const { activities, droppedActivities, sessionStartMs } = await replayFixture({
-      fixtureDir,
-      transformer: new ScaffoldTransformer(),
-    })
-    const transcript = [...activities, ...droppedActivities]
-    const lastBlockEnd =
-      transcript.reduce((max, t) => Math.max(max, t.endTimestamp), 0) || undefined
-
-    // Review video: playback time ≈ elapsed time; trimmed to the last activity so
-    // its length matches golden.md instead of trailing past it.
-    if (!a.noVideo) {
-      await stitchSessionVideo(fixtureDir, promotedFrames, lastBlockEnd)
+  if (result.video) {
+    if (result.video.ok) {
+      console.log(
+        `  Video:         session.mp4 (${((result.video.durationMs ?? 0) / 1000).toFixed(0)}s)`,
+      )
+    } else {
+      console.warn(`  Video:         skipped (ffmpeg failed: ${result.video.error})`)
     }
-    // Editable golden.md transcript. Skipped when one exists (unless --reseed).
-    if (!a.noSeed) {
-      seedGolden(fixtureDir, a, transcript, sessionStartMs)
+  }
+
+  if (result.golden) {
+    if (!result.golden.seeded) {
+      console.log(
+        '  Golden:        golden.md exists — not overwriting (use --reseed to regenerate).',
+      )
+    } else {
+      const summarySrc = a.noDbSummaries
+        ? 'no summaries'
+        : `${result.golden.summariesFilled}/${result.golden.kept} summaries from DB`
+      console.log(
+        `  Golden:        golden.md scaffolded (${result.golden.kept} kept + ${result.golden.dropped} dropped, ${summarySrc}) — review each summary.`,
+      )
     }
   }
 
   console.log('')
   console.log(
     '  ⚠  Hand-review for private content (window titles, URLs, on-screen text) before committing.',
-  )
-}
-
-/**
- * Stitches fixture frames into one session video for golden review. When
- * `endTimestampMs` is given (the last activity's end), trailing frames past it
- * are dropped and a terminal marker is pinned at the end so the video stops there
- * — otherwise the stitcher holds the final real frame for a full inter-frame
- * interval and the video runs ~1s past the transcript.
- */
-async function stitchSessionVideo(
-  fixtureDir: string,
-  frames: DumpedFrame[],
-  endTimestampMs?: number,
-): Promise<void> {
-  if (frames.length === 0) return
-
-  let clip = frames
-  if (endTimestampMs !== undefined) {
-    const kept = frames.filter((f) => f.timestamp <= endTimestampMs)
-    const last = kept[kept.length - 1]
-    // Pin the final hold to the activity end (re-uses the last frame's image).
-    clip =
-      last && last.timestamp < endTimestampMs
-        ? [...kept, { ...last, timestamp: endTimestampMs }]
-        : kept
-  }
-  if (clip.length === 0) return
-
-  const outputPath = path.join(fixtureDir, 'session.mp4')
-  try {
-    const asset = await new FfmpegVideoStitcher().stitch({
-      activityId: 'session',
-      frames: clip.map((f) => ({
-        filepath: path.resolve(fixtureDir, f.filepath),
-        timestamp: f.timestamp,
-      })),
-      outputPath,
-    })
-    console.log(`  Video:         session.mp4 (${(asset.durationMs / 1000).toFixed(0)}s)`)
-  } catch (error) {
-    console.warn(
-      `  Video:         skipped (ffmpeg failed: ${error instanceof Error ? error.message : String(error)})`,
-    )
-  }
-}
-
-/**
- * Pre-fills each kept activity's summary from the dev DB. The debug session that
- * produced this capture ran the real summarizer and persisted its activities, so
- * those summaries already exist. The producer is deterministic, so a fresh replay
- * cuts activities at the same timestamps the live run did; we match scaffold
- * blocks to DB rows by time overlap and copy the persisted summary in — you edit
- * golden.md from a real summary instead of a blank line.
- *
- * Best-effort and mutates `transcript` in place: a missing DB or an unmatched
- * block just leaves a blank (the original scaffold behavior). Returns the count
- * of blocks filled. DROPPED blocks were never persisted, so they're skipped.
- */
-function fillSummariesFromDb(transcript: ReplayActivity[], dbPath: string): number {
-  if (!fs.existsSync(dbPath)) {
-    console.log(`  Golden:        no DB at ${dbPath} — summaries left blank.`)
-    return 0
-  }
-
-  const kept = transcript.filter((t) => !t.dropped)
-  if (kept.length === 0) return 0
-
-  const sessionStart = Math.min(...kept.map((t) => t.startTimestamp))
-  const sessionEnd = Math.max(...kept.map((t) => t.endTimestamp))
-
-  const storage = new StorageService(dbPath)
-  let rows: ActivityDetail[]
-  try {
-    rows = storage.activities.getForDay(sessionStart, sessionEnd)
-  } finally {
-    storage.close()
-  }
-
-  const used = new Set<string>()
-  let filled = 0
-  for (const act of kept) {
-    let best: ActivityDetail | null = null
-    let bestOverlap = 0
-    for (const row of rows) {
-      if (used.has(row.id)) continue
-      const overlap = Math.max(
-        0,
-        Math.min(act.endTimestamp, row.endTimestamp) -
-          Math.max(act.startTimestamp, row.startTimestamp),
-      )
-      if (overlap > bestOverlap) {
-        bestOverlap = overlap
-        best = row
-      }
-    }
-    if (best && best.summary.trim()) {
-      act.summary = best.summary
-      used.add(best.id)
-      filled++
-    }
-  }
-  return filled
-}
-
-/**
- * Writes an editable golden.md scaffold from the producer transcript (emitted
- * activities + DROPPED blocks for everything discarded), on the session.mp4 clock
- * so mm:ss lines up with the review video. Summaries are pre-filled from the dev
- * DB (unless --no-db-summaries); no LLM is called.
- */
-function seedGolden(
-  fixtureDir: string,
-  a: CliArgs,
-  transcript: ReplayActivity[],
-  sessionStartMs: number,
-): void {
-  const goldenPath = path.join(fixtureDir, 'golden.md')
-  if (fs.existsSync(goldenPath) && !a.reseed) {
-    console.log('  Golden:        golden.md exists — not overwriting (use --reseed to regenerate).')
-    return
-  }
-
-  const dropped = transcript.filter((t) => t.dropped).length
-  const kept = transcript.length - dropped
-  const filled = a.noDbSummaries ? 0 : fillSummariesFromDb(transcript, a.dbPath)
-
-  fs.writeFileSync(
-    goldenPath,
-    renderGoldenMd(path.basename(fixtureDir), transcript, sessionStartMs),
-    'utf8',
-  )
-  const summarySrc = a.noDbSummaries ? 'no summaries' : `${filled}/${kept} summaries from DB`
-  console.log(
-    `  Golden:        golden.md scaffolded (${kept} kept + ${dropped} dropped, ${summarySrc}) — review each summary.`,
   )
 }
 

--- a/src/main/eval/eval-fixture-store.test.ts
+++ b/src/main/eval/eval-fixture-store.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { EvalFixtureStore } from './eval-fixture-store'
+import type { FixtureManifest } from './types'
+
+vi.mock('../logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+let root: string
+let store: EvalFixtureStore
+
+function writeFixture(name: string, opts: { video?: boolean; golden?: string } = {}): void {
+  const dir = path.join(root, name)
+  fs.mkdirSync(path.join(dir, 'frames'), { recursive: true })
+  const manifest: FixtureManifest = {
+    name,
+    label: `Label ${name}`,
+    description: '',
+    capturedAt: new Date(T0).toISOString(),
+    platform: 'darwin',
+    appMix: ['Code', 'Chrome'],
+    frameCount: 3,
+    eventWindowCount: 2,
+    schemaVersion: 1,
+  }
+  fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify(manifest), 'utf8')
+  fs.writeFileSync(path.join(dir, 'golden.md'), opts.golden ?? '# Golden — ' + name, 'utf8')
+  fs.writeFileSync(path.join(dir, 'frames', 'frame-0001.png'), 'PNGDATA', 'utf8')
+  if (opts.video) fs.writeFileSync(path.join(dir, 'session.mp4'), 'MP4DATA', 'utf8')
+}
+
+const T0 = 1_700_000_000_000
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-store-test-'))
+  store = new EvalFixtureStore(root)
+})
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('EvalFixtureStore', () => {
+  it('lists fixtures and ignores the staging dir', () => {
+    writeFixture('alpha', { video: true })
+    writeFixture('beta')
+    fs.mkdirSync(path.join(root, '.staging', 'in-progress'), { recursive: true })
+
+    const list = store.list()
+    expect(list.map((f) => f.name).sort()).toEqual(['alpha', 'beta'])
+    const alpha = list.find((f) => f.name === 'alpha')
+    expect(alpha?.hasVideo).toBe(true)
+    expect(alpha?.appMix).toEqual(['Code', 'Chrome'])
+    expect(list.find((f) => f.name === 'beta')?.hasVideo).toBe(false)
+  })
+
+  it('loads golden + a streamable video URL', () => {
+    writeFixture('alpha', { video: true, golden: '# Golden — alpha\n\nhi' })
+    const loaded = store.load('alpha')
+    expect(loaded?.goldenMd).toBe('# Golden — alpha\n\nhi')
+    expect(loaded?.videoUrl).toBe('mlmedia://eval/alpha/session.mp4')
+
+    const noVideo = (writeFixture('beta'), store.load('beta'))
+    expect(noVideo?.videoUrl).toBeNull()
+  })
+
+  it('returns null when loading a missing fixture', () => {
+    expect(store.load('nope')).toBeNull()
+  })
+
+  it('saves an edited golden', () => {
+    writeFixture('alpha')
+    store.saveGolden('alpha', '# Golden — alpha\n\nedited summary')
+    expect(store.load('alpha')?.goldenMd).toBe('# Golden — alpha\n\nedited summary')
+  })
+
+  it('exports a fixture to a non-empty zip', async () => {
+    writeFixture('alpha', { video: true })
+    const dest = path.join(root, 'out', 'alpha.zip')
+    await store.exportZip('alpha', dest)
+    expect(fs.existsSync(dest)).toBe(true)
+    const bytes = fs.readFileSync(dest)
+    expect(bytes.length).toBeGreaterThan(0)
+    // ZIP local file header magic.
+    expect(bytes.subarray(0, 2).toString('latin1')).toBe('PK')
+  })
+
+  it('deletes a fixture', () => {
+    writeFixture('alpha')
+    store.delete('alpha')
+    expect(store.list()).toEqual([])
+    expect(fs.existsSync(path.join(root, 'alpha'))).toBe(false)
+  })
+})

--- a/src/main/eval/eval-fixture-store.ts
+++ b/src/main/eval/eval-fixture-store.ts
@@ -1,0 +1,116 @@
+/**
+ * Reads/writes promoted eval fixtures under `{userData}/eval-fixtures`. Backs the
+ * in-app Developer review UI: list fixtures, load one for review (its `golden.md`
+ * + a `mlmedia://` URL for the review video — streamed off disk so `<video>`
+ * seeking works; a base64 data URL does not play in Electron), save the edited
+ * golden, export a fixture as a zip to hand back, and delete.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import * as yazl from 'yazl'
+import log from '../logger'
+import type { FixtureManifest } from './types'
+import type { EvalFixtureLoad, EvalFixtureSummary } from '../../shared/eval-review'
+import { evalMediaUrl } from './eval-media-protocol'
+
+/** Staging dir for in-progress recordings — never listed as a fixture. */
+const STAGING_DIR = '.staging'
+
+export class EvalFixtureStore {
+  constructor(private readonly root: string) {}
+
+  private dirFor(name: string): string {
+    // Guard against path traversal — names are single path segments.
+    const base = path.basename(name)
+    return path.join(this.root, base)
+  }
+
+  private readManifest(dir: string): FixtureManifest | null {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(dir, 'manifest.json'), 'utf8')) as FixtureManifest
+    } catch {
+      return null
+    }
+  }
+
+  list(): EvalFixtureSummary[] {
+    if (!fs.existsSync(this.root)) return []
+    const out: EvalFixtureSummary[] = []
+    for (const entry of fs.readdirSync(this.root, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name === STAGING_DIR) continue
+      const dir = path.join(this.root, entry.name)
+      const manifest = this.readManifest(dir)
+      if (!manifest) continue
+      out.push({
+        name: entry.name,
+        label: manifest.label,
+        capturedAt: manifest.capturedAt,
+        frameCount: manifest.frameCount,
+        eventWindowCount: manifest.eventWindowCount,
+        appMix: manifest.appMix,
+        hasVideo: fs.existsSync(path.join(dir, 'session.mp4')),
+      })
+    }
+    // Newest first.
+    out.sort((a, b) => b.capturedAt.localeCompare(a.capturedAt))
+    return out
+  }
+
+  load(name: string): EvalFixtureLoad | null {
+    const dir = this.dirFor(name)
+    const manifest = this.readManifest(dir)
+    if (!manifest) return null
+
+    const goldenPath = path.join(dir, 'golden.md')
+    const goldenMd = fs.existsSync(goldenPath) ? fs.readFileSync(goldenPath, 'utf8') : ''
+
+    const hasVideo = fs.existsSync(path.join(dir, 'session.mp4'))
+    const videoUrl = hasVideo ? evalMediaUrl(path.basename(name)) : null
+
+    return { name: path.basename(name), label: manifest.label, goldenMd, videoUrl }
+  }
+
+  saveGolden(name: string, markdown: string): void {
+    const dir = this.dirFor(name)
+    if (!fs.existsSync(dir)) throw new Error(`Fixture not found: ${name}`)
+    fs.writeFileSync(path.join(dir, 'golden.md'), markdown, 'utf8')
+  }
+
+  delete(name: string): void {
+    const dir = this.dirFor(name)
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+
+  /** Zips the fixture dir to `destPath`, entries rooted at `<name>/`. */
+  async exportZip(name: string, destPath: string): Promise<void> {
+    const dir = this.dirFor(name)
+    if (!fs.existsSync(dir)) throw new Error(`Fixture not found: ${name}`)
+
+    const files: { real: string; entry: string }[] = []
+    const walk = (current: string, rel: string): void => {
+      for (const e of fs.readdirSync(current, { withFileTypes: true })) {
+        const real = path.join(current, e.name)
+        const entry = path.posix.join(rel, e.name)
+        if (e.isDirectory()) walk(real, entry)
+        else if (e.isFile()) files.push({ real, entry })
+      }
+    }
+    walk(dir, path.basename(name))
+
+    await fs.promises.mkdir(path.dirname(destPath), { recursive: true })
+    await new Promise<void>((resolve, reject) => {
+      const zip = new yazl.ZipFile()
+      const output = fs.createWriteStream(destPath)
+      const onError = (error: unknown): void =>
+        reject(error instanceof Error ? error : new Error(String(error)))
+      output.once('error', onError)
+      zip.outputStream.once('error', onError)
+      output.once('close', resolve)
+      zip.outputStream.pipe(output)
+      for (const f of files) zip.addFile(f.real, f.entry)
+      zip.end()
+    })
+    log.info(`[EvalFixtureStore] Exported "${name}" (${files.length} files) -> ${destPath}`)
+  }
+}

--- a/src/main/eval/eval-media-protocol.ts
+++ b/src/main/eval/eval-media-protocol.ts
@@ -1,0 +1,67 @@
+/**
+ * Streams eval fixture videos to the renderer. A base64 `data:` URL in a
+ * `<video>` fails in Electron — media playback needs HTTP range requests for
+ * seeking, which `data:` URLs can't serve — so we register a privileged
+ * `mlmedia://` scheme and stream `session.mp4` off disk via `net.fetch`, which
+ * honors Range requests (206 partial content) for free.
+ *
+ * URL shape: `mlmedia://eval/<fixtureName>/session.mp4`. The fixture name is the
+ * only variable; we `basename()` it and confine the served path to the fixtures
+ * root, so the scheme can never read outside `{userData}/eval-fixtures`.
+ */
+
+import { protocol, net } from 'electron'
+import * as fs from 'fs'
+import * as path from 'path'
+import { pathToFileURL } from 'url'
+
+export const EVAL_MEDIA_SCHEME = 'mlmedia'
+
+/** URL for a fixture's review video. Pure string — safe to call anywhere. */
+export function evalMediaUrl(name: string): string {
+  return `${EVAL_MEDIA_SCHEME}://eval/${encodeURIComponent(name)}/session.mp4`
+}
+
+/** Must be called BEFORE the app `ready` event (top-level in the entry point). */
+export function registerEvalMediaScheme(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: EVAL_MEDIA_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        stream: true,
+        bypassCSP: true,
+      },
+    },
+  ])
+}
+
+/** Must be called AFTER `ready`, once the fixtures root is known. */
+export function registerEvalMediaProtocol(fixturesRoot: string): void {
+  const root = path.resolve(fixturesRoot)
+
+  protocol.handle(EVAL_MEDIA_SCHEME, (request) => {
+    try {
+      const { pathname } = new URL(request.url)
+      const parts = pathname.split('/').filter(Boolean).map(decodeURIComponent)
+      // Expect: /<name>/session.mp4
+      if (parts.length !== 2 || parts[1] !== 'session.mp4') {
+        return new Response('Not found', { status: 404 })
+      }
+      const name = path.basename(parts[0]) // strip any traversal
+      const filePath = path.resolve(root, name, 'session.mp4')
+      if (!filePath.startsWith(root + path.sep) || !fs.existsSync(filePath)) {
+        return new Response('Not found', { status: 404 })
+      }
+      // Forward the Range header so seeking yields 206 partial content.
+      const range = request.headers.get('range')
+      return net.fetch(pathToFileURL(filePath).toString(), {
+        headers: range ? { range } : undefined,
+      })
+    } catch {
+      return new Response('Bad request', { status: 400 })
+    }
+  })
+}

--- a/src/main/eval/eval-recorder.test.ts
+++ b/src/main/eval/eval-recorder.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import sharp from 'sharp'
+import { EvalRecorder, sanitizeFixtureName } from './eval-recorder'
+import { InMemoryStream } from '../streams/in-memory-stream'
+import type { Frame } from '../recorder/screen-capturer'
+import type { EventWindow } from '../../shared/types'
+import type { PipelineHarness } from '../pipeline-harness'
+import type { RuntimeCaptureController } from '../capture-controller'
+import type { StorageService } from '../storage'
+
+vi.mock('../logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+// Avoid ffmpeg: promoteCapture stitches a session.mp4 with video:true.
+vi.mock('../video/video-stitcher', () => ({
+  FfmpegVideoStitcher: class {
+    async stitch(): Promise<{ videoPath: string; frameCount: number; durationMs: number }> {
+      return { videoPath: 'mock.mp4', frameCount: 1, durationMs: 1000 }
+    }
+  },
+}))
+
+const storageStub = {
+  activities: { getForDay: () => [] },
+} as unknown as StorageService
+
+const T0 = 1_700_000_000_000
+
+let tmp: string
+let fixturesRoot: string
+let frameStream: InMemoryStream<Frame>
+let eventStream: InMemoryStream<EventWindow>
+let harness: PipelineHarness
+let capture: RuntimeCaptureController
+let setRetain: ReturnType<typeof vi.fn>
+let sweepNow: ReturnType<typeof vi.fn>
+let startCapture: ReturnType<typeof vi.fn>
+let stopCapture: ReturnType<typeof vi.fn>
+let capturing: boolean
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'recorder-test-'))
+  fixturesRoot = path.join(tmp, 'eval-fixtures')
+  frameStream = new InMemoryStream<Frame>()
+  eventStream = new InMemoryStream<EventWindow>()
+  setRetain = vi.fn()
+  sweepNow = vi.fn()
+  startCapture = vi.fn(() => {
+    capturing = true
+  })
+  stopCapture = vi.fn(() => {
+    capturing = false
+  })
+  capturing = false
+
+  harness = {
+    frameStream,
+    eventStream,
+    eventCapturer: { flush: vi.fn() },
+    setRetainScreenshots: setRetain,
+    sweepNow,
+  } as unknown as PipelineHarness
+
+  capture = {
+    isCapturingNow: () => capturing,
+    startCapture,
+    stopCapture,
+    waitForIdle: vi.fn().mockResolvedValue(undefined),
+  } as unknown as RuntimeCaptureController
+})
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+async function appendFrameAndWindow(): Promise<void> {
+  const pngPath = path.join(tmp, 'live-frame.png')
+  await sharp({ create: { width: 64, height: 64, channels: 3, background: { r: 0, g: 0, b: 0 } } })
+    .png()
+    .toFile(pngPath)
+  await frameStream.append({
+    filepath: pngPath,
+    timestamp: T0,
+    width: 64,
+    height: 64,
+    displayId: 1,
+    sequenceNumber: 1,
+  })
+  await eventStream.append({
+    id: 'w1',
+    startTimestamp: T0,
+    endTimestamp: T0 + 1000,
+    events: [
+      {
+        type: 'app_change',
+        timestamp: T0,
+        activeWindow: { title: 'auth.ts', processName: 'Code' },
+      },
+    ],
+    closedBy: 'gap',
+  } as EventWindow)
+}
+
+describe('sanitizeFixtureName', () => {
+  it('makes a filesystem-safe name', () => {
+    expect(sanitizeFixtureName('My Session: 2026/06/15')).toBe('My-Session-2026-06-15')
+    expect(sanitizeFixtureName('   ')).toBe('recording')
+  })
+})
+
+describe('EvalRecorder', () => {
+  it('holds retention, starts capture if off, and promotes on stop', async () => {
+    const recorder = new EvalRecorder({ harness, capture, storage: storageStub, fixturesRoot })
+
+    const status = recorder.start('rec1')
+    expect(status.recording).toBe(true)
+    expect(setRetain).toHaveBeenCalledWith(true)
+    expect(startCapture).toHaveBeenCalled() // capture was off
+    expect(recorder.isRecording()).toBe(true)
+
+    await appendFrameAndWindow()
+
+    const result = await recorder.stop()
+    expect(result.frameCount).toBe(1)
+    expect(result.eventWindowCount).toBe(1)
+
+    // Retention released + reclaimed, capture restored to prior (off) state.
+    expect(setRetain).toHaveBeenLastCalledWith(false)
+    expect(sweepNow).toHaveBeenCalled()
+    expect(stopCapture).toHaveBeenCalled()
+
+    // Fixture written, staging cleaned up.
+    expect(fs.existsSync(path.join(fixturesRoot, 'rec1', 'frames', 'live-frame.png'))).toBe(true)
+    expect(fs.existsSync(path.join(fixturesRoot, '.staging', 'rec1'))).toBe(false)
+    expect(recorder.isRecording()).toBe(false)
+  })
+
+  it('leaves capture running when it was already on', async () => {
+    capturing = true
+    const recorder = new EvalRecorder({ harness, capture, storage: storageStub, fixturesRoot })
+    recorder.start('rec2')
+    expect(startCapture).not.toHaveBeenCalled()
+
+    await appendFrameAndWindow()
+    await recorder.stop()
+    expect(stopCapture).not.toHaveBeenCalled()
+  })
+
+  it('rejects a second concurrent recording', () => {
+    const recorder = new EvalRecorder({ harness, capture, storage: storageStub, fixturesRoot })
+    recorder.start('rec3')
+    expect(() => recorder.start('rec4')).toThrow(/already in progress/)
+  })
+})

--- a/src/main/eval/eval-recorder.ts
+++ b/src/main/eval/eval-recorder.ts
@@ -1,0 +1,162 @@
+/**
+ * In-app eval recorder. Lets a non-technical operator record a real session from
+ * the normal app and turn it into a committed replay fixture — no `DEBUG_PIPELINE`
+ * env var, no CLI, no restart.
+ *
+ * It reuses the exact debug-pipeline machinery the CLI fixtures already trust:
+ *   - the `FrameDebugDumper` / `EventWindowDebugDumper` tap the producer's input
+ *     streams to a per-session staging dir, and
+ *   - the harness's runtime `setRetainScreenshots(true)` holds the frame PNGs on
+ *     disk for the duration so the cleanup sweep can't delete them mid-session.
+ *
+ * On stop it drains capture (so the final activity is summarized + persisted),
+ * runs `promoteCapture()` over the staging dir, then releases retention and
+ * sweeps to reclaim the screenshots dir. Inert until `start()` is called.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import log from '../logger'
+import type { StorageService } from '../storage'
+import type { StreamSubscription } from '../streams/stream'
+import type { PipelineHarness } from '../pipeline-harness'
+import type { RuntimeCaptureController } from '../capture-controller'
+import { FrameDebugDumper } from '../frame-debug-dump'
+import { EventWindowDebugDumper } from '../event-window-debug-dump'
+import { promoteCapture, type PromoteCaptureResult } from './promote-fixture'
+
+export interface EvalRecordingStatus {
+  recording: boolean
+  name: string | null
+  startedAt: number | null
+}
+
+/** Filesystem-safe fixture name (the dir under the fixtures root). */
+export function sanitizeFixtureName(name: string): string {
+  const cleaned = name
+    .trim()
+    .replace(/[^a-zA-Z0-9-_]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return cleaned || 'recording'
+}
+
+export class EvalRecorder {
+  private readonly harness: PipelineHarness
+  private readonly capture: RuntimeCaptureController
+  private readonly storage: StorageService
+  private readonly fixturesRoot: string
+
+  private activeName: string | null = null
+  private startedAt: number | null = null
+  private stagingDir: string | null = null
+  private frameSub: StreamSubscription | null = null
+  private eventSub: StreamSubscription | null = null
+  private startedCapture = false
+
+  constructor(deps: {
+    harness: PipelineHarness
+    capture: RuntimeCaptureController
+    storage: StorageService
+    fixturesRoot: string
+  }) {
+    this.harness = deps.harness
+    this.capture = deps.capture
+    this.storage = deps.storage
+    this.fixturesRoot = deps.fixturesRoot
+  }
+
+  isRecording(): boolean {
+    return this.activeName !== null
+  }
+
+  getStatus(): EvalRecordingStatus {
+    return { recording: this.isRecording(), name: this.activeName, startedAt: this.startedAt }
+  }
+
+  /** Begins capturing the producer's frame + event-window streams to a staging dir. */
+  start(name: string): EvalRecordingStatus {
+    if (this.isRecording()) throw new Error('A recording is already in progress')
+
+    const safeName = sanitizeFixtureName(name)
+    const stagingDir = path.join(this.fixturesRoot, '.staging', safeName)
+    fs.rmSync(stagingDir, { recursive: true, force: true })
+    fs.mkdirSync(stagingDir, { recursive: true })
+
+    // Hold frame PNGs on disk for the whole recording so the cleanup sweep can't
+    // delete them before we promote (the dumped frames.jsonl references them).
+    this.harness.setRetainScreenshots(true)
+
+    const frameDumper = new FrameDebugDumper(stagingDir)
+    const eventDumper = new EventWindowDebugDumper(stagingDir)
+    this.frameSub = this.harness.frameStream.subscribe({
+      startAt: { type: 'now' },
+      onRecord: (record) => frameDumper.dump(record.payload),
+    })
+    this.eventSub = this.harness.eventStream.subscribe({
+      startAt: { type: 'now' },
+      onRecord: (record) => eventDumper.dump(record.payload),
+    })
+
+    // Frames only flow while capture is running; start it for the operator if it
+    // is off, and remember so we can restore the prior state on stop.
+    this.startedCapture = !this.capture.isCapturingNow()
+    if (this.startedCapture) this.capture.startCapture()
+
+    this.activeName = safeName
+    this.startedAt = Date.now()
+    this.stagingDir = stagingDir
+    log.info(`[EvalRecorder] Recording "${safeName}" -> ${stagingDir}`)
+    return this.getStatus()
+  }
+
+  /** Stops the recording and promotes the staged capture into a fixture. */
+  async stop(): Promise<PromoteCaptureResult> {
+    const name = this.activeName
+    const stagingDir = this.stagingDir
+    if (!name || !stagingDir) throw new Error('No recording in progress')
+
+    // Flush + drain so the session's final activity closes, gets summarized, and
+    // is persisted before we promote — otherwise its golden summary seeds blank.
+    // The dumpers stay subscribed through this so any final window/frame is dumped.
+    try {
+      this.harness.eventCapturer.flush()
+    } catch (error) {
+      log.warn('[EvalRecorder] eventCapturer.flush failed:', error)
+    }
+    await this.capture.waitForIdle()
+    if (this.startedCapture) {
+      // We turned capture on for this recording; turning it off fully drains the
+      // producer/extractor (final activity summarized + persisted) and restores
+      // the operator's prior "capture off" state.
+      this.capture.stopCapture()
+      await this.capture.waitForIdle()
+    }
+
+    this.frameSub?.unsubscribe()
+    this.eventSub?.unsubscribe()
+    this.frameSub = null
+    this.eventSub = null
+
+    try {
+      const result = await promoteCapture({
+        sourceDir: stagingDir,
+        fixturesRoot: this.fixturesRoot,
+        name,
+        storage: this.storage,
+        video: true,
+        seed: true,
+      })
+      log.info(`[EvalRecorder] Promoted "${name}" -> ${result.fixtureDir}`)
+      return result
+    } finally {
+      // Release retention and reclaim the screenshots that piled up; drop staging.
+      this.harness.setRetainScreenshots(false)
+      this.harness.sweepNow()
+      fs.rmSync(stagingDir, { recursive: true, force: true })
+      this.activeName = null
+      this.startedAt = null
+      this.stagingDir = null
+      this.startedCapture = false
+    }
+  }
+}

--- a/src/main/eval/promote-fixture.test.ts
+++ b/src/main/eval/promote-fixture.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import sharp from 'sharp'
+import { promoteCapture } from './promote-fixture'
+import { parseGoldenMd } from './golden-md'
+import type { StorageService } from '../storage'
+
+vi.mock('../logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+const storageStub = {
+  activities: { getForDay: () => [] },
+} as unknown as StorageService
+
+let tmp: string
+let sourceDir: string
+let fixturesRoot: string
+
+const T0 = 1_700_000_000_000
+
+async function makePng(filepath: string, shade: number): Promise<void> {
+  await sharp({
+    create: { width: 64, height: 64, channels: 3, background: { r: shade, g: shade, b: shade } },
+  })
+    .png()
+    .toFile(filepath)
+}
+
+beforeEach(async () => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'promote-test-'))
+  sourceDir = path.join(tmp, 'staging')
+  fixturesRoot = path.join(tmp, 'fixtures')
+  const srcFrames = path.join(sourceDir, 'src-frames')
+  fs.mkdirSync(srcFrames, { recursive: true })
+
+  const f1 = path.join(srcFrames, 'frame-0001.png')
+  const f2 = path.join(srcFrames, 'frame-0002.png')
+  await makePng(f1, 0)
+  await makePng(f2, 255)
+
+  const frames = [
+    { filepath: f1, timestamp: T0, width: 64, height: 64, displayId: 1, sequenceNumber: 1 },
+    { filepath: f2, timestamp: T0 + 1000, width: 64, height: 64, displayId: 1, sequenceNumber: 2 },
+  ]
+  fs.writeFileSync(
+    path.join(sourceDir, 'frames.jsonl'),
+    frames.map((f) => JSON.stringify(f)).join('\n') + '\n',
+  )
+
+  const window = {
+    id: 'w1',
+    startTimestamp: T0,
+    endTimestamp: T0 + 1000,
+    events: [
+      {
+        type: 'app_change',
+        timestamp: T0,
+        activeWindow: { title: 'auth.ts', processName: 'Code' },
+      },
+      {
+        type: 'keyboard',
+        timestamp: T0 + 500,
+        activeWindow: { title: 'auth.ts', processName: 'Code' },
+      },
+    ],
+    closedBy: 'gap',
+  }
+  fs.writeFileSync(path.join(sourceDir, 'event-windows.jsonl'), JSON.stringify(window) + '\n')
+})
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('promoteCapture', () => {
+  it('copies frames + event windows and writes a manifest (no seed/video)', async () => {
+    const result = await promoteCapture({
+      sourceDir,
+      fixturesRoot,
+      name: 'demo',
+      seed: false,
+      video: false,
+    })
+
+    expect(result.frameCount).toBe(2)
+    expect(result.missingFrames).toBe(0)
+    expect(result.eventWindowCount).toBe(1)
+    expect(result.appMix).toEqual(['Code'])
+
+    const fxDir = path.join(fixturesRoot, 'demo')
+    expect(fs.existsSync(path.join(fxDir, 'event-windows.jsonl'))).toBe(true)
+    expect(fs.existsSync(path.join(fxDir, 'frames', 'frame-0001.png'))).toBe(true)
+    expect(fs.existsSync(path.join(fxDir, 'golden.md'))).toBe(false)
+    expect(fs.existsSync(path.join(fxDir, 'session.mp4'))).toBe(false)
+
+    // frame paths rewritten to relative.
+    const promoted = fs
+      .readFileSync(path.join(fxDir, 'frames.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l) as { filepath: string })
+    expect(promoted.every((f) => f.filepath.startsWith('frames/'))).toBe(true)
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(fxDir, 'manifest.json'), 'utf8'))
+    expect(manifest.name).toBe('demo')
+    expect(manifest.frameCount).toBe(2)
+    expect(manifest.eventWindowCount).toBe(1)
+
+    // event-windows copied verbatim.
+    const copied = fs.readFileSync(path.join(fxDir, 'event-windows.jsonl'), 'utf8')
+    const original = fs.readFileSync(path.join(sourceDir, 'event-windows.jsonl'), 'utf8')
+    expect(copied).toBe(original)
+  })
+
+  it('seeds an editable golden.md that round-trips through parseGoldenMd', async () => {
+    const result = await promoteCapture({
+      sourceDir,
+      fixturesRoot,
+      name: 'demo2',
+      seed: true,
+      video: false,
+      storage: storageStub,
+    })
+
+    expect(result.golden?.seeded).toBe(true)
+    const golden = fs.readFileSync(path.join(fixturesRoot, 'demo2', 'golden.md'), 'utf8')
+    expect(golden.startsWith('# Golden — demo2')).toBe(true)
+    expect(() => parseGoldenMd(golden)).not.toThrow()
+  })
+
+  it('does not overwrite an existing golden.md unless reseed', async () => {
+    const fxDir = path.join(fixturesRoot, 'demo3')
+    fs.mkdirSync(fxDir, { recursive: true })
+    fs.writeFileSync(path.join(fxDir, 'golden.md'), 'CUSTOM EDIT', 'utf8')
+
+    const result = await promoteCapture({
+      sourceDir,
+      fixturesRoot,
+      name: 'demo3',
+      seed: true,
+      video: false,
+      storage: storageStub,
+    })
+
+    expect(result.golden?.seeded).toBe(false)
+    expect(fs.readFileSync(path.join(fxDir, 'golden.md'), 'utf8')).toBe('CUSTOM EDIT')
+  })
+})

--- a/src/main/eval/promote-fixture.ts
+++ b/src/main/eval/promote-fixture.ts
@@ -1,0 +1,311 @@
+/**
+ * Promotes a captured session (the debug-pipeline JSONL streams + their PNGs)
+ * into a committed replay fixture. Shared by the `promote-debug-fixture` CLI and
+ * the in-app eval recorder — both hand it a directory containing
+ * `event-windows.jsonl` + `frames.jsonl` (the CLI's `.debug-pipeline`, or the
+ * recorder's per-session staging dir) and get back a self-contained fixture.
+ *
+ * The fixture is: event windows copied verbatim (the replay-critical input),
+ * referenced PNGs copied in with paths rewritten to relative, a `manifest.json`,
+ * an optional `session.mp4` for review, and an optional editable `golden.md`
+ * scaffold seeded from a deterministic no-LLM replay (summaries pre-filled from
+ * the live DB when available). No LLM is called here.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import sharp from 'sharp'
+import { SCREEN_CAPTURER_CONFIG } from '../../shared/constants'
+import { FfmpegVideoStitcher } from '../video/video-stitcher'
+import { StorageService } from '../storage'
+import type { ActivityDetail } from '../storage/types'
+import type { EventWindow } from '../../shared/types'
+import { renderGoldenMd } from './golden-md'
+import { replayFixture, ScaffoldTransformer } from './replay-harness'
+import { readJsonl } from './jsonl'
+import {
+  FIXTURE_SCHEMA_VERSION,
+  type DumpedFrame,
+  type FixtureManifest,
+  type ReplayActivity,
+} from './types'
+
+export interface PromoteCaptureOptions {
+  /** Dir holding `event-windows.jsonl` + `frames.jsonl` (`.debug-pipeline` or staging). */
+  sourceDir: string
+  /** Where `<name>/` is created (e.g. `{userData}/eval-fixtures` or `evals/.../fixtures`). */
+  fixturesRoot: string
+  name: string
+  label?: string
+  description?: string
+  /** Re-encode PNGs to smaller JPEGs (affects OCR/snapshot pixels uniformly). */
+  downsample?: boolean
+  /** Stitch a `session.mp4` for review. Default true. */
+  video?: boolean
+  /** Seed an editable `golden.md`. Default true; never overwrites unless `reseed`. */
+  seed?: boolean
+  reseed?: boolean
+  expectedActivities?: number
+  /** Pre-fill golden summaries from the DB. Default true (when a DB is reachable). */
+  dbSummaries?: boolean
+  /** Live storage to read summaries from (in-app). Not closed by this function. */
+  storage?: StorageService
+  /** DB path to open for summaries (CLI). Ignored when `storage` is given. */
+  dbPath?: string
+}
+
+export interface PromoteCaptureResult {
+  fixtureDir: string
+  frameCount: number
+  missingFrames: number
+  eventWindowCount: number
+  appMix: string[]
+  downsampled: boolean
+  video: { ok: boolean; durationMs?: number; error?: string } | null
+  golden: { seeded: boolean; kept: number; dropped: number; summariesFilled: number } | null
+}
+
+async function copyFrame(
+  srcPath: string,
+  destDir: string,
+  downsample: boolean,
+): Promise<{ relPath: string } | null> {
+  if (!fs.existsSync(srcPath)) return null
+  const base = path.basename(srcPath)
+
+  if (!downsample) {
+    fs.copyFileSync(srcPath, path.join(destDir, base))
+    return { relPath: path.posix.join('frames', base) }
+  }
+
+  const jpgName = base.replace(/\.[^.]+$/, '') + '.jpg'
+  await sharp(srcPath)
+    .resize({
+      width: SCREEN_CAPTURER_CONFIG.MAX_DIMENSION_PX,
+      height: SCREEN_CAPTURER_CONFIG.MAX_DIMENSION_PX,
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: 80 })
+    .toFile(path.join(destDir, jpgName))
+  return { relPath: path.posix.join('frames', jpgName) }
+}
+
+function deriveAppMix(windows: EventWindow[]): string[] {
+  const apps = new Set<string>()
+  for (const w of windows) {
+    for (const e of w.events) {
+      const name = e.activeWindow?.processName
+      if (name) apps.add(name)
+    }
+  }
+  return [...apps].sort()
+}
+
+/**
+ * Stitches fixture frames into one session video for golden review. When
+ * `endTimestampMs` is given (the last activity's end), trailing frames past it
+ * are dropped and a terminal marker is pinned at the end so the video stops there
+ * — otherwise the stitcher holds the final real frame for a full inter-frame
+ * interval and the video runs ~1s past the transcript.
+ */
+async function stitchSessionVideo(
+  fixtureDir: string,
+  frames: DumpedFrame[],
+  endTimestampMs?: number,
+): Promise<{ ok: boolean; durationMs?: number; error?: string }> {
+  if (frames.length === 0) return { ok: false, error: 'no frames' }
+
+  let clip = frames
+  if (endTimestampMs !== undefined) {
+    const kept = frames.filter((f) => f.timestamp <= endTimestampMs)
+    const last = kept[kept.length - 1]
+    // Pin the final hold to the activity end (re-uses the last frame's image).
+    clip =
+      last && last.timestamp < endTimestampMs
+        ? [...kept, { ...last, timestamp: endTimestampMs }]
+        : kept
+  }
+  if (clip.length === 0) return { ok: false, error: 'no frames in range' }
+
+  const outputPath = path.join(fixtureDir, 'session.mp4')
+  try {
+    const asset = await new FfmpegVideoStitcher().stitch({
+      activityId: 'session',
+      frames: clip.map((f) => ({
+        filepath: path.resolve(fixtureDir, f.filepath),
+        timestamp: f.timestamp,
+      })),
+      outputPath,
+    })
+    return { ok: true, durationMs: asset.durationMs }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+/**
+ * Pre-fills each kept activity's summary from the DB. The session that produced
+ * this capture ran the real summarizer and persisted its activities, so those
+ * summaries already exist. The producer is deterministic, so a fresh replay cuts
+ * activities at the same timestamps the live run did; we match scaffold blocks to
+ * DB rows by time overlap and copy the persisted summary in. Mutates `transcript`
+ * in place; an unmatched block just leaves a blank. DROPPED blocks were never
+ * persisted, so they're skipped. Returns the count of blocks filled.
+ */
+function fillSummariesFromDb(transcript: ReplayActivity[], storage: StorageService): number {
+  const kept = transcript.filter((t) => !t.dropped)
+  if (kept.length === 0) return 0
+
+  const sessionStart = Math.min(...kept.map((t) => t.startTimestamp))
+  const sessionEnd = Math.max(...kept.map((t) => t.endTimestamp))
+  const rows: ActivityDetail[] = storage.activities.getForDay(sessionStart, sessionEnd)
+
+  const used = new Set<string>()
+  let filled = 0
+  for (const act of kept) {
+    let best: ActivityDetail | null = null
+    let bestOverlap = 0
+    for (const row of rows) {
+      if (used.has(row.id)) continue
+      const overlap = Math.max(
+        0,
+        Math.min(act.endTimestamp, row.endTimestamp) -
+          Math.max(act.startTimestamp, row.startTimestamp),
+      )
+      if (overlap > bestOverlap) {
+        bestOverlap = overlap
+        best = row
+      }
+    }
+    if (best && best.summary.trim()) {
+      act.summary = best.summary
+      used.add(best.id)
+      filled++
+    }
+  }
+  return filled
+}
+
+/** Resolves a storage handle for summary pre-fill: the injected one (not owned),
+ *  or one opened from `dbPath` (owned → caller closes via the returned `close`). */
+function resolveStorage(opts: PromoteCaptureOptions): {
+  storage: StorageService | null
+  close: () => void
+} {
+  if (opts.dbSummaries === false) return { storage: null, close: () => undefined }
+  if (opts.storage) return { storage: opts.storage, close: () => undefined }
+  if (opts.dbPath && fs.existsSync(opts.dbPath)) {
+    const storage = new StorageService(opts.dbPath)
+    return { storage, close: () => storage.close() }
+  }
+  return { storage: null, close: () => undefined }
+}
+
+export async function promoteCapture(opts: PromoteCaptureOptions): Promise<PromoteCaptureResult> {
+  const windowsSrc = path.join(opts.sourceDir, 'event-windows.jsonl')
+  const framesSrc = path.join(opts.sourceDir, 'frames.jsonl')
+  for (const f of [windowsSrc, framesSrc]) {
+    if (!fs.existsSync(f)) throw new Error(`Not found: ${f}`)
+  }
+
+  const windows = readJsonl<EventWindow>(windowsSrc)
+  const frames = readJsonl<DumpedFrame>(framesSrc)
+
+  const fixtureDir = path.join(opts.fixturesRoot, opts.name)
+  const framesDir = path.join(fixtureDir, 'frames')
+  fs.mkdirSync(framesDir, { recursive: true })
+
+  // Copy event windows verbatim (replay-critical input).
+  fs.copyFileSync(windowsSrc, path.join(fixtureDir, 'event-windows.jsonl'))
+
+  // Copy referenced PNGs, rewrite paths to relative, drop missing ones.
+  const downsample = opts.downsample ?? false
+  const promotedFrames: DumpedFrame[] = []
+  let missing = 0
+  for (const frame of frames) {
+    const copied = await copyFrame(frame.filepath, framesDir, downsample)
+    if (!copied) {
+      missing++
+      continue
+    }
+    promotedFrames.push({ ...frame, filepath: copied.relPath })
+  }
+  fs.writeFileSync(
+    path.join(fixtureDir, 'frames.jsonl'),
+    promotedFrames.map((f) => JSON.stringify(f)).join('\n') + '\n',
+    'utf8',
+  )
+
+  const manifest: FixtureManifest = {
+    name: opts.name,
+    label: opts.label ?? opts.name,
+    description: opts.description ?? '',
+    capturedAt: new Date().toISOString(),
+    platform: process.platform,
+    appMix: deriveAppMix(windows),
+    frameCount: promotedFrames.length,
+    eventWindowCount: windows.length,
+    expectedActivityCount: opts.expectedActivities,
+    downsampled: downsample || undefined,
+    schemaVersion: FIXTURE_SCHEMA_VERSION,
+  }
+  fs.writeFileSync(
+    path.join(fixtureDir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2),
+    'utf8',
+  )
+
+  const result: PromoteCaptureResult = {
+    fixtureDir,
+    frameCount: promotedFrames.length,
+    missingFrames: missing,
+    eventWindowCount: windows.length,
+    appMix: manifest.appMix,
+    downsampled: downsample,
+    video: null,
+    golden: null,
+  }
+
+  const wantVideo = opts.video ?? true
+  const wantSeed = opts.seed ?? true
+  if (!wantVideo && !wantSeed) return result
+
+  // One no-LLM replay feeds both the review video and the golden transcript, so
+  // they share a clock and the video ends exactly where the transcript does.
+  const { activities, droppedActivities, sessionStartMs } = await replayFixture({
+    fixtureDir,
+    transformer: new ScaffoldTransformer(),
+  })
+  const transcript = [...activities, ...droppedActivities]
+  const lastBlockEnd = transcript.reduce((max, t) => Math.max(max, t.endTimestamp), 0) || undefined
+
+  if (wantVideo) {
+    result.video = await stitchSessionVideo(fixtureDir, promotedFrames, lastBlockEnd)
+  }
+
+  if (wantSeed) {
+    const goldenPath = path.join(fixtureDir, 'golden.md')
+    if (fs.existsSync(goldenPath) && !opts.reseed) {
+      result.golden = { seeded: false, kept: 0, dropped: 0, summariesFilled: 0 }
+    } else {
+      const dropped = transcript.filter((t) => t.dropped).length
+      const kept = transcript.length - dropped
+      const { storage, close } = resolveStorage(opts)
+      let filled = 0
+      try {
+        if (storage) filled = fillSummariesFromDb(transcript, storage)
+      } finally {
+        close()
+      }
+      fs.writeFileSync(
+        goldenPath,
+        renderGoldenMd(path.basename(fixtureDir), transcript, sessionStartMs),
+        'utf8',
+      )
+      result.golden = { seeded: true, kept, dropped, summariesFilled: filled }
+    }
+  }
+
+  return result
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import { UserContextBuilder } from './services/user-context-builder'
 import { RawDatabaseExportSync } from './services/raw-database-export-sync'
 import { DatabaseUploadSync } from './services/database-upload-sync'
 import { createMainRuntime, type MainRuntime } from './runtime'
+import { registerEvalMediaScheme, registerEvalMediaProtocol } from './eval/eval-media-protocol'
 import { createObservationController, type ObservationController } from './observation-controller'
 import { getAppDirectoryName } from './paths'
 import { loadAppEditionConfig } from './edition'
@@ -44,6 +45,10 @@ import { ENTERPRISE_BACKEND_CONFIG } from '../shared/constants'
 if (app.isPackaged && !app.requestSingleInstanceLock()) {
   app.quit()
 }
+
+// Privileged scheme for streaming eval review videos — must be registered
+// before the app `ready` event (the handler is wired after the runtime exists).
+registerEvalMediaScheme()
 
 try {
   if (!app.isPackaged) {
@@ -178,6 +183,9 @@ app.on('ready', async () => {
     initialSnapshotModel: initialCaptureSettings.semanticSnapshotModel,
   })
 
+  // Serve eval review videos from the fixtures dir (Developer mode).
+  registerEvalMediaProtocol(runtime.evalFixturesRoot)
+
   rawDatabaseExportSync = new RawDatabaseExportSync({
     storage: runtime.storage,
     getExportDirectory: () => captureSettingsManager.get().databaseExportDirectory,
@@ -291,6 +299,8 @@ app.on('ready', async () => {
     databaseUploadSync: databaseUploadSync ?? undefined,
     purgeAll: () => runtime?.purgeAll() ?? Promise.reject(new Error('Runtime not initialized')),
     observation,
+    evalRecorder: runtime.evalRecorder,
+    evalFixtureStore: runtime.evalFixtureStore,
   })
 
   runtime.accessProvider.startPeriodicRefresh()

--- a/src/main/pipeline-harness.ts
+++ b/src/main/pipeline-harness.ts
@@ -30,6 +30,15 @@ export interface PipelineHarness {
     minActivityDurationMs: number
     maxActivityDurationMs: number
   }): void
+  /**
+   * Toggle screenshot/video retention at runtime. While true, processed
+   * activities' frames/videos are NOT deleted and the periodic stale sweep is
+   * skipped, so frames survive (e.g. for the in-app eval recorder). The
+   * screenshots dir grows until set back to false (then call `sweepNow`).
+   */
+  setRetainScreenshots(value: boolean): void
+  /** Run the stale-file sweep immediately (e.g. to reclaim after retention off). */
+  sweepNow(): void
 }
 
 export function createPipelineHarness(params: {
@@ -44,7 +53,9 @@ export function createPipelineHarness(params: {
   // inspection. Lets the screenshots dir grow unbounded — dev use only.
   retainScreenshots?: boolean
 }): PipelineHarness {
-  const retainScreenshots = params.retainScreenshots ?? false
+  // Mutable so the eval recorder can hold retention open for a recording and
+  // release it afterwards, without a restart. Read live at the cleanup callsites.
+  let retainScreenshots = params.retainScreenshots ?? false
   const frameStream = new InMemoryStream<Frame>()
   const eventStream = new InMemoryStream<EventWindow>()
   const activityStream = new InMemoryStream<Activity>()
@@ -115,11 +126,12 @@ export function createPipelineHarness(params: {
             '[PipelineHarness] retainScreenshots enabled — activity frames/videos are kept and the ' +
               'stale-file sweep is disabled. The screenshots dir will grow unbounded (debug only).',
           )
-        } else {
-          cleanupTimer = setInterval(() => {
-            sweepStaleFiles(params.outputDir)
-          }, SCREENSHOT_CLEANUP_CONFIG.CLEANUP_INTERVAL_MS)
         }
+        // Timer always runs; the sweep itself is skipped while retention is on,
+        // so toggling `setRetainScreenshots` at runtime takes effect immediately.
+        cleanupTimer = setInterval(() => {
+          if (!retainScreenshots) sweepStaleFiles(params.outputDir)
+        }, SCREENSHOT_CLEANUP_CONFIG.CLEANUP_INTERVAL_MS)
       } catch (error) {
         running = false
         throw error
@@ -168,6 +180,13 @@ export function createPipelineHarness(params: {
         ...input,
         frameBufferRetentionMs: Math.max(input.maxActivityDurationMs * 2, 1),
       })
+    },
+    setRetainScreenshots(value: boolean) {
+      retainScreenshots = value
+      log.info(`[PipelineHarness] retainScreenshots set to ${value}`)
+    },
+    sweepNow() {
+      sweepStaleFiles(params.outputDir)
     },
   }
 }

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -33,6 +33,8 @@ import {
 import { PresenceMonitor } from './presence-monitor'
 import { getSystemIdleSeconds, shouldPause } from './power-monitor'
 import { PRESENCE_MONITOR_CONFIG } from '../shared/constants'
+import { EvalRecorder } from './eval/eval-recorder'
+import { EvalFixtureStore } from './eval/eval-fixture-store'
 
 export interface MainRuntime {
   capture: RuntimeCapture
@@ -42,6 +44,9 @@ export interface MainRuntime {
   inferenceProvider: InferenceProvider
   semanticService: ActivitySemanticService
   accessProvider: AccessProvider
+  evalRecorder: EvalRecorder
+  evalFixtureStore: EvalFixtureStore
+  evalFixturesRoot: string
   updateExclusions(exclusions: {
     apps: string[]
     windowTitlePatterns: string[]
@@ -239,6 +244,17 @@ export async function createMainRuntime(params: {
   const deviceIdentity = params.deviceIdentity ?? new DeviceIdentity()
   const accessProvider = createAccessProvider(params.edition, deviceIdentity)
 
+  // In-app eval recorder (Developer mode). Inert until start() is called; ships
+  // in every build but does nothing unless the hidden UI invokes it.
+  const evalFixturesRoot = path.join(userDataPath, 'eval-fixtures')
+  const evalRecorder = new EvalRecorder({
+    harness,
+    capture,
+    storage,
+    fixturesRoot: evalFixturesRoot,
+  })
+  const evalFixtureStore = new EvalFixtureStore(evalFixturesRoot)
+
   let disposePromise: Promise<void> | null = null
 
   return {
@@ -249,6 +265,9 @@ export async function createMainRuntime(params: {
     inferenceProvider,
     semanticService,
     accessProvider,
+    evalRecorder,
+    evalFixtureStore,
+    evalFixturesRoot,
     updateExclusions(exclusions): void {
       blacklistCoordinator.updateExclusions(exclusions)
     },

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -31,6 +31,8 @@ import { VENDORS } from '../../shared/types'
 import { VENDOR_PRESETS, getVendorDefaults } from '../../shared/vendor-defaults'
 import { applyVendorSwitch } from './vendor-switch'
 import { applyModelSettings } from './model-settings'
+import type { EvalRecorder } from '../eval/eval-recorder'
+import type { EvalFixtureStore } from '../eval/eval-fixture-store'
 import type { AccessProvider } from '../access'
 import type {
   AccessState,
@@ -113,6 +115,8 @@ interface MainWindowDependencies {
     stop: (reason: 'user' | 'timer') => ObservationState
     getState: () => ObservationState
   }
+  evalRecorder: EvalRecorder
+  evalFixtureStore: EvalFixtureStore
 }
 
 let mainWindow: BrowserWindow | null = null
@@ -1029,4 +1033,95 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     log.info('[Updater] Install requested from renderer')
     void quitAndInstall()
   })
+
+  // Eval recorder + fixture review (Developer mode). Handlers ship in every build
+  // and are inert until the hidden UI invokes them.
+  ipcMain.handle('main-window:evalStartRecording', (_event: IpcMainInvokeEvent, name: unknown) => {
+    if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
+    try {
+      const status = deps.evalRecorder.start(typeof name === 'string' ? name : '')
+      return { success: true as const, status }
+    } catch (error) {
+      return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }
+    }
+  })
+
+  ipcMain.handle('main-window:evalStopRecording', async () => {
+    if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
+    try {
+      const result = await deps.evalRecorder.stop()
+      return {
+        success: true as const,
+        fixture: {
+          name: path.basename(result.fixtureDir),
+          frameCount: result.frameCount,
+          eventWindowCount: result.eventWindowCount,
+          hasVideo: result.video?.ok ?? false,
+        },
+      }
+    } catch (error) {
+      return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }
+    }
+  })
+
+  ipcMain.handle('main-window:evalRecordingStatus', () => {
+    return deps?.evalRecorder.getStatus() ?? { recording: false, name: null, startedAt: null }
+  })
+
+  ipcMain.handle('main-window:evalListFixtures', () => {
+    return deps?.evalFixtureStore.list() ?? []
+  })
+
+  ipcMain.handle('main-window:evalLoadFixture', (_event: IpcMainInvokeEvent, name: unknown) => {
+    if (!deps || typeof name !== 'string') return null
+    return deps.evalFixtureStore.load(name)
+  })
+
+  ipcMain.handle(
+    'main-window:evalSaveGolden',
+    (_event: IpcMainInvokeEvent, name: unknown, markdown: unknown) => {
+      if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
+      if (typeof name !== 'string' || typeof markdown !== 'string') {
+        return { success: false as const, error: 'Invalid arguments' }
+      }
+      try {
+        deps.evalFixtureStore.saveGolden(name, markdown)
+        return { success: true as const }
+      } catch (error) {
+        return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }
+      }
+    },
+  )
+
+  ipcMain.handle('main-window:evalDeleteFixture', (_event: IpcMainInvokeEvent, name: unknown) => {
+    if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
+    if (typeof name !== 'string') return { success: false as const, error: 'Invalid arguments' }
+    try {
+      deps.evalFixtureStore.delete(name)
+      return { success: true as const }
+    } catch (error) {
+      return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }
+    }
+  })
+
+  ipcMain.handle(
+    'main-window:evalExportFixture',
+    async (_event: IpcMainInvokeEvent, name: unknown) => {
+      if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
+      if (typeof name !== 'string') return { success: false as const, error: 'Invalid arguments' }
+      const result = await dialog.showSaveDialog(getMainWindow() ?? undefined, {
+        title: 'Export Eval Fixture',
+        defaultPath: path.join(app.getPath('desktop'), `${name}.zip`),
+        buttonLabel: 'Export',
+        filters: [{ name: 'ZIP Archives', extensions: ['zip'] }],
+      })
+      if (result.canceled || !result.filePath) return { success: false as const, error: 'Canceled' }
+      try {
+        await deps.evalFixtureStore.exportZip(name, result.filePath)
+        return { success: true as const, path: result.filePath }
+      } catch (error) {
+        return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }
+      }
+    },
+  )
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -135,6 +135,16 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
   },
   // App lifecycle
   restartApp: () => ipcRenderer.invoke('main-window:restartApp'),
+  // Eval recorder + fixture review (Developer mode)
+  evalStartRecording: (name: string) => ipcRenderer.invoke('main-window:evalStartRecording', name),
+  evalStopRecording: () => ipcRenderer.invoke('main-window:evalStopRecording'),
+  evalRecordingStatus: () => ipcRenderer.invoke('main-window:evalRecordingStatus'),
+  evalListFixtures: () => ipcRenderer.invoke('main-window:evalListFixtures'),
+  evalLoadFixture: (name: string) => ipcRenderer.invoke('main-window:evalLoadFixture', name),
+  evalSaveGolden: (name: string, markdown: string) =>
+    ipcRenderer.invoke('main-window:evalSaveGolden', name, markdown),
+  evalDeleteFixture: (name: string) => ipcRenderer.invoke('main-window:evalDeleteFixture', name),
+  evalExportFixture: (name: string) => ipcRenderer.invoke('main-window:evalExportFixture', name),
   // Host platform — read once at preload time; never changes mid-session.
   platform: process.platform,
 })

--- a/src/renderer/lib/dev-mode.ts
+++ b/src/renderer/lib/dev-mode.ts
@@ -1,0 +1,70 @@
+/**
+ * Hidden Developer mode (for the in-app eval recorder). Not security, just
+ * obscurity — the eval IPC handlers ship in every build and are inert until the
+ * UI invokes them. Enabled by 7 rapid taps on the Settings title; disabled only
+ * via an explicit button in the Developer tab.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const STORAGE_KEY = 'memorylane:devMode'
+const UNLOCK_TAPS = 7
+/** Tap streak resets after this long so stray clicks can't accumulate. */
+const TAP_RESET_MS = 600
+
+export function isDevMode(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function setDevMode(enabled: boolean): void {
+  try {
+    if (enabled) localStorage.setItem(STORAGE_KEY, '1')
+    else localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // ignore storage failures
+  }
+  window.dispatchEvent(new Event('memorylane:devModeChanged'))
+}
+
+/** Reactive dev-mode flag, kept in sync across components via a window event. */
+export function useDevMode(): boolean {
+  const [enabled, setEnabled] = useState(isDevMode)
+  useEffect(() => {
+    const sync = (): void => setEnabled(isDevMode())
+    window.addEventListener('memorylane:devModeChanged', sync)
+    window.addEventListener('storage', sync)
+    return () => {
+      window.removeEventListener('memorylane:devModeChanged', sync)
+      window.removeEventListener('storage', sync)
+    }
+  }, [])
+  return enabled
+}
+
+/**
+ * Returns an `onClick` to attach to an existing element. Counts rapid taps and
+ * fires `onUnlock` on the Nth; the streak resets after a pause. No-op once dev
+ * mode is already on.
+ */
+export function useTapUnlock(onUnlock: () => void): () => void {
+  const count = useRef(0)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  return useCallback(() => {
+    if (isDevMode()) return
+    count.current += 1
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => {
+      count.current = 0
+    }, TAP_RESET_MS)
+    if (count.current >= UNLOCK_TAPS) {
+      count.current = 0
+      if (timer.current) clearTimeout(timer.current)
+      onUnlock()
+    }
+  }, [onUnlock])
+}

--- a/src/renderer/main-window.html
+++ b/src/renderer/main-window.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self' data:; object-src 'self' data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self' data:; object-src 'self' data:; media-src 'self' mlmedia:"
     />
     <title>MemoryLane</title>
   </head>

--- a/src/renderer/pages/main-window/components/advanced-settings/DeveloperSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/DeveloperSection.tsx
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  RecordIcon,
+  StopIcon,
+  TrashIcon,
+  ExportIcon,
+  ArrowLeftIcon,
+  FloppyDiskIcon,
+} from '@phosphor-icons/react'
+import { Button } from '@components/ui/button'
+import { Input } from '@components/ui/input'
+import { Textarea } from '@components/ui/textarea'
+import { Card, CardContent } from '@components/ui/card'
+import type { MainWindowAPI } from '@types'
+import type { EvalFixtureLoad, EvalFixtureSummary } from '@/shared/eval-review'
+import { setDevMode } from '@/renderer/lib/dev-mode'
+import { SettingsSection } from './SettingsSection'
+
+/** mm:ss elapsed from a start epoch. */
+function elapsed(startedAt: number, now: number): string {
+  const total = Math.max(0, Math.round((now - startedAt) / 1000))
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`
+}
+
+function defaultName(): string {
+  // Local time, filesystem-friendly — sanitized again in the main process.
+  return new Date().toISOString().slice(0, 16).replace(/[:T]/g, '-')
+}
+
+export function DeveloperSection({ api }: { api: MainWindowAPI }): React.JSX.Element {
+  const [recording, setRecording] = useState(false)
+  const [startedAt, setStartedAt] = useState<number | null>(null)
+  const [now, setNow] = useState(() => Date.now())
+  const [name, setName] = useState(defaultName)
+  const [busy, setBusy] = useState(false)
+
+  const [fixtures, setFixtures] = useState<EvalFixtureSummary[]>([])
+  const [selected, setSelected] = useState<EvalFixtureLoad | null>(null)
+  const [goldenDraft, setGoldenDraft] = useState('')
+  const goldenDirty = selected !== null && goldenDraft !== selected.goldenMd
+
+  const refreshFixtures = useCallback(async () => {
+    setFixtures(await api.evalListFixtures())
+  }, [api])
+
+  // Initial state: are we already recording (e.g. after a re-render)?
+  useEffect(() => {
+    void (async () => {
+      const status = await api.evalRecordingStatus()
+      setRecording(status.recording)
+      setStartedAt(status.startedAt)
+      await refreshFixtures()
+    })()
+  }, [api, refreshFixtures])
+
+  // Tick the elapsed clock while recording.
+  useEffect(() => {
+    if (!recording) return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [recording])
+
+  const startRecording = useCallback(async () => {
+    setBusy(true)
+    const result = await api.evalStartRecording(name)
+    setBusy(false)
+    if (!result.success) {
+      toast.error(result.error ?? 'Failed to start recording')
+      return
+    }
+    setRecording(true)
+    setStartedAt(result.status?.startedAt ?? Date.now())
+    setNow(Date.now())
+    toast.success('Recording started')
+  }, [api, name])
+
+  const stopRecording = useCallback(async () => {
+    setBusy(true)
+    toast.loading('Promoting fixture…', { id: 'eval-stop' })
+    const result = await api.evalStopRecording()
+    setBusy(false)
+    setRecording(false)
+    setStartedAt(null)
+    if (!result.success) {
+      toast.error(result.error ?? 'Failed to stop recording', { id: 'eval-stop' })
+      return
+    }
+    toast.success(
+      `Fixture "${result.fixture?.name}" created (${result.fixture?.frameCount ?? 0} frames)`,
+      { id: 'eval-stop' },
+    )
+    setName(defaultName())
+    await refreshFixtures()
+  }, [api, refreshFixtures])
+
+  const openFixture = useCallback(
+    async (fixtureName: string) => {
+      const loaded = await api.evalLoadFixture(fixtureName)
+      if (!loaded) {
+        toast.error('Failed to load fixture')
+        return
+      }
+      setSelected(loaded)
+      setGoldenDraft(loaded.goldenMd)
+    },
+    [api],
+  )
+
+  const saveGolden = useCallback(async () => {
+    if (!selected) return
+    const result = await api.evalSaveGolden(selected.name, goldenDraft)
+    if (!result.success) {
+      toast.error(result.error ?? 'Failed to save golden')
+      return
+    }
+    setSelected({ ...selected, goldenMd: goldenDraft })
+    toast.success('Golden saved')
+  }, [api, selected, goldenDraft])
+
+  const exportFixture = useCallback(
+    async (fixtureName: string) => {
+      const result = await api.evalExportFixture(fixtureName)
+      if (!result.success) {
+        if (result.error !== 'Canceled') toast.error(result.error ?? 'Export failed')
+        return
+      }
+      toast.success('Fixture exported')
+    },
+    [api],
+  )
+
+  const deleteFixture = useCallback(
+    async (fixtureName: string) => {
+      const result = await api.evalDeleteFixture(fixtureName)
+      if (!result.success) {
+        toast.error(result.error ?? 'Delete failed')
+        return
+      }
+      if (selected?.name === fixtureName) setSelected(null)
+      await refreshFixtures()
+    },
+    [api, selected, refreshFixtures],
+  )
+
+  if (selected) {
+    return (
+      <FixtureReview
+        fixture={selected}
+        goldenDraft={goldenDraft}
+        dirty={goldenDirty}
+        onGoldenChange={setGoldenDraft}
+        onSave={saveGolden}
+        onBack={() => setSelected(null)}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <SettingsSection
+        title="Record eval session"
+        description="Records a real session and turns it into an eval fixture (video + editable golden). Capture is left as you found it when you stop."
+      >
+        <div className="flex items-center gap-2 py-3">
+          {recording ? (
+            <>
+              <Button variant="destructive" onClick={stopRecording} disabled={busy}>
+                <StopIcon weight="fill" /> Stop
+              </Button>
+              <span className="text-sm text-muted-foreground tabular-nums">
+                Recording… {startedAt ? elapsed(startedAt, now) : '0:00'}
+              </span>
+            </>
+          ) : (
+            <>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="fixture name"
+                className="max-w-xs"
+              />
+              <Button onClick={startRecording} disabled={busy || !name.trim()}>
+                <RecordIcon weight="fill" /> Start recording
+              </Button>
+            </>
+          )}
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Fixtures"
+        description="Open a fixture to review its video and edit the golden."
+      >
+        {fixtures.length === 0 ? (
+          <p className="py-3 text-sm text-muted-foreground">No fixtures yet.</p>
+        ) : (
+          <div className="divide-y divide-border">
+            {fixtures.map((f) => (
+              <div key={f.name} className="flex items-center gap-2 py-2">
+                <button
+                  type="button"
+                  onClick={() => void openFixture(f.name)}
+                  className="flex-1 text-left"
+                >
+                  <div className="text-sm font-medium">{f.label || f.name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {new Date(f.capturedAt).toLocaleString()} · {f.frameCount} frames ·{' '}
+                    {f.appMix.slice(0, 3).join(', ') || 'no apps'}
+                    {f.hasVideo ? '' : ' · no video'}
+                  </div>
+                </button>
+                <Button variant="ghost" size="sm" onClick={() => void exportFixture(f.name)}>
+                  <ExportIcon /> Export
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => void deleteFixture(f.name)}>
+                  <TrashIcon /> Delete
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </SettingsSection>
+
+      <div className="pt-2">
+        <Button variant="outline" size="sm" onClick={() => setDevMode(false)}>
+          Disable Developer mode
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function FixtureReview({
+  fixture,
+  goldenDraft,
+  dirty,
+  onGoldenChange,
+  onSave,
+  onBack,
+}: {
+  fixture: EvalFixtureLoad
+  goldenDraft: string
+  dirty: boolean
+  onGoldenChange: (value: string) => void
+  onSave: () => void
+  onBack: () => void
+}): React.JSX.Element {
+  const videoRef = useRef<HTMLVideoElement>(null)
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          <ArrowLeftIcon /> Back
+        </Button>
+        <div className="text-sm font-medium">{fixture.label || fixture.name}</div>
+      </div>
+
+      <Card>
+        <CardContent className="p-3">
+          {fixture.videoUrl ? (
+            <video
+              ref={videoRef}
+              src={fixture.videoUrl}
+              controls
+              className="w-full rounded-md bg-black"
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">No video for this fixture.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            golden.md
+          </span>
+          <Button size="sm" onClick={onSave} disabled={!dirty}>
+            <FloppyDiskIcon /> Save golden
+          </Button>
+        </div>
+        <Textarea
+          value={goldenDraft}
+          onChange={(e) => onGoldenChange(e.target.value)}
+          spellCheck={false}
+          className="min-h-[420px] font-mono text-xs leading-relaxed"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/pages/main-window/components/shell/PageLayout.tsx
+++ b/src/renderer/pages/main-window/components/shell/PageLayout.tsx
@@ -10,6 +10,8 @@ interface PageLayoutProps {
    * vertical space (e.g. the Patterns split-view).
    */
   fillHeight?: boolean
+  /** Click handler on the title — used as the hidden Developer-mode tap target. */
+  onTitleClick?: () => void
   children: React.ReactNode
 }
 
@@ -18,6 +20,7 @@ export function PageLayout({
   subtitle,
   headerBefore,
   fillHeight,
+  onTitleClick,
   children,
 }: PageLayoutProps): React.JSX.Element {
   const root = fillHeight
@@ -27,7 +30,9 @@ export function PageLayout({
     <div className={root}>
       {headerBefore}
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        <h1 className="text-2xl font-semibold tracking-tight" onClick={onTitleClick}>
+          {title}
+        </h1>
         {subtitle && <div className="mt-1">{subtitle}</div>}
       </div>
       {fillHeight ? <div className="flex-1 min-h-0 flex flex-col gap-4">{children}</div> : children}

--- a/src/renderer/pages/main-window/pages/SettingsPage.tsx
+++ b/src/renderer/pages/main-window/pages/SettingsPage.tsx
@@ -8,12 +8,14 @@ import type { CaptureSettings, SemanticPipelineMode, Vendor, VendorStatus } from
 import { AiModelsSection } from '../components/advanced-settings/AiModelsSection'
 import { CapturePrivacySection } from '../components/advanced-settings/CapturePrivacySection'
 import { DataTabPanel } from '../components/advanced-settings/DataTabPanel'
+import { DeveloperSection } from '../components/advanced-settings/DeveloperSection'
 import { IntegrationsTabPanel } from '../components/advanced-settings/IntegrationsTabPanel'
 import type { NumericCaptureSetting } from '../components/advanced-settings/types'
 import { PageLayout } from '../components/shell/PageLayout'
 import { detectHotkeyPlatform, toRecordedAccelerator } from '../hotkey-utils'
+import { setDevMode, useDevMode, useTapUnlock } from '@/renderer/lib/dev-mode'
 
-export type SettingsTab = 'privacy' | 'data' | 'ai-models' | 'integrations'
+export type SettingsTab = 'privacy' | 'data' | 'ai-models' | 'integrations' | 'developer'
 
 export function SettingsPage({
   initialTab,
@@ -260,10 +262,16 @@ export function SettingsPage({
   }, [api, load, recordingHotkey, setCaptureHotkeyAccelerator])
 
   const showAiModels = editionConfig?.edition !== 'enterprise'
+  const devMode = useDevMode()
+  const handleTitleTap = useTapUnlock(() => {
+    setDevMode(true)
+    toast.success('Developer mode enabled')
+  })
 
   return (
     <PageLayout
       title="Settings"
+      onTitleClick={handleTitleTap}
       headerBefore={
         onBack && (
           <Button variant="ghost" size="sm" onClick={onBack}>
@@ -279,6 +287,7 @@ export function SettingsPage({
             <TabsTab value="data">Data</TabsTab>
             {showAiModels && <TabsTab value="ai-models">AI models</TabsTab>}
             <TabsTab value="integrations">Integrations</TabsTab>
+            {devMode && <TabsTab value="developer">Developer</TabsTab>}
           </TabsList>
 
           <TabsPanel value="privacy" className="pt-2">
@@ -326,6 +335,12 @@ export function SettingsPage({
           <TabsPanel value="integrations" className="pt-2">
             <IntegrationsTabPanel api={api} />
           </TabsPanel>
+
+          {devMode && (
+            <TabsPanel value="developer" className="pt-2">
+              <DeveloperSection api={api} />
+            </TabsPanel>
+          )}
         </Tabs>
       )}
     </PageLayout>

--- a/src/shared/eval-review.ts
+++ b/src/shared/eval-review.ts
@@ -1,0 +1,40 @@
+/**
+ * Renderer-facing types for the in-app eval recorder + golden review (Developer
+ * mode). Shared between the main-process IPC handlers and the React UI. Kept free
+ * of any `src/main` imports so the renderer's tsconfig can compile it.
+ */
+
+export interface EvalRecordingStatus {
+  recording: boolean
+  name: string | null
+  /** Epoch ms the current recording started, or null. */
+  startedAt: number | null
+}
+
+/** One promoted fixture, for the Developer tab's list. */
+export interface EvalFixtureSummary {
+  name: string
+  label: string
+  capturedAt: string
+  frameCount: number
+  eventWindowCount: number
+  appMix: string[]
+  hasVideo: boolean
+}
+
+/** A fixture loaded for review: the editable golden + the review video. */
+export interface EvalFixtureLoad {
+  name: string
+  label: string
+  goldenMd: string
+  /** `mlmedia://` URL streaming `session.mp4` off disk (seekable), or null. */
+  videoUrl: string | null
+}
+
+/** Result of stopping a recording (the freshly promoted fixture). */
+export interface EvalPromoteSummary {
+  name: string
+  frameCount: number
+  eventWindowCount: number
+  hasVideo: boolean
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,10 @@
 import type { AppEditionConfig } from './edition'
+import type {
+  EvalFixtureLoad,
+  EvalFixtureSummary,
+  EvalPromoteSummary,
+  EvalRecordingStatus,
+} from './eval-review'
 
 export interface InteractionContext {
   // 'presence' is a synthetic heartbeat emitted while the user is at the machine
@@ -380,6 +386,21 @@ export interface MainWindowAPI {
   onPermissionStatusChanged: (callback: (status: PermissionStatus) => void) => () => void
   // App lifecycle
   restartApp: () => Promise<void>
+  // Eval recorder + fixture review (Developer mode)
+  evalStartRecording: (
+    name: string,
+  ) => Promise<{ success: boolean; status?: EvalRecordingStatus; error?: string }>
+  evalStopRecording: () => Promise<{
+    success: boolean
+    fixture?: EvalPromoteSummary
+    error?: string
+  }>
+  evalRecordingStatus: () => Promise<EvalRecordingStatus>
+  evalListFixtures: () => Promise<EvalFixtureSummary[]>
+  evalLoadFixture: (name: string) => Promise<EvalFixtureLoad | null>
+  evalSaveGolden: (name: string, markdown: string) => Promise<{ success: boolean; error?: string }>
+  evalDeleteFixture: (name: string) => Promise<{ success: boolean; error?: string }>
+  evalExportFixture: (name: string) => Promise<{ success: boolean; path?: string; error?: string }>
   // Host platform (set at preload time; never changes mid-session)
   platform: NodeJS.Platform
 }


### PR DESCRIPTION
## What

Lets a non-technical operator produce eval fixtures **from the normal app** — record a real session, edit the resulting `golden.md` in a simple GUI, export a zip — without `DEBUG_PIPELINE`, the CLI, or hand-editing markdown. Hidden behind a **Developer mode**.

Feeds the existing activity-summary eval pipeline (`npm run eval-summaries`).

## How to use

1. Open **Settings**, click the **"Settings" page title 7× quickly** (streak resets after ~600ms) → a **Developer** tab appears.
2. Developer tab → **Start recording** → use apps → **Stop** (auto-promotes to a fixture).
3. Open the fixture → review **video + an editable `golden.md` textarea** → **Save golden**.
4. **Export zip** (→ Desktop) to hand a fixture back; unzip into `evals/semantic-summary/fixtures/` and run `npm run eval-summaries -- --fixture <name>`.
5. Turn it off via **Disable Developer mode** in the tab.

## Approach (reuse, not reimplement)

- `promoteCapture()` extracted from the `promote-debug-fixture` CLI (now a thin wrapper); accepts the live `storage` in-app or a `dbPath` for the CLI.
- Recording **reuses the existing debug pipeline** rather than adding a parallel subscriber: `retainScreenshots` is now a runtime toggle on the harness (`setRetainScreenshots()` / `sweepNow()`), and the recorder subscribes the existing `FrameDebugDumper` / `EventWindowDebugDumper` to the harness streams for the duration.
- On stop it drains capture (so the final activity is summarized + persisted), promotes, then releases retention and sweeps to reclaim disk.
- Review video is streamed via a privileged **`mlmedia://`** protocol (`net.fetch` with `Range`) — a base64 `data:` URL does not play in Electron (no range requests → no seeking).

## Gating / safety

- No separate build/edition. Eval IPC ships in every build and is **inert until invoked**. Obscurity, not security.
- 7-tap unlock hangs off the existing Settings `<h1>` (no new visible element).
- Never changes DB selection (`app.isPackaged` decides dev vs packaged); no second DB.
- `mlmedia://` only ever serves `session.mp4` inside the fixtures root (basename + root-confinement).

## Tests

13 new unit tests (promote-fixture, eval-fixture-store, eval-recorder). Full suite **799 pass / 33 skipped**; eslint + prettier clean.

## Not yet done

Built + typechecked + tested, but **not yet run live in the Electron app** — the real proof is recording a session and confirming the video plays/seeks. Per-frame redaction is out of scope (review video/titles before exporting; blacklisted-app frames are suppressed at the source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)