### PR TITLE
feat(eval): in-app task-mining golden builder (Developer → Tasks tab)

### DIFF
--- a/scripts/export-day.ts
+++ b/scripts/export-day.ts
@@ -28,11 +28,8 @@ import * as path from 'path'
 import { StorageService } from '../src/main/storage'
 import { getDefaultDbPath } from '../src/main/paths'
 import { renderTaskGoldenMd } from '../src/main/eval/task-golden-md'
-import {
-  TASK_FIXTURE_SCHEMA_VERSION,
-  type TaskFixtureActivity,
-  type TaskFixtureManifest,
-} from '../src/main/eval/task-types'
+import { toFixtureActivity } from '../src/main/eval/task-fixture-build'
+import { TASK_FIXTURE_SCHEMA_VERSION, type TaskFixtureManifest } from '../src/main/eval/task-types'
 import type { StoredActivity } from '../src/main/storage/types'
 
 const FIXTURES_ROOT = path.resolve('evals/task-mining/fixtures')
@@ -119,20 +116,6 @@ function hhmmToMin(s: string): number {
     process.exit(1)
   }
   return parseInt(m[1], 10) * 60 + parseInt(m[2], 10)
-}
-
-function toFixtureActivity(s: StoredActivity, dayStart: number): TaskFixtureActivity {
-  return {
-    id: s.id,
-    // Preserve real time-of-day so spacing/order matches the recorded day.
-    offsetMin: Math.round((s.startTimestamp - dayStart) / 60_000),
-    durationMin: Math.max(1, Math.round((s.endTimestamp - s.startTimestamp) / 60_000)),
-    app: s.appName,
-    windowTitle: s.windowTitle,
-    tld: s.tld,
-    summary: s.summary,
-    ocrText: s.ocrText,
-  }
 }
 
 function main() {

--- a/src/main/eval/task-fixture-build.test.ts
+++ b/src/main/eval/task-fixture-build.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as os from 'os'
+import * as path from 'path'
+import { StorageService } from '../storage'
+import { applyMigrations } from '../storage/migrator'
+import { createStoredActivity, deleteDbFiles } from '../storage/test-utils'
+import { buildWindowedActivities, renderSightingGoldenMd } from './task-fixture-build'
+import { parseTaskGoldenMd } from './task-golden-md'
+
+const DB_PATH = path.join(os.tmpdir(), 'task-fixture-build-test.db')
+const MIN = 60_000
+// Local midnight June 10 2026 — deterministic regardless of timezone.
+const DAY = new Date(2026, 5, 10).getTime()
+
+let storage: StorageService
+
+function addAt(id: string, offsetMin: number, durationMin = 5): void {
+  storage.activities.add(
+    createStoredActivity({
+      id,
+      startTimestamp: DAY + offsetMin * MIN,
+      endTimestamp: DAY + (offsetMin + durationMin) * MIN,
+      ocrText: `ocr-${id}`,
+    }),
+  )
+}
+
+beforeEach(() => {
+  deleteDbFiles(DB_PATH)
+  storage = new StorageService(DB_PATH)
+  applyMigrations(storage.getDatabase())
+})
+
+afterEach(() => {
+  storage.close()
+  deleteDbFiles(DB_PATH)
+})
+
+describe('buildWindowedActivities', () => {
+  it('includes only activities inside the padded window', () => {
+    addAt('before-far', 7 * 60) // 07:00 — outside ±1h
+    addAt('before-near', 8 * 60 + 40) // 08:40 — inside
+    addAt('s1', 9 * 60) // 09:00 — sighting
+    addAt('s2', 9 * 60 + 20, 10) // 09:20–09:30 — sighting
+    addAt('after-near', 9 * 60 + 50) // 09:50 — inside
+    addAt('after-far', 11 * 60) // 11:00 — outside
+
+    const { activities, dayStart } = buildWindowedActivities(storage, ['s1', 's2'], 60, 60)
+    expect(activities.map((a) => a.id)).toEqual(['before-near', 's1', 's2', 'after-near'])
+    expect(dayStart).toBe(DAY)
+    // offsetMin is relative to local midnight; OCR is rehydrated.
+    expect(activities.find((a) => a.id === 's1')?.offsetMin).toBe(540)
+    expect(activities.find((a) => a.id === 's1')?.ocrText).toBe('ocr-s1')
+  })
+
+  it('throws when the sighting has no resolvable activities', () => {
+    expect(() => buildWindowedActivities(storage, ['ghost'], 60, 60)).toThrow()
+  })
+})
+
+describe('renderSightingGoldenMd', () => {
+  it('round-trips a keep block through parseTaskGoldenMd', () => {
+    const md = renderSightingGoldenMd(
+      'my-golden',
+      {
+        title: 'Submit expense report',
+        apps: ['Chrome', 'Preview'],
+        activityIds: ['s1', 's2'],
+        description: 'Filled the Concur form and submitted.',
+      },
+      [
+        {
+          id: 's1',
+          offsetMin: 540,
+          durationMin: 5,
+          app: 'Chrome',
+          windowTitle: 'Concur',
+          tld: null,
+          summary: 'opened form',
+          ocrText: '',
+        },
+      ],
+    )
+
+    const parsed = parseTaskGoldenMd(md)
+    expect(parsed.sightings).toHaveLength(1)
+    const s = parsed.sightings[0]
+    expect(s.title).toBe('Submit expense report')
+    expect(s.verdict).toBe('keep')
+    expect(s.apps).toEqual(['Chrome', 'Preview'])
+    expect(s.activityIds).toEqual(['s1', 's2'])
+    expect(s.description).toContain('Filled the Concur form')
+  })
+})

--- a/src/main/eval/task-fixture-build.ts
+++ b/src/main/eval/task-fixture-build.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared helpers for turning real activities into a task-mining fixture.
+ *
+ * Used by both the `export-day` CLI (a whole day) and the in-app Tasks tab
+ * (a single sighting + a noise window around it). The on-disk shape is the same
+ * either way: `TaskFixtureActivity[]` (→ activities.jsonl) plus a `golden.md`.
+ */
+
+import type { StorageService } from '../storage'
+import type { StoredActivity } from '../storage/types'
+import type { TaskFixtureActivity } from './task-types'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** Local midnight (ms) of the day containing `ts`. */
+export function localMidnight(ts: number): number {
+  const d = new Date(ts)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+/** YYYY-MM-DD for a local-midnight timestamp. */
+export function dayString(dayStart: number): string {
+  const d = new Date(dayStart)
+  const pad = (n: number): string => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+/** Freeze a stored activity into a fixture row. `offsetMin` is from `dayStart`. */
+export function toFixtureActivity(s: StoredActivity, dayStart: number): TaskFixtureActivity {
+  return {
+    id: s.id,
+    // Preserve real time-of-day so spacing/order matches the recorded day.
+    offsetMin: Math.round((s.startTimestamp - dayStart) / 60_000),
+    durationMin: Math.max(1, Math.round((s.endTimestamp - s.startTimestamp) / 60_000)),
+    app: s.appName,
+    windowTitle: s.windowTitle,
+    tld: s.tld,
+    summary: s.summary,
+    ocrText: s.ocrText,
+  }
+}
+
+export interface WindowedActivities {
+  activities: TaskFixtureActivity[]
+  dayStart: number
+  windowFrom: number
+  windowTo: number
+}
+
+/**
+ * Builds the fixture activity set for a sighting: every activity within
+ * `[span − beforeMin, span + afterMin]` (the span is the sighting's own
+ * activities), padded into a noise window the miner must discriminate against.
+ *
+ * The window is clamped to the sighting day's local-midnight bounds — the miner
+ * scans one day, so a fixture never spans two. `offsetMin` is relative to that
+ * midnight, matching `seedFixtureDb` in `task-replay.ts`.
+ */
+export function buildWindowedActivities(
+  storage: StorageService,
+  activityIds: readonly string[],
+  beforeMin: number,
+  afterMin: number,
+): WindowedActivities {
+  const seed = storage.activities.getByIds(activityIds)
+  if (seed.length === 0) {
+    throw new Error('Sighting has no resolvable activities')
+  }
+
+  const minStart = Math.min(...seed.map((a) => a.startTimestamp))
+  const maxEnd = Math.max(...seed.map((a) => a.endTimestamp))
+  const dayStart = localMidnight(minStart)
+  const dayEnd = dayStart + DAY_MS
+
+  const windowFrom = Math.max(dayStart, minStart - beforeMin * 60_000)
+  const windowTo = Math.min(dayEnd, maxEnd + afterMin * 60_000)
+
+  // getForDay returns lightweight rows (no OCR); filter to the window, then
+  // rehydrate full rows by id so ocrText is present (needed for the grounding
+  // embedding in seedFixtureDb).
+  const details = storage.activities.getForDay(dayStart, dayEnd)
+  const inWindow = details.filter(
+    (d) => d.endTimestamp >= windowFrom && d.startTimestamp < windowTo,
+  )
+  const stored = storage.activities.getByIds(inWindow.map((d) => d.id))
+
+  const activities = stored
+    .map((s) => toFixtureActivity(s, dayStart))
+    .sort((x, y) => x.offsetMin - y.offsetMin)
+
+  return { activities, dayStart, windowFrom, windowTo }
+}
+
+function offsetToHhmm(offsetMin: number): string {
+  const m = ((offsetMin % 1440) + 1440) % 1440
+  return `${String(Math.floor(m / 60)).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`
+}
+
+/** One hand-editable `keep` block seeded from a sighting. */
+export interface GoldenBlockSeed {
+  title: string
+  apps: string[]
+  activityIds: string[]
+  description: string
+}
+
+/**
+ * Renders golden.md for a single sighting: a feedback instruction, one editable
+ * `keep` block, then a chronological reference of every activity id in the
+ * window. Round-trips through `parseTaskGoldenMd` (the `Notes:` line folds into
+ * the description — fine for a human-feedback golden).
+ */
+export function renderSightingGoldenMd(
+  name: string,
+  block: GoldenBlockSeed,
+  activities: TaskFixtureActivity[],
+): string {
+  const sorted = [...activities].sort((a, b) => a.offsetMin - b.offsetMin)
+
+  const lines: string[] = []
+  lines.push(`# Golden tasks — ${name}`)
+  lines.push('')
+  lines.push('<!-- Feedback golden built from a sighting. Edit the block below:')
+  lines.push('     fix the title / Apps / Activities, rewrite the description, set')
+  lines.push('     Verdict (keep = a legit task, reject = the miner shouldn’t surface')
+  lines.push('     this), and add free-text notes after "Notes:" on what the miner')
+  lines.push('     missed or got wrong. The day reference at the bottom lists every')
+  lines.push('     activity id in the window. -->')
+  lines.push('')
+
+  lines.push(`## ${block.title}`)
+  lines.push('Verdict: keep')
+  lines.push(`Apps: ${block.apps.join(', ')}`)
+  lines.push(`Activities: ${block.activityIds.join(', ')}`)
+  lines.push('')
+  if (block.description.trim()) lines.push(block.description.trim())
+  lines.push('')
+  lines.push('Notes:')
+  lines.push('')
+  lines.push('---')
+  lines.push('')
+
+  lines.push('<!-- THE DAY — chronological reference of every activity id in the window.')
+  for (const a of sorted) {
+    const title = a.windowTitle ? ` — ${a.windowTitle}` : ''
+    const sum = a.summary.replace(/\s+/g, ' ').slice(0, 100)
+    lines.push(`  ${a.id}  ${offsetToHhmm(a.offsetMin)} [${a.app}${title}]  ${sum}`)
+  }
+  lines.push('-->')
+  lines.push('')
+
+  return lines.join('\n')
+}

--- a/src/main/eval/task-fixture-store.test.ts
+++ b/src/main/eval/task-fixture-store.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { TaskFixtureStore, sanitizeFixtureName } from './task-fixture-store'
+import { TASK_FIXTURE_SCHEMA_VERSION, type TaskFixtureActivity } from './task-types'
+
+vi.mock('../logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+let root: string
+let store: TaskFixtureStore
+
+const ACTS: TaskFixtureActivity[] = [
+  {
+    id: 'a1',
+    offsetMin: 540,
+    durationMin: 5,
+    app: 'Chrome',
+    windowTitle: 'Tab',
+    tld: 'example.com',
+    summary: 'did a thing',
+    ocrText: 'OCR',
+  },
+]
+
+function manifest(name: string) {
+  return {
+    name,
+    label: `Label ${name}`,
+    description: 'desc',
+    activityCount: ACTS.length,
+    sourceDay: '2026-06-10',
+    schemaVersion: TASK_FIXTURE_SCHEMA_VERSION,
+  }
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'task-fixture-store-test-'))
+  store = new TaskFixtureStore(root)
+})
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('sanitizeFixtureName', () => {
+  it('produces a filesystem-safe single segment', () => {
+    expect(sanitizeFixtureName('OpenRouter credits / 2026-06-10')).toBe(
+      'OpenRouter-credits-2026-06-10',
+    )
+    expect(sanitizeFixtureName('   ')).toBe('fixture')
+    expect(sanitizeFixtureName('../../etc/passwd')).toBe('etc-passwd')
+  })
+})
+
+describe('TaskFixtureStore', () => {
+  it('writes the three fixture files and lists them', () => {
+    const summary = store.write('alpha', ACTS, '# Golden — alpha', manifest('alpha'))
+    expect(summary.name).toBe('alpha')
+    expect(summary.activityCount).toBe(1)
+    expect(summary.sourceDay).toBe('2026-06-10')
+
+    const dir = path.join(root, 'alpha')
+    expect(fs.existsSync(path.join(dir, 'activities.jsonl'))).toBe(true)
+    expect(fs.existsSync(path.join(dir, 'golden.md'))).toBe(true)
+    expect(fs.existsSync(path.join(dir, 'manifest.json'))).toBe(true)
+
+    const jsonl = fs.readFileSync(path.join(dir, 'activities.jsonl'), 'utf8').trim()
+    expect(JSON.parse(jsonl)).toMatchObject({ id: 'a1', offsetMin: 540 })
+
+    const list = store.list()
+    expect(list.map((f) => f.name)).toEqual(['alpha'])
+    expect(list[0].label).toBe('Label alpha')
+  })
+
+  it('sanitizes the name on write', () => {
+    const summary = store.write('My Golden!', ACTS, '# g', manifest('My Golden!'))
+    expect(summary.name).toBe('My-Golden')
+    expect(fs.existsSync(path.join(root, 'My-Golden', 'manifest.json'))).toBe(true)
+  })
+
+  it('loads and saves an edited golden', () => {
+    store.write('alpha', ACTS, '# Golden — alpha', manifest('alpha'))
+    expect(store.load('alpha')?.goldenMd).toBe('# Golden — alpha')
+
+    store.saveGolden('alpha', '# edited')
+    expect(store.load('alpha')?.goldenMd).toBe('# edited')
+  })
+
+  it('returns null for a missing fixture', () => {
+    expect(store.load('nope')).toBeNull()
+  })
+
+  it('exports a non-empty zip', async () => {
+    store.write('alpha', ACTS, '# g', manifest('alpha'))
+    const dest = path.join(root, 'out', 'alpha.zip')
+    await store.exportZip('alpha', dest)
+    const bytes = fs.readFileSync(dest)
+    expect(bytes.length).toBeGreaterThan(0)
+    expect(bytes.subarray(0, 2).toString('latin1')).toBe('PK')
+  })
+
+  it('deletes a fixture', () => {
+    store.write('alpha', ACTS, '# g', manifest('alpha'))
+    store.delete('alpha')
+    expect(store.list()).toEqual([])
+  })
+})

--- a/src/main/eval/task-fixture-store.ts
+++ b/src/main/eval/task-fixture-store.ts
@@ -27,9 +27,10 @@ export function sanitizeFixtureName(name: string): string {
 export class TaskFixtureStore {
   constructor(private readonly root: string) {}
 
-  /** Guard against path traversal — names are single path segments. */
+  /** Resolve a fixture's directory. Sanitizing keeps names single, safe path
+   *  segments — also guards against path traversal. */
   private dirFor(name: string): string {
-    return path.join(this.root, path.basename(name))
+    return path.join(this.root, sanitizeFixtureName(name))
   }
 
   /**
@@ -44,7 +45,7 @@ export class TaskFixtureStore {
     manifest: TaskFixtureManifest,
   ): TaskFixtureSummary {
     const safe = sanitizeFixtureName(name)
-    const dir = path.join(this.root, safe)
+    const dir = this.dirFor(name)
     fs.mkdirSync(dir, { recursive: true })
     fs.writeFileSync(
       path.join(dir, 'activities.jsonl'),
@@ -109,7 +110,7 @@ export class TaskFixtureStore {
     if (!manifest) return null
     const goldenPath = path.join(dir, 'golden.md')
     const goldenMd = fs.existsSync(goldenPath) ? fs.readFileSync(goldenPath, 'utf8') : ''
-    return { name: path.basename(name), label: manifest.label, goldenMd }
+    return { name: sanitizeFixtureName(name), label: manifest.label, goldenMd }
   }
 
   saveGolden(name: string, markdown: string): void {
@@ -136,7 +137,7 @@ export class TaskFixtureStore {
         else if (e.isFile()) files.push({ real, entry })
       }
     }
-    walk(dir, path.basename(name))
+    walk(dir, sanitizeFixtureName(name))
 
     await fs.promises.mkdir(path.dirname(destPath), { recursive: true })
     await new Promise<void>((resolve, reject) => {

--- a/src/main/eval/task-fixture-store.ts
+++ b/src/main/eval/task-fixture-store.ts
@@ -1,0 +1,156 @@
+/**
+ * Reads/writes task-mining goldens built in-app, under `{userData}/task-fixtures`.
+ * Backs the Developer → Tasks UI: list goldens, load one for editing (its
+ * `golden.md`), save the edited golden, export a fixture as a zip to hand back
+ * into the repo (`evals/task-mining/fixtures/`), and delete.
+ *
+ * Mirrors `EvalFixtureStore`, but a task fixture has no video — it's
+ * `manifest.json` + `activities.jsonl` + `golden.md`.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import * as yazl from 'yazl'
+import log from '../logger'
+import type { TaskFixtureActivity, TaskFixtureManifest } from './task-types'
+import type { TaskFixtureLoad, TaskFixtureSummary } from '../../shared/eval-review'
+
+/** Filesystem-safe single path segment from a free-text name. */
+export function sanitizeFixtureName(name: string): string {
+  const cleaned = name
+    .trim()
+    .replace(/[^a-zA-Z0-9-_]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return cleaned || 'fixture'
+}
+
+export class TaskFixtureStore {
+  constructor(private readonly root: string) {}
+
+  /** Guard against path traversal — names are single path segments. */
+  private dirFor(name: string): string {
+    return path.join(this.root, path.basename(name))
+  }
+
+  /**
+   * Writes a freshly built fixture (`activities.jsonl` + `golden.md` +
+   * `manifest.json`). Returns its summary. The name is sanitized; if a fixture
+   * with that name exists it is overwritten.
+   */
+  write(
+    name: string,
+    activities: TaskFixtureActivity[],
+    goldenMd: string,
+    manifest: TaskFixtureManifest,
+  ): TaskFixtureSummary {
+    const safe = sanitizeFixtureName(name)
+    const dir = path.join(this.root, safe)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(
+      path.join(dir, 'activities.jsonl'),
+      activities.map((a) => JSON.stringify(a)).join('\n') + '\n',
+      'utf8',
+    )
+    fs.writeFileSync(path.join(dir, 'golden.md'), goldenMd, 'utf8')
+    fs.writeFileSync(
+      path.join(dir, 'manifest.json'),
+      JSON.stringify({ ...manifest, name: safe }, null, 2) + '\n',
+      'utf8',
+    )
+    return {
+      name: safe,
+      label: manifest.label,
+      sourceDay: manifest.sourceDay ?? null,
+      activityCount: manifest.activityCount,
+      createdAt: fs.statSync(path.join(dir, 'manifest.json')).mtimeMs,
+    }
+  }
+
+  private readManifest(dir: string): TaskFixtureManifest | null {
+    try {
+      return JSON.parse(
+        fs.readFileSync(path.join(dir, 'manifest.json'), 'utf8'),
+      ) as TaskFixtureManifest
+    } catch {
+      return null
+    }
+  }
+
+  list(): TaskFixtureSummary[] {
+    if (!fs.existsSync(this.root)) return []
+    const out: TaskFixtureSummary[] = []
+    for (const entry of fs.readdirSync(this.root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const dir = path.join(this.root, entry.name)
+      const manifest = this.readManifest(dir)
+      if (!manifest) continue
+      let createdAt = 0
+      try {
+        createdAt = fs.statSync(path.join(dir, 'manifest.json')).mtimeMs
+      } catch {
+        // leave as 0
+      }
+      out.push({
+        name: entry.name,
+        label: manifest.label,
+        sourceDay: manifest.sourceDay ?? null,
+        activityCount: manifest.activityCount,
+        createdAt,
+      })
+    }
+    // Newest first.
+    out.sort((a, b) => b.createdAt - a.createdAt)
+    return out
+  }
+
+  load(name: string): TaskFixtureLoad | null {
+    const dir = this.dirFor(name)
+    const manifest = this.readManifest(dir)
+    if (!manifest) return null
+    const goldenPath = path.join(dir, 'golden.md')
+    const goldenMd = fs.existsSync(goldenPath) ? fs.readFileSync(goldenPath, 'utf8') : ''
+    return { name: path.basename(name), label: manifest.label, goldenMd }
+  }
+
+  saveGolden(name: string, markdown: string): void {
+    const dir = this.dirFor(name)
+    if (!fs.existsSync(dir)) throw new Error(`Fixture not found: ${name}`)
+    fs.writeFileSync(path.join(dir, 'golden.md'), markdown, 'utf8')
+  }
+
+  delete(name: string): void {
+    fs.rmSync(this.dirFor(name), { recursive: true, force: true })
+  }
+
+  /** Zips the fixture dir to `destPath`, entries rooted at `<name>/`. */
+  async exportZip(name: string, destPath: string): Promise<void> {
+    const dir = this.dirFor(name)
+    if (!fs.existsSync(dir)) throw new Error(`Fixture not found: ${name}`)
+
+    const files: { real: string; entry: string }[] = []
+    const walk = (current: string, rel: string): void => {
+      for (const e of fs.readdirSync(current, { withFileTypes: true })) {
+        const real = path.join(current, e.name)
+        const entry = path.posix.join(rel, e.name)
+        if (e.isDirectory()) walk(real, entry)
+        else if (e.isFile()) files.push({ real, entry })
+      }
+    }
+    walk(dir, path.basename(name))
+
+    await fs.promises.mkdir(path.dirname(destPath), { recursive: true })
+    await new Promise<void>((resolve, reject) => {
+      const zip = new yazl.ZipFile()
+      const output = fs.createWriteStream(destPath)
+      const onError = (error: unknown): void =>
+        reject(error instanceof Error ? error : new Error(String(error)))
+      output.once('error', onError)
+      zip.outputStream.once('error', onError)
+      output.once('close', resolve)
+      zip.outputStream.pipe(output)
+      for (const f of files) zip.addFile(f.real, f.entry)
+      zip.end()
+    })
+    log.info(`[TaskFixtureStore] Exported "${name}" (${files.length} files) -> ${destPath}`)
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -303,6 +303,7 @@ app.on('ready', async () => {
     observation,
     evalRecorder: runtime.evalRecorder,
     evalFixtureStore: runtime.evalFixtureStore,
+    taskFixtureStore: runtime.taskFixtureStore,
   })
 
   runtime.accessProvider.startPeriodicRefresh()

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -35,6 +35,7 @@ import { getSystemIdleSeconds, shouldPause } from './power-monitor'
 import { PRESENCE_MONITOR_CONFIG } from '../shared/constants'
 import { EvalRecorder } from './eval/eval-recorder'
 import { EvalFixtureStore } from './eval/eval-fixture-store'
+import { TaskFixtureStore } from './eval/task-fixture-store'
 
 export interface MainRuntime {
   capture: RuntimeCapture
@@ -46,6 +47,7 @@ export interface MainRuntime {
   accessProvider: AccessProvider
   evalRecorder: EvalRecorder
   evalFixtureStore: EvalFixtureStore
+  taskFixtureStore: TaskFixtureStore
   evalFixturesRoot: string
   updateExclusions(exclusions: {
     apps: string[]
@@ -254,6 +256,7 @@ export async function createMainRuntime(params: {
     fixturesRoot: evalFixturesRoot,
   })
   const evalFixtureStore = new EvalFixtureStore(evalFixturesRoot)
+  const taskFixtureStore = new TaskFixtureStore(path.join(userDataPath, 'task-fixtures'))
 
   let disposePromise: Promise<void> | null = null
 
@@ -267,6 +270,7 @@ export async function createMainRuntime(params: {
     accessProvider,
     evalRecorder,
     evalFixtureStore,
+    taskFixtureStore,
     evalFixturesRoot,
     updateExclusions(exclusions): void {
       blacklistCoordinator.updateExclusions(exclusions)

--- a/src/main/storage/pattern-repository.ts
+++ b/src/main/storage/pattern-repository.ts
@@ -41,6 +41,12 @@ export interface PatternDetail {
   sightings: PatternSighting[]
 }
 
+/** A sighting joined with its parent pattern's name + apps (for flat listing). */
+export interface PatternSightingWithPattern extends PatternSighting {
+  patternName: string
+  patternApps: string[]
+}
+
 // ---------------------------------------------------------------------------
 // Scoring
 // ---------------------------------------------------------------------------
@@ -287,6 +293,25 @@ export class PatternRepository {
       .all(patternId, limit) as Record<string, unknown>[]
 
     return rows.map((row) => this.rowToSighting(row))
+  }
+
+  /** All sightings across patterns, newest first, with parent name + apps. */
+  getAllSightings(limit = 200): PatternSightingWithPattern[] {
+    const rows = this.db
+      .prepare(
+        `SELECT s.*, p.name AS pattern_name, p.apps AS pattern_apps
+         FROM pattern_sightings s
+         JOIN patterns p ON p.id = s.pattern_id
+         ORDER BY s.detected_at DESC
+         LIMIT ?`,
+      )
+      .all(limit) as Record<string, unknown>[]
+
+    return rows.map((row) => ({
+      ...this.rowToSighting(row),
+      patternName: row.pattern_name as string,
+      patternApps: JSON.parse((row.pattern_apps as string) || '[]') as string[],
+    }))
   }
 
   getSightingsByRunId(runId: string): PatternSighting[] {

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -33,6 +33,14 @@ import { applyVendorSwitch } from './vendor-switch'
 import { applyModelSettings } from './model-settings'
 import type { EvalRecorder } from '../eval/eval-recorder'
 import type { EvalFixtureStore } from '../eval/eval-fixture-store'
+import type { TaskFixtureStore } from '../eval/task-fixture-store'
+import {
+  buildWindowedActivities,
+  dayString,
+  renderSightingGoldenMd,
+} from '../eval/task-fixture-build'
+import { TASK_FIXTURE_SCHEMA_VERSION } from '../eval/task-types'
+import type { TaskSightingSummary } from '../../shared/eval-review'
 import type { AccessProvider } from '../access'
 import type {
   AccessState,
@@ -117,6 +125,7 @@ interface MainWindowDependencies {
   }
   evalRecorder: EvalRecorder
   evalFixtureStore: EvalFixtureStore
+  taskFixtureStore: TaskFixtureStore
 }
 
 let mainWindow: BrowserWindow | null = null
@@ -1118,6 +1127,169 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       if (result.canceled || !result.filePath) return { success: false as const, error: 'Canceled' }
       try {
         await deps.evalFixtureStore.exportZip(name, result.filePath)
+        return { success: true as const, path: result.filePath }
+      } catch (error) {
+        return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }
+      }
+    },
+  )
+
+  // Task-mining goldens (Developer → Tasks tab). Source: legacy pattern-detection
+  // sightings; output: {userData}/task-fixtures via taskFixtureStore.
+  ipcMain.handle('main-window:evalListTaskSightings', () => {
+    if (!deps) return []
+    const sightings = deps.storage.patterns.getAllSightings()
+    const allActivityIds = Array.from(new Set(sightings.flatMap((s) => s.activityIds)))
+    const activities = deps.storage.activities.getByIds(allActivityIds)
+    const spanById = new Map(activities.map((a) => [a.id, a]))
+    return sightings.map((s): TaskSightingSummary => {
+      const acts = s.activityIds
+        .map((id) => spanById.get(id))
+        .filter((a): a is NonNullable<typeof a> => a !== undefined)
+      const startedAt = acts.length ? Math.min(...acts.map((a) => a.startTimestamp)) : null
+      const endedAt = acts.length ? Math.max(...acts.map((a) => a.endTimestamp)) : null
+      return {
+        id: s.id,
+        patternName: s.patternName,
+        evidence: s.evidence,
+        apps: s.patternApps,
+        activityIds: s.activityIds,
+        detectedAt: s.detectedAt,
+        startedAt,
+        endedAt,
+        activityCount: s.activityIds.length,
+      }
+    })
+  })
+
+  ipcMain.handle(
+    'main-window:evalPreviewTaskGolden',
+    (_event: IpcMainInvokeEvent, sightingId: unknown, beforeMin: unknown, afterMin: unknown) => {
+      if (!deps || typeof sightingId !== 'string') return null
+      const before = typeof beforeMin === 'number' ? beforeMin : 60
+      const after = typeof afterMin === 'number' ? afterMin : 60
+      const sighting = deps.storage.patterns.getAllSightings().find((s) => s.id === sightingId)
+      if (!sighting) return null
+      try {
+        const { activities, dayStart, windowFrom, windowTo } = buildWindowedActivities(
+          deps.storage,
+          sighting.activityIds,
+          before,
+          after,
+        )
+        const name = `${sighting.patternName}-${dayString(dayStart)}`
+        const goldenMd = renderSightingGoldenMd(
+          name,
+          {
+            title: sighting.patternName,
+            apps: sighting.patternApps,
+            activityIds: sighting.activityIds,
+            description: sighting.evidence,
+          },
+          activities,
+        )
+        return { name, goldenMd, activityCount: activities.length, windowFrom, windowTo }
+      } catch {
+        return null
+      }
+    },
+  )
+
+  ipcMain.handle(
+    'main-window:evalPromoteTaskSighting',
+    (_event: IpcMainInvokeEvent, sightingId: unknown, opts: unknown) => {
+      if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
+      if (typeof sightingId !== 'string' || typeof opts !== 'object' || opts === null) {
+        return { success: false as const, error: 'Invalid arguments' }
+      }
+      const { beforeMin, afterMin, goldenMd, name } = opts as {
+        beforeMin?: unknown
+        afterMin?: unknown
+        goldenMd?: unknown
+        name?: unknown
+      }
+      const before = typeof beforeMin === 'number' ? beforeMin : 60
+      const after = typeof afterMin === 'number' ? afterMin : 60
+      if (typeof goldenMd !== 'string' || typeof name !== 'string') {
+        return { success: false as const, error: 'Invalid arguments' }
+      }
+      const sighting = deps.storage.patterns.getAllSightings().find((s) => s.id === sightingId)
+      if (!sighting) return { success: false as const, error: 'Sighting not found' }
+      try {
+        const { activities, dayStart } = buildWindowedActivities(
+          deps.storage,
+          sighting.activityIds,
+          before,
+          after,
+        )
+        const fixture = deps.taskFixtureStore.write(name, activities, goldenMd, {
+          name,
+          label: name,
+          description: `Built from sighting "${sighting.patternName}"; ${activities.length} activities (±${before}/${after} min).`,
+          activityCount: activities.length,
+          sourceDay: dayString(dayStart),
+          schemaVersion: TASK_FIXTURE_SCHEMA_VERSION,
+        })
+        return { success: true as const, fixture }
+      } catch (error) {
+        return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }
+      }
+    },
+  )
+
+  ipcMain.handle('main-window:evalListTaskFixtures', () => {
+    return deps?.taskFixtureStore.list() ?? []
+  })
+
+  ipcMain.handle('main-window:evalLoadTaskFixture', (_event: IpcMainInvokeEvent, name: unknown) => {
+    if (!deps || typeof name !== 'string') return null
+    return deps.taskFixtureStore.load(name)
+  })
+
+  ipcMain.handle(
+    'main-window:evalSaveTaskGolden',
+    (_event: IpcMainInvokeEvent, name: unknown, markdown: unknown) => {
+      if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
+      if (typeof name !== 'string' || typeof markdown !== 'string') {
+        return { success: false as const, error: 'Invalid arguments' }
+      }
+      try {
+        deps.taskFixtureStore.saveGolden(name, markdown)
+        return { success: true as const }
+      } catch (error) {
+        return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    'main-window:evalDeleteTaskFixture',
+    (_event: IpcMainInvokeEvent, name: unknown) => {
+      if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
+      if (typeof name !== 'string') return { success: false as const, error: 'Invalid arguments' }
+      try {
+        deps.taskFixtureStore.delete(name)
+        return { success: true as const }
+      } catch (error) {
+        return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    'main-window:evalExportTaskFixture',
+    async (_event: IpcMainInvokeEvent, name: unknown) => {
+      if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
+      if (typeof name !== 'string') return { success: false as const, error: 'Invalid arguments' }
+      const result = await dialog.showSaveDialog(getMainWindow() ?? undefined, {
+        title: 'Export Task Golden',
+        defaultPath: path.join(app.getPath('desktop'), `${name}.zip`),
+        buttonLabel: 'Export',
+        filters: [{ name: 'ZIP Archives', extensions: ['zip'] }],
+      })
+      if (result.canceled || !result.filePath) return { success: false as const, error: 'Canceled' }
+      try {
+        await deps.taskFixtureStore.exportZip(name, result.filePath)
         return { success: true as const, path: result.filePath }
       } catch (error) {
         return { success: false as const, error: error instanceof Error ? error.message : 'Failed' }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -145,6 +145,23 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
     ipcRenderer.invoke('main-window:evalSaveGolden', name, markdown),
   evalDeleteFixture: (name: string) => ipcRenderer.invoke('main-window:evalDeleteFixture', name),
   evalExportFixture: (name: string) => ipcRenderer.invoke('main-window:evalExportFixture', name),
+  // Task-mining goldens (Developer → Tasks tab)
+  evalListTaskSightings: () => ipcRenderer.invoke('main-window:evalListTaskSightings'),
+  evalPreviewTaskGolden: (sightingId: string, beforeMin: number, afterMin: number) =>
+    ipcRenderer.invoke('main-window:evalPreviewTaskGolden', sightingId, beforeMin, afterMin),
+  evalPromoteTaskSighting: (
+    sightingId: string,
+    opts: { beforeMin: number; afterMin: number; goldenMd: string; name: string },
+  ) => ipcRenderer.invoke('main-window:evalPromoteTaskSighting', sightingId, opts),
+  evalListTaskFixtures: () => ipcRenderer.invoke('main-window:evalListTaskFixtures'),
+  evalLoadTaskFixture: (name: string) =>
+    ipcRenderer.invoke('main-window:evalLoadTaskFixture', name),
+  evalSaveTaskGolden: (name: string, markdown: string) =>
+    ipcRenderer.invoke('main-window:evalSaveTaskGolden', name, markdown),
+  evalDeleteTaskFixture: (name: string) =>
+    ipcRenderer.invoke('main-window:evalDeleteTaskFixture', name),
+  evalExportTaskFixture: (name: string) =>
+    ipcRenderer.invoke('main-window:evalExportTaskFixture', name),
   // Host platform — read once at preload time; never changes mid-session.
   platform: process.platform,
 })

--- a/src/renderer/pages/main-window/components/advanced-settings/DeveloperSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/DeveloperSection.tsx
@@ -12,10 +12,37 @@ import { Button } from '@components/ui/button'
 import { Input } from '@components/ui/input'
 import { Textarea } from '@components/ui/textarea'
 import { Card, CardContent } from '@components/ui/card'
+import { Tabs, TabsList, TabsTab, TabsPanel } from '@components/ui/tabs'
 import type { MainWindowAPI } from '@types'
 import type { EvalFixtureLoad, EvalFixtureSummary } from '@/shared/eval-review'
 import { setDevMode } from '@/renderer/lib/dev-mode'
 import { SettingsSection } from './SettingsSection'
+import { TaskGoldenSection } from './TaskGoldenSection'
+
+export function DeveloperSection({ api }: { api: MainWindowAPI }): React.JSX.Element {
+  return (
+    <div className="space-y-6">
+      <Tabs defaultValue="recorder">
+        <TabsList>
+          <TabsTab value="recorder">Recorder</TabsTab>
+          <TabsTab value="tasks">Tasks</TabsTab>
+        </TabsList>
+        <TabsPanel value="recorder" className="pt-2">
+          <RecorderSection api={api} />
+        </TabsPanel>
+        <TabsPanel value="tasks" className="pt-2">
+          <TaskGoldenSection api={api} />
+        </TabsPanel>
+      </Tabs>
+
+      <div className="pt-2">
+        <Button variant="outline" size="sm" onClick={() => setDevMode(false)}>
+          Disable Developer mode
+        </Button>
+      </div>
+    </div>
+  )
+}
 
 /** mm:ss elapsed from a start epoch. */
 function elapsed(startedAt: number, now: number): string {
@@ -28,7 +55,7 @@ function defaultName(): string {
   return new Date().toISOString().slice(0, 16).replace(/[:T]/g, '-')
 }
 
-export function DeveloperSection({ api }: { api: MainWindowAPI }): React.JSX.Element {
+function RecorderSection({ api }: { api: MainWindowAPI }): React.JSX.Element {
   const [recording, setRecording] = useState(false)
   const [startedAt, setStartedAt] = useState<number | null>(null)
   const [now, setNow] = useState(() => Date.now())
@@ -221,12 +248,6 @@ export function DeveloperSection({ api }: { api: MainWindowAPI }): React.JSX.Ele
           </div>
         )}
       </SettingsSection>
-
-      <div className="pt-2">
-        <Button variant="outline" size="sm" onClick={() => setDevMode(false)}>
-          Disable Developer mode
-        </Button>
-      </div>
     </div>
   )
 }

--- a/src/renderer/pages/main-window/components/advanced-settings/TaskGoldenSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/TaskGoldenSection.tsx
@@ -1,0 +1,388 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  ArrowLeftIcon,
+  ArrowClockwiseIcon,
+  ExportIcon,
+  FloppyDiskIcon,
+  TrashIcon,
+} from '@phosphor-icons/react'
+import { Button } from '@components/ui/button'
+import { Input } from '@components/ui/input'
+import { Textarea } from '@components/ui/textarea'
+import type { MainWindowAPI } from '@types'
+import type { TaskFixtureLoad, TaskFixtureSummary, TaskSightingSummary } from '@/shared/eval-review'
+import { SettingsSection } from './SettingsSection'
+
+type Selection =
+  | { kind: 'sighting'; sighting: TaskSightingSummary }
+  | { kind: 'fixture'; name: string }
+  | null
+
+export function TaskGoldenSection({ api }: { api: MainWindowAPI }): React.JSX.Element {
+  const [sightings, setSightings] = useState<TaskSightingSummary[]>([])
+  const [fixtures, setFixtures] = useState<TaskFixtureSummary[]>([])
+  const [selected, setSelected] = useState<Selection>(null)
+
+  const refresh = useCallback(async () => {
+    const [s, f] = await Promise.all([api.evalListTaskSightings(), api.evalListTaskFixtures()])
+    setSightings(s)
+    setFixtures(f)
+  }, [api])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const deleteFixture = useCallback(
+    async (name: string) => {
+      const result = await api.evalDeleteTaskFixture(name)
+      if (!result.success) {
+        toast.error(result.error ?? 'Delete failed')
+        return
+      }
+      await refresh()
+    },
+    [api, refresh],
+  )
+
+  const exportFixture = useCallback(
+    async (name: string) => {
+      const result = await api.evalExportTaskFixture(name)
+      if (!result.success) {
+        if (result.error !== 'Canceled') toast.error(result.error ?? 'Export failed')
+        return
+      }
+      toast.success('Golden exported')
+    },
+    [api],
+  )
+
+  if (selected?.kind === 'sighting') {
+    return (
+      <SightingPromote
+        api={api}
+        sighting={selected.sighting}
+        onDone={async () => {
+          setSelected(null)
+          await refresh()
+        }}
+        onBack={() => setSelected(null)}
+      />
+    )
+  }
+
+  if (selected?.kind === 'fixture') {
+    return (
+      <TaskFixtureReview
+        api={api}
+        name={selected.name}
+        onExport={() => exportFixture(selected.name)}
+        onDelete={async () => {
+          await deleteFixture(selected.name)
+          setSelected(null)
+        }}
+        onBack={() => setSelected(null)}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <SettingsSection
+        title="Sightings"
+        description="Pick a detected sighting to turn into a golden. You'll edit its task description and choose how much surrounding activity (noise) to include."
+      >
+        {sightings.length === 0 ? (
+          <p className="py-3 text-sm text-muted-foreground">
+            No sightings yet — run the app so it detects patterns first.
+          </p>
+        ) : (
+          <div className="divide-y divide-border">
+            {sightings.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => setSelected({ kind: 'sighting', sighting: s })}
+                className="block w-full py-2 text-left"
+              >
+                <div className="text-sm font-medium">{s.patternName}</div>
+                <div className="text-xs text-muted-foreground">
+                  {new Date(s.detectedAt).toLocaleString()} · {s.activityCount} activities ·{' '}
+                  {s.apps.slice(0, 3).join(', ') || 'no apps'}
+                </div>
+                {s.evidence && (
+                  <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground/80">
+                    {s.evidence}
+                  </div>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </SettingsSection>
+
+      <SettingsSection
+        title="Goldens"
+        description="Promoted goldens. Edit or export one to add it to the repo (evals/task-mining/fixtures)."
+      >
+        {fixtures.length === 0 ? (
+          <p className="py-3 text-sm text-muted-foreground">No goldens yet.</p>
+        ) : (
+          <div className="divide-y divide-border">
+            {fixtures.map((f) => (
+              <div key={f.name} className="flex items-center gap-2 py-2">
+                <button
+                  type="button"
+                  onClick={() => setSelected({ kind: 'fixture', name: f.name })}
+                  className="flex-1 text-left"
+                >
+                  <div className="text-sm font-medium">{f.label || f.name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {f.sourceDay ?? '—'} · {f.activityCount} activities
+                  </div>
+                </button>
+                <Button variant="ghost" size="sm" onClick={() => void exportFixture(f.name)}>
+                  <ExportIcon /> Export
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => void deleteFixture(f.name)}>
+                  <TrashIcon /> Delete
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </SettingsSection>
+    </div>
+  )
+}
+
+function clampMinutes(value: string): number {
+  const n = Math.trunc(Number(value))
+  if (!Number.isFinite(n) || n < 0) return 0
+  return Math.min(n, 24 * 60)
+}
+
+function SightingPromote({
+  api,
+  sighting,
+  onDone,
+  onBack,
+}: {
+  api: MainWindowAPI
+  sighting: TaskSightingSummary
+  onDone: () => void
+  onBack: () => void
+}): React.JSX.Element {
+  const [beforeMin, setBeforeMin] = useState(60)
+  const [afterMin, setAfterMin] = useState(60)
+  const [name, setName] = useState('')
+  const [draft, setDraft] = useState('')
+  const [generated, setGenerated] = useState('')
+  const [activityCount, setActivityCount] = useState<number | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const draftRef = useRef('')
+  const generatedRef = useRef('')
+  const nameEdited = useRef(false)
+  const firstRun = useRef(true)
+  useEffect(() => {
+    draftRef.current = draft
+  }, [draft])
+
+  const dirty = draft !== generated
+
+  const loadPreview = useCallback(
+    async (force: boolean) => {
+      const res = await api.evalPreviewTaskGolden(sighting.id, beforeMin, afterMin)
+      if (!res) {
+        toast.error('Could not build a preview for this sighting')
+        return
+      }
+      setActivityCount(res.activityCount)
+      const wasDirty = draftRef.current !== '' && draftRef.current !== generatedRef.current
+      generatedRef.current = res.goldenMd
+      setGenerated(res.goldenMd)
+      if (force || !wasDirty) setDraft(res.goldenMd)
+      if (!nameEdited.current) setName(res.name)
+    },
+    [api, sighting.id, beforeMin, afterMin],
+  )
+
+  useEffect(() => {
+    void loadPreview(firstRun.current)
+    firstRun.current = false
+  }, [loadPreview])
+
+  const promote = useCallback(async () => {
+    if (!name.trim()) {
+      toast.error('Name the golden first')
+      return
+    }
+    setBusy(true)
+    const result = await api.evalPromoteTaskSighting(sighting.id, {
+      beforeMin,
+      afterMin,
+      goldenMd: draft,
+      name,
+    })
+    setBusy(false)
+    if (!result.success) {
+      toast.error(result.error ?? 'Promote failed')
+      return
+    }
+    toast.success(`Golden "${result.fixture?.name}" created`)
+    onDone()
+  }, [api, sighting.id, beforeMin, afterMin, draft, name, onDone])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          <ArrowLeftIcon /> Back
+        </Button>
+        <div className="text-sm font-medium">{sighting.patternName}</div>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="space-y-1 text-xs text-muted-foreground">
+          <div>Golden name</div>
+          <Input
+            value={name}
+            onChange={(e) => {
+              nameEdited.current = true
+              setName(e.target.value)
+            }}
+            className="w-64"
+          />
+        </label>
+        <label className="space-y-1 text-xs text-muted-foreground">
+          <div>Minutes before</div>
+          <Input
+            type="number"
+            min={0}
+            value={beforeMin}
+            onChange={(e) => setBeforeMin(clampMinutes(e.target.value))}
+            className="w-24"
+          />
+        </label>
+        <label className="space-y-1 text-xs text-muted-foreground">
+          <div>Minutes after</div>
+          <Input
+            type="number"
+            min={0}
+            value={afterMin}
+            onChange={(e) => setAfterMin(clampMinutes(e.target.value))}
+            className="w-24"
+          />
+        </label>
+        <span className="pb-2 text-xs text-muted-foreground">
+          {activityCount === null ? '…' : `${activityCount} activities in window`}
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            golden.md
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void loadPreview(true)}
+              disabled={!dirty}
+              title="Rebuild the draft from the current window (discards edits)"
+            >
+              <ArrowClockwiseIcon /> Regenerate
+            </Button>
+            <Button size="sm" onClick={() => void promote()} disabled={busy}>
+              <FloppyDiskIcon /> Promote to golden
+            </Button>
+          </div>
+        </div>
+        <Textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          spellCheck={false}
+          className="min-h-[420px] font-mono text-xs leading-relaxed"
+        />
+      </div>
+    </div>
+  )
+}
+
+function TaskFixtureReview({
+  api,
+  name,
+  onExport,
+  onDelete,
+  onBack,
+}: {
+  api: MainWindowAPI
+  name: string
+  onExport: () => void
+  onDelete: () => void
+  onBack: () => void
+}): React.JSX.Element {
+  const [loaded, setLoaded] = useState<TaskFixtureLoad | null>(null)
+  const [draft, setDraft] = useState('')
+  const dirty = loaded !== null && draft !== loaded.goldenMd
+
+  useEffect(() => {
+    void (async () => {
+      const f = await api.evalLoadTaskFixture(name)
+      if (!f) {
+        toast.error('Failed to load golden')
+        return
+      }
+      setLoaded(f)
+      setDraft(f.goldenMd)
+    })()
+  }, [api, name])
+
+  const save = useCallback(async () => {
+    if (!loaded) return
+    const result = await api.evalSaveTaskGolden(loaded.name, draft)
+    if (!result.success) {
+      toast.error(result.error ?? 'Failed to save golden')
+      return
+    }
+    setLoaded({ ...loaded, goldenMd: draft })
+    toast.success('Golden saved')
+  }, [api, loaded, draft])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          <ArrowLeftIcon /> Back
+        </Button>
+        <div className="flex-1 text-sm font-medium">{loaded?.label || name}</div>
+        <Button variant="ghost" size="sm" onClick={onExport}>
+          <ExportIcon /> Export
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onDelete}>
+          <TrashIcon /> Delete
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            golden.md
+          </span>
+          <Button size="sm" onClick={() => void save()} disabled={!dirty}>
+            <FloppyDiskIcon /> Save golden
+          </Button>
+        </div>
+        <Textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          spellCheck={false}
+          className="min-h-[420px] font-mono text-xs leading-relaxed"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/shared/eval-review.ts
+++ b/src/shared/eval-review.ts
@@ -38,3 +38,48 @@ export interface EvalPromoteSummary {
   eventWindowCount: number
   hasVideo: boolean
 }
+
+// ---------------------------------------------------------------------------
+// Task-mining goldens (Developer → Tasks tab)
+// ---------------------------------------------------------------------------
+
+/** A legacy pattern-detection sighting, for the Tasks tab's list. */
+export interface TaskSightingSummary {
+  id: string
+  patternName: string
+  evidence: string
+  apps: string[]
+  activityIds: string[]
+  detectedAt: number
+  /** Earliest start / latest end of the sighting's activities, or null if unresolved. */
+  startedAt: number | null
+  endedAt: number | null
+  activityCount: number
+}
+
+/** A golden.md draft + window preview for a sighting, before promotion. */
+export interface TaskGoldenDraft {
+  name: string
+  goldenMd: string
+  /** Activities that fall inside the noise window. */
+  activityCount: number
+  windowFrom: number
+  windowTo: number
+}
+
+/** One promoted task golden, for the Tasks tab's list. */
+export interface TaskFixtureSummary {
+  name: string
+  label: string
+  sourceDay: string | null
+  activityCount: number
+  /** Epoch ms the fixture was written (manifest mtime). */
+  createdAt: number
+}
+
+/** A task golden loaded for editing. */
+export interface TaskFixtureLoad {
+  name: string
+  label: string
+  goldenMd: string
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,6 +4,10 @@ import type {
   EvalFixtureSummary,
   EvalPromoteSummary,
   EvalRecordingStatus,
+  TaskFixtureLoad,
+  TaskFixtureSummary,
+  TaskGoldenDraft,
+  TaskSightingSummary,
 } from './eval-review'
 
 export interface InteractionContext {
@@ -401,6 +405,27 @@ export interface MainWindowAPI {
   evalSaveGolden: (name: string, markdown: string) => Promise<{ success: boolean; error?: string }>
   evalDeleteFixture: (name: string) => Promise<{ success: boolean; error?: string }>
   evalExportFixture: (name: string) => Promise<{ success: boolean; path?: string; error?: string }>
+  // Task-mining goldens (Developer → Tasks tab)
+  evalListTaskSightings: () => Promise<TaskSightingSummary[]>
+  evalPreviewTaskGolden: (
+    sightingId: string,
+    beforeMin: number,
+    afterMin: number,
+  ) => Promise<TaskGoldenDraft | null>
+  evalPromoteTaskSighting: (
+    sightingId: string,
+    opts: { beforeMin: number; afterMin: number; goldenMd: string; name: string },
+  ) => Promise<{ success: boolean; fixture?: TaskFixtureSummary; error?: string }>
+  evalListTaskFixtures: () => Promise<TaskFixtureSummary[]>
+  evalLoadTaskFixture: (name: string) => Promise<TaskFixtureLoad | null>
+  evalSaveTaskGolden: (
+    name: string,
+    markdown: string,
+  ) => Promise<{ success: boolean; error?: string }>
+  evalDeleteTaskFixture: (name: string) => Promise<{ success: boolean; error?: string }>
+  evalExportTaskFixture: (
+    name: string,
+  ) => Promise<{ success: boolean; path?: string; error?: string }>
   // Host platform (set at preload time; never changes mid-session)
   platform: NodeJS.Platform
 }


### PR DESCRIPTION
## What

Adds a **Tasks** sub-tab to the hidden Developer section for building task-mining eval goldens from real, already-detected sightings — entirely in-app, so a non-technical user can feed evals without the `export-day` CLI or hand-editing markdown.

## Flow

1. **Sightings list** — every legacy pattern-detection sighting (`pattern_sightings`), newest first: pattern name, time, app mix, activity count, evidence snippet.
2. **Click a sighting** → editor with a name field, "minutes before / after" inputs (default ±60) showing a live "N activities in window" count, and an editable `golden.md` prefilled with a `keep` block (pattern title, evidence → description, the sighting's activity IDs, a `Notes:` line for feedback) plus a chronological day reference. **Regenerate** rebuilds the draft after a window change (only when you've edited, so it won't clobber silently).
3. **Promote** → writes a fixture (`activities.jsonl` + `golden.md` + `manifest.json`, schemaVersion 3) to `{userData}/task-fixtures/`.
4. **Goldens list** → edit / **Export** (zip via save dialog) / delete. Exported zips drop into `evals/task-mining/fixtures/` for `npm run eval-tasks`.

Per discussion: source is the **legacy pattern-detection** sightings (the live model), and output goes to **app data + Export zip** (works in a packaged app), mirroring the existing eval recorder.

## Changes

- New shared `task-fixture-build.ts` (extracts `toFixtureActivity` — reused by `export-day` — plus windowed-activity builder and golden renderer).
- `PatternRepository.getAllSightings`, a `TaskFixtureStore` (list/load/save/delete/export/write + name sanitizer).
- 8 `eval*` IPC handlers + preload bindings + `MainWindowAPI` types; `taskFixtureStore` wired through runtime/deps.
- `DeveloperSection` wrapped in Recorder/Tasks sub-tabs; new `TaskGoldenSection`.
- Unit tests for the store and the build helper (windowed selection + golden round-trip through `parseTaskGoldenMd`).

## Notes

- Noise window is clamped to the sighting's local day (the miner scans one day).
- Free-text under `Notes:` folds into the golden description on parse — fine for human feedback.

## Verification

- `npm run lint` (0 errors), `npm run build` clean on top of `main`.
- New unit tests pass; storage + eval suites green.
- Not yet exercised live end-to-end (needs a dev DB with detected sightings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)