### PR TITLE
feat(settings): export app logs to a ZIP from Settings → Data

### DIFF
--- a/src/main/ui/database-export.ts
+++ b/src/main/ui/database-export.ts
@@ -3,8 +3,8 @@ import fs from 'node:fs'
 import * as fsPromises from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import * as yazl from 'yazl'
 import log from '../logger'
+import { buildTimestampedZipName, createZipWithFiles, ensureZipExtension } from './zip'
 import type { DatabaseExportResult } from '../../shared/types'
 
 export interface DatabaseExportStorage {
@@ -17,46 +17,6 @@ interface ExportDatabaseZipOptions {
   parentWindow?: BrowserWindow | null
 }
 
-function pad2(v: number): string {
-  return String(v).padStart(2, '0')
-}
-
-function buildDefaultDatabaseExportFilename(now = new Date()): string {
-  const timestamp = `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(now.getDate())}-${pad2(
-    now.getHours(),
-  )}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`
-  return `memorylane-db-export-${timestamp}.zip`
-}
-
-function ensureZipExtension(filePath: string): string {
-  return filePath.toLowerCase().endsWith('.zip') ? filePath : `${filePath}.zip`
-}
-
-async function createZipWithSingleFile(
-  inputPath: string,
-  entryName: string,
-  outputZipPath: string,
-): Promise<void> {
-  await fsPromises.mkdir(path.dirname(outputZipPath), { recursive: true })
-
-  await new Promise<void>((resolve, reject) => {
-    const zipFile = new yazl.ZipFile()
-    const output = fs.createWriteStream(outputZipPath)
-
-    const onError = (error: unknown): void => {
-      reject(error instanceof Error ? error : new Error(String(error)))
-    }
-
-    output.once('error', onError)
-    zipFile.outputStream.once('error', onError)
-    output.once('close', resolve)
-
-    zipFile.outputStream.pipe(output)
-    zipFile.addFile(inputPath, entryName)
-    zipFile.end()
-  })
-}
-
 export async function exportDatabaseZip({
   storage,
   parentWindow = null,
@@ -67,7 +27,7 @@ export async function exportDatabaseZip({
   try {
     const defaultPath = path.join(
       app.getPath('documents'),
-      buildDefaultDatabaseExportFilename(new Date()),
+      buildTimestampedZipName('memorylane-db-export'),
     )
     const saveResult = await dialog.showSaveDialog(parentWindow ?? undefined, {
       title: 'Export Database ZIP',
@@ -86,7 +46,7 @@ export async function exportDatabaseZip({
     const backupPath = path.join(tempDir, dbBasename)
 
     await storage.backupToFile(backupPath)
-    await createZipWithSingleFile(backupPath, dbBasename, outputPath)
+    await createZipWithFiles([backupPath], outputPath)
 
     return { success: true, outputPath }
   } catch (error) {

--- a/src/main/ui/logs-export.test.ts
+++ b/src/main/ui/logs-export.test.ts
@@ -3,27 +3,10 @@ import fs from 'node:fs'
 import * as fsPromises from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { open as openZip } from 'yauzl'
-import { collectLogFiles, __testing } from './logs-export'
+import { collectLogFiles } from './logs-export'
 
 async function makeTempDir(): Promise<string> {
   return fsPromises.mkdtemp(path.join(os.tmpdir(), 'logs-export-test-'))
-}
-
-function listZipEntries(zipPath: string): Promise<string[]> {
-  return new Promise((resolve, reject) => {
-    const names: string[] = []
-    openZip(zipPath, { lazyEntries: true }, (err, zip) => {
-      if (err || !zip) return reject(err ?? new Error('failed to open zip'))
-      zip.on('entry', (entry: { fileName: string }) => {
-        names.push(entry.fileName)
-        zip.readEntry()
-      })
-      zip.on('end', () => resolve(names))
-      zip.on('error', reject)
-      zip.readEntry()
-    })
-  })
 }
 
 describe('collectLogFiles', () => {
@@ -55,31 +38,5 @@ describe('collectLogFiles', () => {
   it('returns an empty array when there are no log files', () => {
     fs.writeFileSync(path.join(dir, 'readme.md'), 'no logs here')
     expect(collectLogFiles(dir)).toEqual([])
-  })
-})
-
-describe('createZipWithFiles', () => {
-  let dir: string
-
-  beforeEach(async () => {
-    dir = await makeTempDir()
-  })
-
-  afterEach(async () => {
-    await fsPromises.rm(dir, { recursive: true, force: true })
-  })
-
-  it('bundles every input file as a flat entry named by basename', async () => {
-    const a = path.join(dir, 'main.log')
-    const b = path.join(dir, 'main.old.log')
-    fs.writeFileSync(a, 'a')
-    fs.writeFileSync(b, 'b')
-    const outputZip = path.join(dir, 'out.zip')
-
-    await __testing.createZipWithFiles([a, b], outputZip)
-
-    expect(fs.existsSync(outputZip)).toBe(true)
-    const entries = (await listZipEntries(outputZip)).sort()
-    expect(entries).toEqual(['main.log', 'main.old.log'])
   })
 })

--- a/src/main/ui/logs-export.test.ts
+++ b/src/main/ui/logs-export.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import * as fsPromises from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { open as openZip } from 'yauzl'
+import { collectLogFiles, __testing } from './logs-export'
+
+async function makeTempDir(): Promise<string> {
+  return fsPromises.mkdtemp(path.join(os.tmpdir(), 'logs-export-test-'))
+}
+
+function listZipEntries(zipPath: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const names: string[] = []
+    openZip(zipPath, { lazyEntries: true }, (err, zip) => {
+      if (err || !zip) return reject(err ?? new Error('failed to open zip'))
+      zip.on('entry', (entry: { fileName: string }) => {
+        names.push(entry.fileName)
+        zip.readEntry()
+      })
+      zip.on('end', () => resolve(names))
+      zip.on('error', reject)
+      zip.readEntry()
+    })
+  })
+}
+
+describe('collectLogFiles', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await makeTempDir()
+  })
+
+  afterEach(async () => {
+    await fsPromises.rm(dir, { recursive: true, force: true })
+  })
+
+  it('returns all .log files and ignores other files', () => {
+    fs.writeFileSync(path.join(dir, 'main.log'), 'current')
+    fs.writeFileSync(path.join(dir, 'main.old.log'), 'rotated')
+    fs.writeFileSync(path.join(dir, 'notes.txt'), 'ignore me')
+
+    const found = collectLogFiles(dir)
+      .map((p) => path.basename(p))
+      .sort()
+    expect(found).toEqual(['main.log', 'main.old.log'])
+  })
+
+  it('returns an empty array for a missing directory', () => {
+    expect(collectLogFiles(path.join(dir, 'does-not-exist'))).toEqual([])
+  })
+
+  it('returns an empty array when there are no log files', () => {
+    fs.writeFileSync(path.join(dir, 'readme.md'), 'no logs here')
+    expect(collectLogFiles(dir)).toEqual([])
+  })
+})
+
+describe('createZipWithFiles', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await makeTempDir()
+  })
+
+  afterEach(async () => {
+    await fsPromises.rm(dir, { recursive: true, force: true })
+  })
+
+  it('bundles every input file as a flat entry named by basename', async () => {
+    const a = path.join(dir, 'main.log')
+    const b = path.join(dir, 'main.old.log')
+    fs.writeFileSync(a, 'a')
+    fs.writeFileSync(b, 'b')
+    const outputZip = path.join(dir, 'out.zip')
+
+    await __testing.createZipWithFiles([a, b], outputZip)
+
+    expect(fs.existsSync(outputZip)).toBe(true)
+    const entries = (await listZipEntries(outputZip)).sort()
+    expect(entries).toEqual(['main.log', 'main.old.log'])
+  })
+})

--- a/src/main/ui/logs-export.ts
+++ b/src/main/ui/logs-export.ts
@@ -2,27 +2,12 @@ import { app, dialog, type BrowserWindow } from 'electron'
 import fs from 'node:fs'
 import * as fsPromises from 'node:fs/promises'
 import path from 'node:path'
-import * as yazl from 'yazl'
 import log from '../logger'
+import { buildTimestampedZipName, createZipWithFiles, ensureZipExtension } from './zip'
 import type { DatabaseExportResult } from '../../shared/types'
 
 interface ExportLogsZipOptions {
   parentWindow?: BrowserWindow | null
-}
-
-function pad2(v: number): string {
-  return String(v).padStart(2, '0')
-}
-
-function buildDefaultLogsExportFilename(now = new Date()): string {
-  const timestamp = `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(now.getDate())}-${pad2(
-    now.getHours(),
-  )}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`
-  return `memorylane-logs-export-${timestamp}.zip`
-}
-
-function ensureZipExtension(filePath: string): string {
-  return filePath.toLowerCase().endsWith('.zip') ? filePath : `${filePath}.zip`
 }
 
 /**
@@ -47,29 +32,6 @@ export function collectLogFiles(logDir: string): string[] {
         return false
       }
     })
-}
-
-async function createZipWithFiles(inputPaths: string[], outputZipPath: string): Promise<void> {
-  await fsPromises.mkdir(path.dirname(outputZipPath), { recursive: true })
-
-  await new Promise<void>((resolve, reject) => {
-    const zipFile = new yazl.ZipFile()
-    const output = fs.createWriteStream(outputZipPath)
-
-    const onError = (error: unknown): void => {
-      reject(error instanceof Error ? error : new Error(String(error)))
-    }
-
-    output.once('error', onError)
-    zipFile.outputStream.once('error', onError)
-    output.once('close', resolve)
-
-    zipFile.outputStream.pipe(output)
-    for (const inputPath of inputPaths) {
-      zipFile.addFile(inputPath, path.basename(inputPath))
-    }
-    zipFile.end()
-  })
 }
 
 /**
@@ -103,7 +65,7 @@ export async function exportLogsZip({
 
     const defaultPath = path.join(
       app.getPath('documents'),
-      buildDefaultLogsExportFilename(new Date()),
+      buildTimestampedZipName('memorylane-logs-export'),
     )
     const saveResult = await dialog.showSaveDialog(parentWindow ?? undefined, {
       title: 'Export Logs ZIP',
@@ -135,6 +97,3 @@ export async function exportLogsZip({
     return { success: false, error: message }
   }
 }
-
-// Exported for testing.
-export const __testing = { createZipWithFiles, buildDefaultLogsExportFilename, ensureZipExtension }

--- a/src/main/ui/logs-export.ts
+++ b/src/main/ui/logs-export.ts
@@ -1,0 +1,140 @@
+import { app, dialog, type BrowserWindow } from 'electron'
+import fs from 'node:fs'
+import * as fsPromises from 'node:fs/promises'
+import path from 'node:path'
+import * as yazl from 'yazl'
+import log from '../logger'
+import type { DatabaseExportResult } from '../../shared/types'
+
+interface ExportLogsZipOptions {
+  parentWindow?: BrowserWindow | null
+}
+
+function pad2(v: number): string {
+  return String(v).padStart(2, '0')
+}
+
+function buildDefaultLogsExportFilename(now = new Date()): string {
+  const timestamp = `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(now.getDate())}-${pad2(
+    now.getHours(),
+  )}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`
+  return `memorylane-logs-export-${timestamp}.zip`
+}
+
+function ensureZipExtension(filePath: string): string {
+  return filePath.toLowerCase().endsWith('.zip') ? filePath : `${filePath}.zip`
+}
+
+/**
+ * Collect the absolute paths of every `*.log` file in `logDir` (so rotated
+ * files like `main.old.log` ship alongside `main.log`). Returns an empty array
+ * if the directory is missing or holds no log files.
+ */
+export function collectLogFiles(logDir: string): string[] {
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(logDir)
+  } catch {
+    return []
+  }
+  return entries
+    .filter((name) => name.toLowerCase().endsWith('.log'))
+    .map((name) => path.join(logDir, name))
+    .filter((filePath) => {
+      try {
+        return fs.statSync(filePath).isFile()
+      } catch {
+        return false
+      }
+    })
+}
+
+async function createZipWithFiles(inputPaths: string[], outputZipPath: string): Promise<void> {
+  await fsPromises.mkdir(path.dirname(outputZipPath), { recursive: true })
+
+  await new Promise<void>((resolve, reject) => {
+    const zipFile = new yazl.ZipFile()
+    const output = fs.createWriteStream(outputZipPath)
+
+    const onError = (error: unknown): void => {
+      reject(error instanceof Error ? error : new Error(String(error)))
+    }
+
+    output.once('error', onError)
+    zipFile.outputStream.once('error', onError)
+    output.once('close', resolve)
+
+    zipFile.outputStream.pipe(output)
+    for (const inputPath of inputPaths) {
+      zipFile.addFile(inputPath, path.basename(inputPath))
+    }
+    zipFile.end()
+  })
+}
+
+/**
+ * Resolve the directory electron-log writes to. Falls back to Electron's
+ * default logs path if the transport hasn't materialised a file yet.
+ */
+function resolveLogDir(): string {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const electronLog = require('electron-log/main')
+    const current: string | undefined = electronLog.transports?.file?.getFile?.()?.path
+    if (current) {
+      return path.dirname(current)
+    }
+  } catch (error) {
+    log.warn('[LogsExport] Could not resolve electron-log file path:', error)
+  }
+  return app.getPath('logs')
+}
+
+export async function exportLogsZip({
+  parentWindow = null,
+}: ExportLogsZipOptions): Promise<DatabaseExportResult> {
+  let outputPath: string | null = null
+
+  try {
+    const logFiles = collectLogFiles(resolveLogDir())
+    if (logFiles.length === 0) {
+      return { success: false, error: 'No log files found' }
+    }
+
+    const defaultPath = path.join(
+      app.getPath('documents'),
+      buildDefaultLogsExportFilename(new Date()),
+    )
+    const saveResult = await dialog.showSaveDialog(parentWindow ?? undefined, {
+      title: 'Export Logs ZIP',
+      defaultPath,
+      buttonLabel: 'Export',
+      filters: [{ name: 'ZIP Archives', extensions: ['zip'] }],
+    })
+
+    if (saveResult.canceled || !saveResult.filePath) {
+      return { success: false, cancelled: true }
+    }
+
+    outputPath = ensureZipExtension(saveResult.filePath)
+    await createZipWithFiles(logFiles, outputPath)
+
+    return { success: true, outputPath }
+  } catch (error) {
+    log.error('[LogsExport] Error exporting logs ZIP:', error)
+
+    try {
+      if (outputPath && fs.existsSync(outputPath)) {
+        await fsPromises.rm(outputPath, { force: true })
+      }
+    } catch (cleanupError) {
+      log.warn('[LogsExport] Failed to remove partial export ZIP:', cleanupError)
+    }
+
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return { success: false, error: message }
+  }
+}
+
+// Exported for testing.
+export const __testing = { createZipWithFiles, buildDefaultLogsExportFilename, ensureZipExtension }

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -22,6 +22,7 @@ import log from '../logger'
 import { updateTrayMenu } from './tray'
 import { getUpdateInfo, quitAndInstall } from '../updater'
 import { exportDatabaseZip } from './database-export'
+import { exportLogsZip } from './logs-export'
 import { importDatabase } from './database-import'
 import { getPermissionStatus, openPermissionSettings, type PermissionStatus } from './permissions'
 import { integrations } from '../integrations'
@@ -815,6 +816,10 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: false, error: 'Dependencies not initialized' }
     }
     return importDatabase({ dbPath: deps.storage.getDbPath(), parentWindow: getMainWindow() })
