### PR TITLE
fix(sync): make enterprise DB uploads regular via catch-up scheduling

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -204,6 +204,8 @@ app.on('ready', async () => {
         return { detailLevel: level === 'detailed' ? 'detailed' : 'summary' }
       },
       getBackendUrl: () => ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
+      getLastUploadAt: () => runtime?.storage.uploadRuns.getLastRunTimestamp() ?? null,
+      recordUploadAt: (ts) => runtime?.storage.uploadRuns.record(ts),
     })
     databaseUploadSync.start()
   }
@@ -332,6 +334,8 @@ app.on('ready', async () => {
     },
     onResume: () => {
       captureCoordinator.resumeCaptureIfDesired('resume')
+      // Catch up uploads on wake — the 24h interval doesn't survive sleep.
+      databaseUploadSync?.scheduleUploadIfStale('resume')
     },
   })
 

--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -42,6 +42,8 @@ describe('DatabaseUploadSync', () => {
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
     })
 
     sync.start()
@@ -75,6 +77,8 @@ describe('DatabaseUploadSync', () => {
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
     })
 
     sync.start()
@@ -101,6 +105,8 @@ describe('DatabaseUploadSync', () => {
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
     })
 
     sync.start()
@@ -126,6 +132,8 @@ describe('DatabaseUploadSync', () => {
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
     })
 
     sync.start()
@@ -154,6 +162,8 @@ describe('DatabaseUploadSync', () => {
       isSyncEnabled: () => true,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
       intervalMs: 1000,
     })
 
@@ -182,6 +192,8 @@ describe('DatabaseUploadSync', () => {
       isSyncEnabled: () => false,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
     })
 
     sync.start()
@@ -206,6 +218,8 @@ describe('DatabaseUploadSync', () => {
       isSyncEnabled: () => false,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
     })
 
     const result = await sync.triggerUpload()
@@ -237,6 +251,8 @@ describe('DatabaseUploadSync', () => {
       isSyncEnabled: () => syncOn,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
       intervalMs: 1000,
     })
 
