### PR TITLE
Fixture review: seekable video, two-column layout, interaction events

### DIFF
--- a/src/main/eval/eval-fixture-store.test.ts
+++ b/src/main/eval/eval-fixture-store.test.ts
@@ -67,6 +67,59 @@ describe('EvalFixtureStore', () => {
     expect(noVideo?.videoUrl).toBeNull()
   })
 
+  it('loads interaction events grouped by window, anchored to the first frame', () => {
+    writeFixture('alpha')
+    const dir = path.join(root, 'alpha')
+    // Earliest frame is the session-clock zero; events offset from it.
+    fs.writeFileSync(
+      path.join(dir, 'frames.jsonl'),
+      [
+        JSON.stringify({ filepath: 'frames/f2.png', timestamp: T0 + 5_000 }),
+        JSON.stringify({ filepath: 'frames/f1.png', timestamp: T0 + 1_000 }),
+      ].join('\n'),
+      'utf8',
+    )
+    fs.writeFileSync(
+      path.join(dir, 'event-windows.jsonl'),
+      [
+        JSON.stringify({
+          id: 'w1',
+          startTimestamp: T0 + 1_000,
+          endTimestamp: T0 + 4_000,
+          closedBy: 'gap',
+          events: [
+            { type: 'presence', timestamp: T0 + 1_000 },
+            {
+              type: 'click',
+              timestamp: T0 + 3_000,
+              activeWindow: { title: 'github.com', processName: 'Chrome' },
+            },
+            { type: 'keyboard', timestamp: T0 + 2_000, keyCount: 45 },
+          ],
+        }),
+      ].join('\n'),
+      'utf8',
+    )
+
+    const loaded = store.load('alpha')
+    expect(loaded?.eventWindows).toHaveLength(1)
+    const w = loaded!.eventWindows[0]
+    expect(w.closedBy).toBe('gap')
+    expect(w.startOffsetMs).toBe(0) // T0+1000 - sessionStart(T0+1000)
+    expect(w.endOffsetMs).toBe(3_000)
+    expect(w.appLabel).toBe('Chrome — github.com')
+    // Presence dropped; remaining sorted by timestamp; text matches the prompt formatter.
+    expect(w.events).toEqual([
+      { offsetMs: 1_000, type: 'keyboard', text: 'typing session (45 keys)' },
+      { offsetMs: 2_000, type: 'click', text: 'mouse click' },
+    ])
+  })
+
+  it('returns [] event windows when the file is absent', () => {
+    writeFixture('alpha')
+    expect(store.load('alpha')?.eventWindows).toEqual([])
+  })
+
   it('returns null when loading a missing fixture', () => {
     expect(store.load('nope')).toBeNull()
   })

--- a/src/main/eval/eval-fixture-store.ts
+++ b/src/main/eval/eval-fixture-store.ts
@@ -10,8 +10,11 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as yazl from 'yazl'
 import log from '../logger'
-import type { FixtureManifest } from './types'
-import type { EvalFixtureLoad, EvalFixtureSummary } from '../../shared/eval-review'
+import type { DumpedFrame, FixtureManifest } from './types'
+import type { EvalEventWindow, EvalFixtureLoad, EvalFixtureSummary } from '../../shared/eval-review'
+import type { EventWindow, InteractionContext } from '../../shared/types'
+import { readJsonl } from './jsonl'
+import { describeInteraction } from '../semantic/prompt'
 import { evalMediaUrl } from './eval-media-protocol'
 
 /** Staging dir for in-progress recordings — never listed as a fixture. */