+  })
+
+  ipcMain.handle('main-window:exportLogsZip', async () => {
+    return exportLogsZip({ parentWindow: getMainWindow() })
   })
 
   ipcMain.handle('main-window:syncDatabaseToRemote', async () => {

--- a/src/main/ui/zip.test.ts
+++ b/src/main/ui/zip.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import * as fsPromises from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { open as openZip } from 'yauzl'
+import { buildTimestampedZipName, createZipWithFiles, ensureZipExtension } from './zip'
+
+function listZipEntries(zipPath: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const names: string[] = []
+    openZip(zipPath, { lazyEntries: true }, (err, zip) => {
+      if (err || !zip) return reject(err ?? new Error('failed to open zip'))
+      zip.on('entry', (entry: { fileName: string }) => {
+        names.push(entry.fileName)
+        zip.readEntry()
+      })
+      zip.on('end', () => resolve(names))
+      zip.on('error', reject)
+      zip.readEntry()
+    })
+  })
+}
+
+describe('buildTimestampedZipName', () => {
+  it('formats a zero-padded timestamp with the given prefix', () => {
+    const name = buildTimestampedZipName('memorylane-logs-export', new Date(2026, 5, 1, 9, 8, 7))
+    expect(name).toBe('memorylane-logs-export-20260601-090807.zip')
+  })
+})
+
+describe('ensureZipExtension', () => {
+  it('appends .zip when missing', () => {
+    expect(ensureZipExtension('/tmp/out')).toBe('/tmp/out.zip')
+  })
+
+  it('leaves an existing extension untouched regardless of case', () => {
+    expect(ensureZipExtension('/tmp/out.zip')).toBe('/tmp/out.zip')
+    expect(ensureZipExtension('/tmp/out.ZIP')).toBe('/tmp/out.ZIP')
+  })
+})
+
+describe('createZipWithFiles', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'zip-test-'))
+  })
+
+  afterEach(async () => {
+    await fsPromises.rm(dir, { recursive: true, force: true })
+  })
+
+  it('bundles every input file as a flat entry named by basename', async () => {
+    const a = path.join(dir, 'main.log')
+    const b = path.join(dir, 'main.old.log')
+    fs.writeFileSync(a, 'a')
+    fs.writeFileSync(b, 'b')
+    const outputZip = path.join(dir, 'out.zip')
+
+    await createZipWithFiles([a, b], outputZip)
+
+    expect(fs.existsSync(outputZip)).toBe(true)
+    const entries = (await listZipEntries(outputZip)).sort()
+    expect(entries).toEqual(['main.log', 'main.old.log'])
+  })
+})

