### PR TITLE
fix(ui): remove sidebar collapse layout jitter

### DIFF
--- a/src/renderer/pages/main-window/components/CaptureControlSection.tsx
+++ b/src/renderer/pages/main-window/components/CaptureControlSection.tsx
@@ -19,7 +19,7 @@ export function CaptureControlSection({
     <Button
       className="w-full"
       variant={capturing ? 'destructive' : 'default'}
-      size={compact ? 'icon' : 'lg'}
+      size={compact ? 'icon-lg' : 'lg'}
       disabled={toggling}
       onClick={onToggle}
       aria-label={label}

--- a/src/renderer/pages/main-window/components/shell/LlmStatusPanel.tsx
+++ b/src/renderer/pages/main-window/components/shell/LlmStatusPanel.tsx
@@ -64,7 +64,7 @@ export function LlmStatusPanel({
         aria-label={`LLM ${state} — open AI Models settings`}
         title={`${VENDOR_LABELS[vendor]} · ${state}`}
         className={cn(
-          'flex items-center justify-center size-9 rounded-md',
+          'flex items-center justify-center w-full h-9 rounded-md',
           'hover:bg-sidebar-accent/70 transition-colors',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
         )}
@@ -78,7 +78,7 @@ export function LlmStatusPanel({
       type="button"
       onClick={onClick}
       className={cn(
-        'flex items-center gap-2 w-full text-left px-3 py-2 rounded-lg',
+        'flex items-center gap-2 w-full text-left px-3 h-9 rounded-lg',
         'border border-sidebar-border bg-sidebar-accent/40',
         'hover:bg-sidebar-accent/70 transition-colors',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',

--- a/src/renderer/pages/main-window/components/shell/MainShell.tsx
+++ b/src/renderer/pages/main-window/components/shell/MainShell.tsx
@@ -16,7 +16,7 @@ export function MainShell({
     <div className="h-screen flex bg-background antialiased select-none">
       <aside
         className={cn(
-          'shrink-0 flex flex-col bg-sidebar text-sidebar-foreground border-r border-sidebar-border transition-[width] duration-200',
+          'shrink-0 flex flex-col bg-sidebar text-sidebar-foreground border-r border-sidebar-border',
           sidebarCollapsed ? 'w-16' : 'w-56',
         )}
       >

--- a/src/renderer/pages/main-window/components/shell/SidebarNavItem.tsx
+++ b/src/renderer/pages/main-window/components/shell/SidebarNavItem.tsx
@@ -26,7 +26,7 @@ export function SidebarNavItem({
       title={collapsed ? label : undefined}
       className={cn(
         'flex items-center rounded-md text-sm text-left transition-colors',
-        collapsed ? 'justify-center size-9' : 'gap-2.5 w-full px-3 py-1.5',
+        collapsed ? 'justify-center w-full h-9' : 'gap-2.5 w-full px-3 h-9',
         active
           ? 'bg-sidebar-accent text-sidebar-accent-foreground font-medium'
           : 'text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground',

--- a/src/renderer/pages/main-window/components/shell/UpdateBanner.tsx
+++ b/src/renderer/pages/main-window/components/shell/UpdateBanner.tsx
@@ -21,7 +21,7 @@ export function UpdateBanner({
         aria-label="Relaunch to update"
         title={version ? `Relaunch to update · v${version}` : 'Relaunch to update'}
         className={cn(
-          'flex items-center justify-center size-9 rounded-md',
+          'flex items-center justify-center w-full h-9 rounded-md',
           'bg-primary/15 text-primary hover:bg-primary/25 transition-colors',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
         )}


### PR DESCRIPTION
## Summary

Fixes the visual jitter when collapsing/expanding the main-window sidebar. Icons previously shifted both vertically and horizontally, and the capture button's label appeared to slide in.

## Changes

- **Fixed heights** — nav items, the capture button, and the LLM status panel now lock to 36px (`h-9` / `icon-lg`) in both states instead of deriving height from padding, so icons no longer jump vertically on collapse.
- **Centered horizontally** — collapsed nav items, the LLM panel, and the update banner use full-width centered content (`w-full h-9`) instead of a fixed 36px box, so each icon centers on the sidebar's true center and matches the expanded icon position (no horizontal nudge on open).
- **Snap collapse** — removed the sidebar width transition so collapse/expand is instant, which eliminates the centered capture button label sliding during the 200ms width animation.

## Notes

- The active nav item highlight in the collapsed state is now full-column width (40px) rather than a 36px square — a soft rounded rect instead of a perfect square. This was the agreed trade-off for clean centering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)