@@ -68,7 +71,52 @@ export class EvalFixtureStore {
     const hasVideo = fs.existsSync(path.join(dir, 'session.mp4'))
     const videoUrl = hasVideo ? evalMediaUrl(path.basename(name)) : null
 
-    return { name: path.basename(name), label: manifest.label, goldenMd, videoUrl }
+    const eventWindows = this.loadEventWindows(dir)
+
+    return { name: path.basename(name), label: manifest.label, goldenMd, videoUrl, eventWindows }
+  }
+
+  /**
+   * Reads `event-windows.jsonl` into a display-ready, window-grouped timeline.
+   * Offsets anchor to the same session-start clock as the video and golden mm:ss
+   * (min frame timestamp, falling back to the earliest window start), so the
+   * review UI lines up across all three columns. Presence heartbeats are
+   * synthetic keep-alives with no user-action signal, so they're dropped — same
+   * as the model's prompt timeline.
+   */
+  private loadEventWindows(dir: string): EvalEventWindow[] {
+    const windowsPath = path.join(dir, 'event-windows.jsonl')
+    if (!fs.existsSync(windowsPath)) return []
+    const windows = readJsonl<EventWindow>(windowsPath)
+    if (windows.length === 0) return []
+
+    const sessionStartMs = this.sessionStartMs(dir, windows)
+    return windows.map((w) => {
+      const events = w.events
+        .filter((e) => e.type !== 'presence')
+        .sort((a, b) => a.timestamp - b.timestamp)
+      return {
+        startOffsetMs: w.startTimestamp - sessionStartMs,
+        endOffsetMs: w.endTimestamp - sessionStartMs,
+        closedBy: w.closedBy,
+        appLabel: appLabelOf(events),
+        events: events.map((e) => ({
+          offsetMs: e.timestamp - sessionStartMs,
+          type: e.type,
+          text: describeInteraction(e),
+        })),
+      }
+    })
+  }
+
+  /** Video/golden clock zero: earliest frame timestamp, else earliest window. */
+  private sessionStartMs(dir: string, windows: EventWindow[]): number {
+    const framesPath = path.join(dir, 'frames.jsonl')
+    if (fs.existsSync(framesPath)) {
+      const frames = readJsonl<DumpedFrame>(framesPath)
+      if (frames.length > 0) return Math.min(...frames.map((f) => f.timestamp))
+    }
+    return Math.min(...windows.map((w) => w.startTimestamp))
   }
 
   saveGolden(name: string, markdown: string): void {
@@ -113,4 +161,11 @@ export class EvalFixtureStore {
     })
     log.info(`[EvalFixtureStore] Exported "${name}" (${files.length} files) -> ${destPath}`)
   }
+}
+
+/** First app/window context in a window, as "processName — title" (or null). */
+function appLabelOf(events: InteractionContext[]): string | null {
+  const win = events.find((e) => e.activeWindow)?.activeWindow
+  if (!win) return null
+  return win.title ? `${win.processName} — ${win.title}` : win.processName
 }

--- a/src/main/eval/eval-media-protocol.ts
+++ b/src/main/eval/eval-media-protocol.ts
@@ -2,18 +2,19 @@
  * Streams eval fixture videos to the renderer. A base64 `data:` URL in a
  * `<video>` fails in Electron — media playback needs HTTP range requests for
  * seeking, which `data:` URLs can't serve — so we register a privileged
- * `mlmedia://` scheme and stream `session.mp4` off disk via `net.fetch`, which
- * honors Range requests (206 partial content) for free.
+ * `mlmedia://` scheme and stream `session.mp4` off disk, serving Range
+ * requests as 206 partial content ourselves (Electron's `net.fetch` over
+ * `file://` ignores Range and returns the whole file, which breaks seeking).
  *
  * URL shape: `mlmedia://eval/<fixtureName>/session.mp4`. The fixture name is the
  * only variable; we `basename()` it and confine the served path to the fixtures
  * root, so the scheme can never read outside `{userData}/eval-fixtures`.
  */
 
-import { protocol, net } from 'electron'
+import { protocol } from 'electron'
 import * as fs from 'fs'
 import * as path from 'path'