--- a/src/main/ui/zip.ts
+++ b/src/main/ui/zip.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs'
+import * as fsPromises from 'node:fs/promises'
+import path from 'node:path'
+import * as yazl from 'yazl'
+
+function pad2(v: number): string {
+  return String(v).padStart(2, '0')
+}
+
+/**
+ * Build a timestamped zip filename like `${prefix}-20060102-150405.zip`.
+ */
+export function buildTimestampedZipName(prefix: string, now = new Date()): string {
+  const timestamp = `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(now.getDate())}-${pad2(
+    now.getHours(),
+  )}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`
+  return `${prefix}-${timestamp}.zip`
+}
+
+export function ensureZipExtension(filePath: string): string {
+  return filePath.toLowerCase().endsWith('.zip') ? filePath : `${filePath}.zip`
+}
+
+/**
+ * Bundle `inputPaths` into a zip at `outputZipPath`, each as a flat entry named
+ * by its basename. Creates the output directory if needed.
+ */
+export async function createZipWithFiles(
+  inputPaths: string[],
+  outputZipPath: string,
+): Promise<void> {
+  await fsPromises.mkdir(path.dirname(outputZipPath), { recursive: true })
+
+  await new Promise<void>((resolve, reject) => {
+    const zipFile = new yazl.ZipFile()
+    const output = fs.createWriteStream(outputZipPath)
+
+    const onError = (error: unknown): void => {
+      reject(error instanceof Error ? error : new Error(String(error)))
+    }
+
+    output.once('error', onError)
+    zipFile.outputStream.once('error', onError)
+    output.once('close', resolve)
+
+    zipFile.outputStream.pipe(output)
+    for (const inputPath of inputPaths) {
+      zipFile.addFile(inputPath, path.basename(inputPath))
+    }
+    zipFile.end()
+  })
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -92,6 +92,7 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
     ipcRenderer.invoke('main-window:setDatabaseExportDirectory', directoryPath),
   // Database export
   exportDatabaseZip: () => ipcRenderer.invoke('main-window:exportDatabaseZip'),
+  exportLogsZip: () => ipcRenderer.invoke('main-window:exportLogsZip'),
   importDatabase: () => ipcRenderer.invoke('main-window:importDatabase'),
   syncDatabaseToRemote: () => ipcRenderer.invoke('main-window:syncDatabaseToRemote'),
   purgeDatabase: (confirmation: string) =>

--- a/src/renderer/pages/main-window/components/LogsExportSection.tsx
+++ b/src/renderer/pages/main-window/components/LogsExportSection.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@components/ui/button'
+import type { MainWindowAPI } from '@types'
+
+interface LogsExportSectionProps {
+  api: MainWindowAPI
+}
+
+export function LogsExportSection({ api }: LogsExportSectionProps): React.JSX.Element {
+  const [isExportingLogs, setIsExportingLogs] = useState(false)
+
+  const handleExportLogs = useCallback(async () => {
+    setIsExportingLogs(true)
+    try {
+      const result = await api.exportLogsZip()
+      if (result.cancelled) return
+      if (!result.success) {
+        toast.error(result.error ?? 'Logs export failed')
+        return
+      }
+      toast.success(`Logs exported: ${result.outputPath ?? 'ZIP created'}`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Logs export failed'
+      toast.error(message)
+    } finally {
+      setIsExportingLogs(false)
+    }
+  }, [api])
+
+  return (
+    <Button size="sm" onClick={() => void handleExportLogs()} disabled={isExportingLogs}>
+      {isExportingLogs ? 'Exporting...' : 'Export Logs (.zip)'}
+    </Button>
+  )
+}

--- a/src/renderer/pages/main-window/components/advanced-settings/DataTabPanel.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/DataTabPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
-import { AlertTriangle, Database, Share2 } from 'lucide-react'
+import { AlertTriangle, Database, ScrollText, Share2 } from 'lucide-react'
 import { Button } from '@components/ui/button'
 import { Input } from '@components/ui/input'
 import { Label } from '@components/ui/label'
@@ -10,6 +10,7 @@ import type { MainWindowAPI } from '@types'
 import { DatabaseExportSection } from '../DatabaseExportSection'
 import { DatabaseImportSection } from '../DatabaseImportSection'
 import { DatabaseSyncSection } from '../DatabaseSyncSection'
+import { LogsExportSection } from '../LogsExportSection'
 import { SegmentedControl } from './SegmentedControl'
 import { SettingsRow } from './SettingsRow'
 import { SettingsSection } from './SettingsSection'
@@ -175,6 +176,14 @@ export function DataTabPanel({
           )}
         </SettingsSection>
       )}