@@ -253,6 +269,154 @@ describe('DatabaseUploadSync', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     await sync.stop()
+  })
+
+  it('skips startup upload when already uploaded earlier today', async () => {
+    const fetchMock = mockFetchResponse(201, { ok: true })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => true,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      getBackendUrl: () => 'http://localhost:8000/',
+      // Uploaded a few hours ago (same calendar day) — gate should skip.
+      getLastUploadAt: () => Date.now() - 3 * 60 * 60 * 1000,
+      recordUploadAt: () => {},
+    })
+
+    sync.start()
+    await sync.stop()
+
+    expect(backupToFile).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('uploads when the last upload was a previous day', async () => {
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_1',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => true,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      getBackendUrl: () => 'http://localhost:8000/',
+      // Last upload ~2 days ago — gate should let it through.
+      getLastUploadAt: () => Date.now() - 2 * 24 * 60 * 60 * 1000,
+      recordUploadAt: () => {},
+    })
+
+    sync.start()
+    await sync.stop()
+
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('records the timestamp only on a successful upload', async () => {
+    const fetchMock = mockFetchResponse(500, 'server error')
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+    const recordUploadAt = vi.fn()
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => true,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt,
+    })
+
+    sync.start()
+    await sync.stop()
+
+    // Upload failed (HTTP 500) — timestamp must NOT be recorded, so the next
+    // wake/startup retries.
+    expect(recordUploadAt).not.toHaveBeenCalled()
+  })
+
+  it('records the timestamp after a successful upload', async () => {
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_1',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+    const recordUploadAt = vi.fn()
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => true,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt,
+    })
+
+    sync.start()
+    await sync.stop()
+
+    expect(recordUploadAt).toHaveBeenCalledTimes(1)
+  })
+
+  it('triggerUpload forces an upload even when already uploaded today', async () => {
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_1',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => true,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      getBackendUrl: () => 'http://localhost:8000/',
+      // Already uploaded today — the gate would skip an automatic upload, but
+      // a manual trigger must bypass it.
+      getLastUploadAt: () => Date.now(),
+      recordUploadAt: () => {},
+    })
+
+    const result = await sync.triggerUpload()
+
+    expect(result).toEqual({ success: true })
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('in-flight upload completes even if the gate flips to false mid-flight', async () => {
@@ -282,6 +446,8 @@ describe('DatabaseUploadSync', () => {
       isSyncEnabled: () => syncOn,
       getStripOptions: () => ({ detailLevel: 'summary' as const }),
       getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
       intervalMs: 1000,
     })
 

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import log from '../logger'
+import { isSameDay } from './pattern-detector/helpers'
 import { stripDatabaseForUpload, type StripOptions } from './strip-database-for-upload'
 
 const DEFAULT_UPLOAD_INTERVAL_MS = 24 * 60 * 60 * 1000
@@ -17,6 +18,10 @@ export interface DatabaseUploadSyncParams {
   isSyncEnabled: () => boolean
   getStripOptions: () => StripOptions
   getBackendUrl: () => string
+  /** Timestamp (ms) of the last successful upload, or null if never. */
+  getLastUploadAt: () => number | null
+  /** Persist the timestamp (ms) of a successful upload. */
+  recordUploadAt: (ts: number) => void
   intervalMs?: number
 }
 
@@ -27,6 +32,8 @@ export class DatabaseUploadSync {
   private readonly isSyncEnabled: () => boolean
   private readonly getStripOptions: () => StripOptions
   private readonly getBackendUrl: () => string
+  private readonly getLastUploadAt: () => number | null
+  private readonly recordUploadAt: (ts: number) => void
   private readonly intervalMs: number
   private timer: ReturnType<typeof setInterval> | null = null
   private uploadRunning = false
@@ -40,6 +47,8 @@ export class DatabaseUploadSync {
     this.isSyncEnabled = params.isSyncEnabled
     this.getStripOptions = params.getStripOptions
     this.getBackendUrl = params.getBackendUrl
+    this.getLastUploadAt = params.getLastUploadAt
+    this.recordUploadAt = params.recordUploadAt
     this.intervalMs = params.intervalMs ?? DEFAULT_UPLOAD_INTERVAL_MS
   }
 
@@ -49,11 +58,26 @@ export class DatabaseUploadSync {
     }
 
     this.timer = setInterval(() => {
-      void this.queueUpload('interval')
+      this.scheduleUploadIfStale('interval')
     }, this.intervalMs)
     this.timer.unref?.()
 
-    void this.queueUpload('startup')
+    this.scheduleUploadIfStale('startup')
+  }
+
+  /**
+   * Upload if we haven't already uploaded today, otherwise skip. Call this on
+   * startup and on power resume so uploads catch up regardless of how the
+   * sleep-fragile 24h interval drifts. Unlike `triggerUpload`, this is gated —
+   * it never forces a duplicate same-day upload.
+   */
+  public scheduleUploadIfStale(reason: string): void {
+    const lastUploadAt = this.getLastUploadAt()
+    if (lastUploadAt !== null && isSameDay(lastUploadAt, Date.now())) {
+      log.debug(`[DatabaseUploadSync] Skipping upload (${reason}) — already uploaded today`)
+      return
+    }
+    void this.queueUpload(reason)
   }
 
   public async triggerUpload(): Promise<{ success: boolean; error?: string }> {
@@ -142,6 +166,7 @@ export class DatabaseUploadSync {
         upload_id: string
         checksum_sha256: string
       }
+      this.recordUploadAt(Date.now())
       log.info(
         `[DatabaseUploadSync] Upload succeeded (${reason}): upload_id=${data.upload_id} checksum=${data.checksum_sha256}`,
       )

--- a/src/main/storage/index.ts
+++ b/src/main/storage/index.ts
@@ -8,12 +8,14 @@ import { ActivityRepository } from './activity-repository'
 import { PatternRepository } from './pattern-repository'
 import { SightingRepository } from './sighting-repository'
 import { MiningRunRepository } from './mining-run-repository'
+import { UploadRunRepository } from './upload-run-repository'
 import { UserContextRepository } from './user-context-repository'
 
 export { ActivityRepository } from './activity-repository'
 export { PatternRepository } from './pattern-repository'
 export { SightingRepository } from './sighting-repository'
 export { MiningRunRepository } from './mining-run-repository'
+export { UploadRunRepository } from './upload-run-repository'
 export { UserContextRepository } from './user-context-repository'
 export type { Pattern, PatternSighting, PatternWithStats } from './pattern-repository'
 export type { Sighting } from './sighting-repository'
@@ -69,6 +71,7 @@ export class StorageService {
   readonly patterns: PatternRepository
   readonly sightings: SightingRepository
   readonly miningRuns: MiningRunRepository
+  readonly uploadRuns: UploadRunRepository
   readonly userContext: UserContextRepository
 
   constructor(dbPath?: string) {
@@ -96,6 +99,7 @@ export class StorageService {
       this.patterns = new PatternRepository(db)
       this.sightings = new SightingRepository(db)
       this.miningRuns = new MiningRunRepository(db)
+      this.uploadRuns = new UploadRunRepository(db)
       this.userContext = new UserContextRepository(db)
       log.info('SQLite database initialized successfully')
     } catch (error) {

--- a/src/main/storage/migrations/0013_add_upload_runs.ts
+++ b/src/main/storage/migrations/0013_add_upload_runs.ts
@@ -1,0 +1,19 @@
+import Database from 'better-sqlite3'
+import type { Migration } from '../migrator'
+
+/**
+ * Tracks successful enterprise database uploads. The only thing read back is
+ * MAX(ran_at), which the uploader compares against `now` (via isSameDay) to
+ * skip re-uploading more than once a day. Persisting this lets uploads catch up
+ * on startup / power-resume instead of relying on a sleep-fragile 24h interval.
+ */
+export const migration: Migration = {
+  name: '0013_add_upload_runs',
+  up(db: Database.Database): void {
+    db.exec(`
+      CREATE TABLE upload_runs (
+        ran_at INTEGER NOT NULL
+      )
+    `)
+  },
+}

--- a/src/main/storage/migrations/index.ts
+++ b/src/main/storage/migrations/index.ts
@@ -11,6 +11,7 @@ import { migration as migration0009 } from './0009_pattern_duration_estimate'
 import { migration as migration0010 } from './0010_pattern_completed_at_column'
 import { migration as migration0011 } from './0011_activities_summary_model_column'
 import { migration as migration0012 } from './0012_add_tasks_tables'
+import { migration as migration0013 } from './0013_add_upload_runs'
 
 export const migrations: Migration[] = [
   migration0001,
@@ -25,4 +26,5 @@ export const migrations: Migration[] = [
   migration0010,
   migration0011,
   migration0012,
+  migration0013,
 ]

--- a/src/main/storage/upload-run-repository.test.ts
+++ b/src/main/storage/upload-run-repository.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as os from 'os'
+import * as path from 'path'
+import { StorageService } from './index'
+import { applyMigrations } from './migrator'
+import { deleteDbFiles } from './test-utils'
+
+describe('UploadRunRepository', () => {
+  const TEST_DB_PATH = path.join(os.tmpdir(), 'temp_upload_run_repo_test.db')
+  let storage: StorageService
+
+  beforeEach(() => {
+    deleteDbFiles(TEST_DB_PATH)
+    storage = new StorageService(TEST_DB_PATH)
+    applyMigrations(storage.getDatabase())
+  })
+
+  afterEach(() => {
+    storage.close()
+    deleteDbFiles(TEST_DB_PATH)
+  })
+
+  it('returns null when no upload has ever been recorded', () => {
+    expect(storage.uploadRuns.getLastRunTimestamp()).toBeNull()
+  })
+
+  it('records an upload timestamp and reads back the latest', () => {
+    storage.uploadRuns.record(1000)
+    storage.uploadRuns.record(3000)
+    storage.uploadRuns.record(2000)
+
+    expect(storage.uploadRuns.getLastRunTimestamp()).toBe(3000)
+  })
+})

--- a/src/main/storage/upload-run-repository.ts
+++ b/src/main/storage/upload-run-repository.ts
@@ -1,0 +1,21 @@
+import type Database from 'better-sqlite3'
+
+/** Once-per-day gate for enterprise DB uploads: records when each successful
+ *  upload happened. The only thing read back is MAX(ran_at), which the uploader
+ *  compares against `now` to skip uploading more than once a day and to catch up
+ *  on startup / power-resume. Only successful uploads are recorded, so a failed
+ *  upload leaves the gate open and retries on the next wake/startup. */
+export class UploadRunRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  record(ranAt: number = Date.now()): void {
+    this.db.prepare('INSERT INTO upload_runs (ran_at) VALUES (?)').run(ranAt)
+  }
+
+  getLastRunTimestamp(): number | null {
+    const row = this.db.prepare('SELECT MAX(ran_at) AS latest FROM upload_runs').get() as {
+      latest: number | null
+    }
+    return row.latest ?? null
+  }
+}


### PR DESCRIPTION
## Problem

Enterprise DB uploads were happening **irregularly** across the fleet. The uploader (`database-upload-sync.ts`) had only two triggers — a one-shot upload at app startup and a 24h `setInterval(...).unref()` — with **no persisted state and no retry**:

- The 24h timer **doesn't survive system sleep**; it pauses and resumes its remaining countdown on wake, never catching up. The "period" is effectively 24h of *awake* time, which stretches over multiple calendar days and varies per device with usage.
- There was **no `powerMonitor` resume hook** for uploads (capture has one).
- **Nothing recorded the last upload**, so there was no way to detect "it's been a day, upload now."
- **No retry**: a single transient failure was logged, swallowed, and skipped a whole cycle.

Net effect: cadence tracked each device's reboot/usage rhythm rather than a schedule — "some devices uploading, but not regularly."

## Fix

Mirror the task miner's proven `mining_runs` + `isSameDay` pattern:

- New `upload_runs` table (migration `0013`) + `UploadRunRepository`, exposed as `storage.uploadRuns`.
- `DatabaseUploadSync` gains `getLastUploadAt` / `recordUploadAt` callbacks and a `scheduleUploadIfStale()` method that uploads only if the last successful upload wasn't today.
- Startup, the 24h interval (kept as a backstop), **and a new power-resume hook** all route through that gate.
- Timestamp recorded **only on HTTP success** → a failed upload stays stale and retries on the next wake/startup.
- The manual "Sync to Remote" button still bypasses the gate.

Result: at most one upload per day, but reliably at least one on any day the device is awake — independent of sleep drift and reboot cadence.

**Scope:** enterprise upload sync only. The local `RawDatabaseExportSync` shares the same bug but is intentionally left unchanged here.

## Tests
- New `upload-run-repository.test.ts` (round-trip) and new `database-upload-sync` cases: skip-when-uploaded-today, upload-when-prior-day, record-only-on-success, manual-trigger-bypasses-gate.
- `npm test`: **46 passed** (incl. migration `0013` applying). Lint clean; no `tsc` errors in changed production files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)