-import { pathToFileURL } from 'url'
+import { Readable } from 'stream'
 
 export const EVAL_MEDIA_SCHEME = 'mlmedia'
 
@@ -55,10 +56,43 @@ export function registerEvalMediaProtocol(fixturesRoot: string): void {
       if (!filePath.startsWith(root + path.sep) || !fs.existsSync(filePath)) {
         return new Response('Not found', { status: 404 })
       }
-      // Forward the Range header so seeking yields 206 partial content.
-      const range = request.headers.get('range')
-      return net.fetch(pathToFileURL(filePath).toString(), {
-        headers: range ? { range } : undefined,
+
+      const size = fs.statSync(filePath).size
+      const toWebBody = (start: number, end: number): ReadableStream =>
+        Readable.toWeb(fs.createReadStream(filePath, { start, end })) as ReadableStream
+
+      // Serve Range requests as 206 partial content so the <video> can seek.
+      const rangeHeader = request.headers.get('range')
+      const match = rangeHeader && /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim())
+      if (match) {
+        let start = match[1] ? parseInt(match[1], 10) : 0
+        let end = match[2] ? parseInt(match[2], 10) : size - 1
+        if (Number.isNaN(start)) start = 0
+        if (Number.isNaN(end) || end >= size) end = size - 1
+        if (start > end || start >= size) {
+          return new Response(null, {
+            status: 416,
+            headers: { 'Content-Range': `bytes */${size}` },
+          })
+        }
+        return new Response(toWebBody(start, end), {
+          status: 206,
+          headers: {
+            'Content-Type': 'video/mp4',
+            'Content-Length': String(end - start + 1),
+            'Content-Range': `bytes ${start}-${end}/${size}`,
+            'Accept-Ranges': 'bytes',
+          },
+        })
+      }
+
+      return new Response(toWebBody(0, size - 1), {
+        status: 200,
+        headers: {
+          'Content-Type': 'video/mp4',
+          'Content-Length': String(size),
+          'Accept-Ranges': 'bytes',
+        },
       })
     } catch {
       return new Response('Bad request', { status: 400 })

--- a/src/main/semantic/prompt.ts
+++ b/src/main/semantic/prompt.ts
@@ -96,7 +96,7 @@ function buildInteractionTimeline(activity: Activity): string {
   return items.join('\n')
 }
 
-function describeInteraction(interaction: InteractionContext): string {
+export function describeInteraction(interaction: InteractionContext): string {
   switch (interaction.type) {
     case 'app_change': {
       const processName = interaction.activeWindow?.processName ?? 'unknown app'

--- a/src/renderer/pages/main-window/components/advanced-settings/DeveloperSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/DeveloperSection.tsx
@@ -276,34 +276,34 @@ function FixtureReview({
           <ArrowLeftIcon /> Back
         </Button>
         <div className="text-sm font-medium">{fixture.label || fixture.name}</div>
+        <Button className="ml-auto" size="sm" onClick={onSave} disabled={!dirty}>
+          <FloppyDiskIcon /> Save golden
+        </Button>
       </div>
 
+      {/* Video on top (kept small), then events + golden.md as scrollable columns. */}
+      <Card>
+        <CardContent className="flex justify-center p-3">
+          {fixture.videoUrl ? (
+            <video
+              ref={videoRef}
+              src={fixture.videoUrl}
+              controls
+              className="max-h-[40vh] w-auto rounded-md bg-black"
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">No video for this fixture.</p>
+          )}
+        </CardContent>
+      </Card>
+
       <div className="grid grid-cols-2 gap-4 items-start">
-        {/* Video sticks in view while the golden.md editor scrolls beside it. */}
-        <Card className="sticky top-2 self-start">
-          <CardContent className="p-3">
-            {fixture.videoUrl ? (
-              <video
-                ref={videoRef}
-                src={fixture.videoUrl}
-                controls
-                className="w-full rounded-md bg-black"
-              />
-            ) : (
-              <p className="text-sm text-muted-foreground">No video for this fixture.</p>
-            )}
-          </CardContent>
-        </Card>
+        <EventTimeline windows={fixture.eventWindows} />
 
         <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              golden.md
-            </span>
-            <Button size="sm" onClick={onSave} disabled={!dirty}>
-              <FloppyDiskIcon /> Save golden
-            </Button>
-          </div>
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            golden.md
+          </span>
           <Textarea
             value={goldenDraft}
             onChange={(e) => onGoldenChange(e.target.value)}
@@ -311,6 +311,60 @@ function FixtureReview({
             className="h-[70vh] resize-none overflow-auto font-mono text-xs leading-relaxed"
           />
         </div>
+      </div>
+    </div>
+  )
+}
+
+/** m:ss from a ms offset — same shape as golden.md timestamps. */
+function formatOffset(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000))
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+/** Read-only timeline of captured interaction events, grouped by EventWindow. */
+function EventTimeline({
+  windows,
+}: {
+  windows: EvalFixtureLoad['eventWindows']
+}): React.JSX.Element {
+  return (
+    <div className="space-y-2">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        events
+      </span>
+      <div className="h-[70vh] overflow-auto rounded-md border p-3 font-mono text-xs leading-relaxed">
+        {windows.length === 0 ? (
+          <p className="text-muted-foreground">No interaction events.</p>
+        ) : (
+          windows.map((w, i) => (
+            <div key={i} className="mb-3 last:mb-0">
+              <div className="flex items-baseline gap-2">
+                <span className="font-medium">
+                  {formatOffset(w.startOffsetMs)} → {formatOffset(w.endOffsetMs)}
+                </span>
+                {w.appLabel && <span className="truncate text-muted-foreground">{w.appLabel}</span>}
+                <span className="ml-auto text-[10px] uppercase text-muted-foreground/70">
+                  {w.closedBy}
+                </span>
+              </div>
+              {w.events.length === 0 ? (
+                <div className="pl-2 text-muted-foreground">(no events)</div>
+              ) : (
+                w.events.map((e, j) => (
+                  <div key={j} className="flex gap-2 pl-2">
+                    <span className="shrink-0 text-muted-foreground">
+                      {formatOffset(e.offsetMs)}
+                    </span>
+                    <span>{e.text}</span>
+                  </div>
+                ))
+              )}
+            </div>
+          ))
+        )}
       </div>
     </div>
   )

--- a/src/renderer/pages/main-window/components/advanced-settings/DeveloperSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/DeveloperSection.tsx
@@ -278,36 +278,39 @@ function FixtureReview({
         <div className="text-sm font-medium">{fixture.label || fixture.name}</div>
       </div>
 
-      <Card>
-        <CardContent className="p-3">
-          {fixture.videoUrl ? (
-            <video
-              ref={videoRef}
-              src={fixture.videoUrl}
-              controls
-              className="w-full rounded-md bg-black"
-            />
-          ) : (
-            <p className="text-sm text-muted-foreground">No video for this fixture.</p>
-          )}
-        </CardContent>
-      </Card>
+      <div className="grid grid-cols-2 gap-4 items-start">
+        {/* Video sticks in view while the golden.md editor scrolls beside it. */}
+        <Card className="sticky top-2 self-start">
+          <CardContent className="p-3">
+            {fixture.videoUrl ? (
+              <video
+                ref={videoRef}
+                src={fixture.videoUrl}
+                controls
+                className="w-full rounded-md bg-black"
+              />
+            ) : (
+              <p className="text-sm text-muted-foreground">No video for this fixture.</p>
+            )}
+          </CardContent>
+        </Card>
 
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            golden.md
-          </span>
-          <Button size="sm" onClick={onSave} disabled={!dirty}>
-            <FloppyDiskIcon /> Save golden
-          </Button>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              golden.md
+            </span>
+            <Button size="sm" onClick={onSave} disabled={!dirty}>
+              <FloppyDiskIcon /> Save golden
+            </Button>
+          </div>
+          <Textarea
+            value={goldenDraft}
+            onChange={(e) => onGoldenChange(e.target.value)}
+            spellCheck={false}
+            className="h-[70vh] resize-none overflow-auto font-mono text-xs leading-relaxed"
+          />
         </div>
-        <Textarea
-          value={goldenDraft}
-          onChange={(e) => onGoldenChange(e.target.value)}
-          spellCheck={false}
-          className="min-h-[420px] font-mono text-xs leading-relaxed"
-        />
       </div>
     </div>
   )

--- a/src/shared/eval-review.ts
+++ b/src/shared/eval-review.ts
@@ -4,6 +4,8 @@
  * of any `src/main` imports so the renderer's tsconfig can compile it.
  */
 
+import type { EventWindow, InteractionContext } from './types'
+
 export interface EvalRecordingStatus {
   recording: boolean
   name: string | null
@@ -22,6 +24,26 @@ export interface EvalFixtureSummary {
   hasVideo: boolean
 }
 
+/** One captured interaction, formatted for display. Offsets anchor to the
+ *  video/golden clock zero (session start). */
+export interface EvalEvent {
+  /** ms from session start (same zero as the video and golden mm:ss offsets). */
+  offsetMs: number
+  type: InteractionContext['type']
+  /** Human text, identical to what the model's prompt timeline shows. */
+  text: string
+}
+
+/** One EventWindow's interactions, grouped for the review timeline. */
+export interface EvalEventWindow {
+  startOffsetMs: number
+  endOffsetMs: number
+  closedBy: EventWindow['closedBy']
+  /** App/window context for the window (e.g. "Chrome — github.com"), or null. */
+  appLabel: string | null
+  events: EvalEvent[]
+}
+
 /** A fixture loaded for review: the editable golden + the review video. */
 export interface EvalFixtureLoad {
   name: string
@@ -29,6 +51,8 @@ export interface EvalFixtureLoad {
   goldenMd: string
   /** `mlmedia://` URL streaming `session.mp4` off disk (seekable), or null. */
   videoUrl: string | null
+  /** Captured interaction events, window-grouped; `[]` when none on disk. */
+  eventWindows: EvalEventWindow[]
 }
 
 /** Result of stopping a recording (the freshly promoted fixture). */


### PR DESCRIPTION
## What

Improvements to the Developer-tab eval **fixture review** UI (video + `golden.md` editor), so reviewers can author goldens with the full picture.

### 1. Seekable review video
The `mlmedia://` handler forwarded the `Range` header to `net.fetch` over a `file://` URL and trusted it to return `206`. Electron's `net.fetch` ignores Range on `file://` and returns the whole file with `200` and no `Accept-Ranges`, so the `<video>` couldn't seek. Now serves range requests manually: streams the requested byte slice as `206` with `Content-Range`/`Content-Length`/`Accept-Ranges` (and `416` for unsatisfiable ranges).

### 2. Show captured interaction events beside golden.md
Each fixture already stores `event-windows.jsonl` — the same raw input the LLM's prompt is built from. `EvalFixtureStore.load()` now parses it into a window-grouped, display-ready timeline anchored to the same session-start clock as the video and golden `mm:ss` offsets. Presence heartbeats are dropped and event text reuses the prompt's `describeInteraction` formatter, so what reviewers see matches what the model sees. This lets them judge whether a golden summary is fair — i.e. whether the model actually had enough signal.

### 3. Layout
Video on top (kept small), then **events** and **golden.md** as independently scrollable columns; **Save golden** moved to the header.

## Test
- Extended `eval-fixture-store.test.ts`: asserts window grouping, presence dropped, offsets anchored to the earliest frame, text via `describeInteraction`, `appLabel`, and the empty-file case. 8/8 pass.
- Typecheck + lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)