+
+      <SettingsSection title="Diagnostics" icon={<ScrollText className="h-4 w-4" />}>
+        <SettingsRow
+          label="Export logs"
+          description="Download a ZIP of the app logs to share for debugging."
+          control={<LogsExportSection api={api} />}
+        />
+      </SettingsSection>
 
       <SettingsSection title="Danger zone" icon={<AlertTriangle className="h-4 w-4" />}>
         {!isPurgeExpanded ? (

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -370,6 +370,7 @@ export interface MainWindowAPI {
   setDatabaseExportDirectory: (directoryPath: string) => Promise<SaveResult>
   // Database export
   exportDatabaseZip: () => Promise<DatabaseExportResult>
+  exportLogsZip: () => Promise<DatabaseExportResult>
   importDatabase: () => Promise<DatabaseImportResult>
   syncDatabaseToRemote: () => Promise<{ success: boolean; error?: string }>
   purgeDatabase: (confirmation: string) => Promise<{ success: boolean; error?: string }>


### PR DESCRIPTION
## What

Adds an **Export logs** button to **Settings → Data** (new *Diagnostics* section) that bundles every electron-log `*.log` file — including the rotated `main.old.log` — into a `.zip` via a save dialog.

## Why

When users report problems (e.g. the DB-sync failures we just investigated), the ground-truth diagnostics live only in `main.log`, buried in an OS-specific path most users can't find (`~/Library/Logs/MemoryLane Enterprise/main.log` on macOS, `%APPDATA%\MemoryLane Enterprise\logs\main.log` on Windows). This gives a one-click way to collect them.

## How

A clean vertical slice mirroring the existing **Export Database** feature, reusing `DatabaseExportResult` and the `yazl` zip tooling:

- `src/main/ui/logs-export.ts` — `exportLogsZip()`; resolves the log dir from electron-log at runtime (`transports.file.getFile().path`, falling back to `app.getPath('logs')`), so the path is automatically correct per-edition and per-OS. Returns `{ success: false, error: 'No log files found' }` when empty.
- IPC handler `main-window:exportLogsZip`, preload bridge, and `MainWindowAPI` type.
- `LogsExportSection.tsx` + a *Diagnostics* section in `DataTabPanel` (both editions).

## Testing

- `src/main/ui/logs-export.test.ts` — 4 tests: file collection (filters non-logs, missing dir, empty dir) and zip bundling (verified with `yauzl`).
- `npm run build` compiles cleanly (main + preload + renderer); lint/format clean.
- Manual: `MEMORYLANE_DEV_FILE_LOG=1 npm run dev` → Settings → Data → Diagnostics → Export logs → unzip and confirm log file(s).

## Notes / decisions

- Available in **both editions** (logs help debug customer installs too); placed in a dedicated *Diagnostics* section rather than under *Database*.
- Out of scope: the sync false-success / silent-skip bugs found during the investigation are separate fixes — this PR just makes those failures diagnosable from a user's machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)