### PR TITLE
chore(logging): cut interaction noise, add high-value signal

### DIFF
--- a/src/main/access/customer-access-provider.ts
+++ b/src/main/access/customer-access-provider.ts
@@ -202,9 +202,15 @@ export class CustomerAccessProvider extends BaseAccessProvider {
     }
 
     if (!response.ok) {
-      const bodyExcerpt = await response.text().catch(() => '')
+      // Only a structured (JSON) error body carries signal. HTML error pages —
+      // e.g. a backend 404 "Page not found" — are noise, so for those we log
+      // just the status + content-type rather than dumping a slab of markup.
+      const contentType = response.headers?.get('content-type') ?? ''
+      const bodyExcerpt = contentType.includes('json')
+        ? `: ${(await response.text().catch(() => '')).slice(0, 200)}`
+        : ''
       log.warn(
-        `[CustomerAccess] /v2/subscription/key returned ${response.status} for device ${deviceIdHint}: ${bodyExcerpt.slice(0, 200)}`,
+        `[CustomerAccess] /v2/subscription/key returned ${response.status} (${contentType || 'no content-type'}) for device ${deviceIdHint}${bodyExcerpt}`,
       )
       if (response.status === 401 || response.status === 403) {
         return { kind: 'no_key' }

--- a/src/main/activity-cleanup.ts
+++ b/src/main/activity-cleanup.ts
@@ -36,6 +36,7 @@ export function cleanupActivityFiles(activity: Activity, videoOutputDir: string)
 export function sweepStaleFiles(outputDir: string): void {
   const now = Date.now()
   let deleted = 0
+  let skipped = 0
   try {
     for (const file of fs.readdirSync(outputDir)) {
       if (!file.endsWith('.png') && !file.endsWith('.jpg') && !file.endsWith('.mp4')) continue
@@ -46,11 +47,14 @@ export function sweepStaleFiles(outputDir: string): void {
           deleted++
         }
       } catch {
-        // ignore per-file errors
+        skipped++
       }
     }
   } catch (err) {
     log.warn('[ActivityCleanup] File cleanup sweep failed:', err)
   }
   if (deleted > 0) log.info(`[ActivityCleanup] Swept ${deleted} stale file(s)`)
+  if (skipped > 0) {
+    log.warn(`[ActivityCleanup] Skipped ${skipped} file(s) during sweep (stat/unlink failed)`)
+  }
 }

--- a/src/main/activity-producer.ts
+++ b/src/main/activity-producer.ts
@@ -197,7 +197,7 @@ export class ActivityProducer {
     const windowContext = this.deriveWindowContext(window.events)
     if (windowContext === null) {
       this.stats.droppedUnknownContextWindows++
-      log.info(
+      log.debug(
         `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: unknown app context`,
       )
       this.config.onActivityDropped?.({
@@ -214,7 +214,7 @@ export class ActivityProducer {
     const candidateFrames = this.getFramesInRange(window.startTimestamp, window.endTimestamp)
     if (candidateFrames.length === 0) {
       this.stats.droppedNoFrameWindows++
-      log.info(
+      log.debug(
         `[ActivityProducer] Dropping window ${window.id} at offset ${record.offset}: no frames in ${window.startTimestamp}-${window.endTimestamp}`,
       )
       this.config.onActivityDropped?.({
@@ -378,7 +378,7 @@ export class ActivityProducer {
     this.pendingActivity = null
 
     if (durationMs < this.config.minActivityDurationMs) {
-      log.info(
+      log.debug(
         `[ActivityProducer] Dropping short activity ${activityToEmit.id} (${durationMs}ms < ${this.config.minActivityDurationMs}ms, reason: ${reason})`,
       )
       this.config.onActivityDropped?.({
@@ -430,7 +430,7 @@ export class ActivityProducer {
         (offset) => !droppedOffsets.has(offset),
       )
       this.stats.trailingFramesTrimmed += framesToDrop.length
-      log.info(
+      log.debug(
         `[ActivityProducer] Trimmed ${framesToDrop.length} trailing boundary frame(s) from activity ${activity.id} (${activity.context.appName}, reason: ${reason}): ${framesToDrop.map((f) => f.frame.filepath).join(', ')}`,
       )
     } catch (err) {

--- a/src/main/capture-orchestrator.ts
+++ b/src/main/capture-orchestrator.ts
@@ -39,7 +39,7 @@ export function createCaptureCoordinator(params: {
       params.captureStateManager.setCaptureEnabled(enabled)
       return true
     } catch (error) {
-      log.error('[Main] Failed to persist capture preference:', error)
+      log.error(`[Main] Failed to persist capture preference (enabled=${enabled}):`, error)
       return false
     }
   }

--- a/src/main/event-capturer.ts
+++ b/src/main/event-capturer.ts
@@ -281,7 +281,7 @@ export class EventCapturer {
       closedBy: pendingWindow.closedBy,
     }
 
-    log.info(
+    log.debug(
       `[EventCapturer] Window closed (${window.closedBy}): ${window.events.length} events, ` +
         `${window.endTimestamp - window.startTimestamp}ms`,
     )

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -340,6 +340,8 @@ app.on('ready', async () => {
     },
   })
 
-  log.info(`[Startup] Running ${editionConfig.edition} edition`)
+  log.info(
+    `[Startup] MemoryLane v${app.getVersion()} (${editionConfig.edition} edition, ${app.isPackaged ? 'packaged' : 'dev'})`,
+  )
   log.info('MemoryLane started. Frame output dir:', runtime.capture.getScreenshotsDir())
 })

--- a/src/main/logger-electron.ts
+++ b/src/main/logger-electron.ts
@@ -5,7 +5,11 @@ import { setLogger } from './logger'
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const electronLog = require('electron-log/main')
 const isDev = !app.isPackaged
-const level = isDev ? 'debug' : 'info'
+// Dev logs at debug, packaged at info. Override with MEMORYLANE_LOG_LEVEL to
+// simulate the production filter locally — e.g. `MEMORYLANE_LOG_LEVEL=info
+// npm run dev` raises the console (and the dev file, when MEMORYLANE_DEV_FILE_LOG
+// is also set) to the prod stream, so you can see what packaged builds record.
+const level = process.env.MEMORYLANE_LOG_LEVEL ?? (isDev ? 'debug' : 'info')
 
 // File logging is normally off in dev (console is primary). Enable it when
 // debugging the pipeline so the run's logs — including otherwise console-only

--- a/src/main/mcp/server.ts
+++ b/src/main/mcp/server.ts
@@ -130,10 +130,10 @@ export class MemoryLaneMCPServer {
 
     if (!fs.existsSync(resolvedPath)) {
       // Just a warning, not an error - database might be created on first write
-      log.error(`Warning: Database path does not exist: ${resolvedPath}`)
+      log.warn(`Database path does not exist: ${resolvedPath}`)
     }
 
-    log.error(`Initializing services with DB path: ${resolvedPath}`)
+    log.info(`Initializing services with DB path: ${resolvedPath}`)
 
     const storage = new StorageService(resolvedPath)
 
@@ -143,7 +143,7 @@ export class MemoryLaneMCPServer {
 
     this.services = { storage, embeddingService }
     this.editionContext = { ...this.editionContext, currentDbPath: resolvedPath }
-    log.error('Services initialized successfully')
+    log.info('Services initialized successfully')
   }
 
   /**
@@ -169,7 +169,7 @@ export class MemoryLaneMCPServer {
     const transport = new StdioServerTransport(process.stdin, stdout ?? process.stdout)
     await this.server.connect(transport)
 
-    log.error(`${SERVER_NAME} MCP server started`)
+    log.info(`${SERVER_NAME} MCP server started`)
   }
 
   /**
@@ -180,8 +180,8 @@ export class MemoryLaneMCPServer {
     if (this.services) {
       try {
         this.services.storage.close()
-      } catch {
-        // ignore close errors
+      } catch (err) {
+        log.warn('Failed to close storage during MCP reinitialization:', err)
       }
     }
     this.services = null

--- a/src/main/pipeline-harness.ts
+++ b/src/main/pipeline-harness.ts
@@ -132,8 +132,10 @@ export function createPipelineHarness(params: {
         cleanupTimer = setInterval(() => {
           if (!retainScreenshots) sweepStaleFiles(params.outputDir)
         }, SCREENSHOT_CLEANUP_CONFIG.CLEANUP_INTERVAL_MS)
+        log.info('[PipelineHarness] Pipeline started')
       } catch (error) {
         running = false
+        log.error('[PipelineHarness] Failed to start pipeline:', error)
         throw error
       }
     },
@@ -151,6 +153,7 @@ export function createPipelineHarness(params: {
         await activityExtractor.stop()
       }
       eventCapturer.destroy()
+      log.info('[PipelineHarness] Pipeline stopped')
     },
     handleEvent(event: InteractionContext) {
       if (event.type === 'app_change' && event.displayId !== undefined) {

--- a/src/main/recorder/interaction-monitor.ts
+++ b/src/main/recorder/interaction-monitor.ts
@@ -157,9 +157,9 @@ const clickSession = new DebouncedSession(
       displayId: undefined,
     }),
     hasActivity: (accumulation) => accumulation.count > 0,
-    onStart: () => log.info('[Interaction Monitor] Click session started'),
+    onStart: () => log.debug('[Interaction Monitor] Click session started'),
     emit: (accumulation, subWindowStart, lastEventTime) => {
-      log.info(
+      log.debug(
         `[Interaction Monitor] Click session: ${accumulation.count} clicks over ${lastEventTime - subWindowStart}ms`,
       )
       notifyInteraction({
@@ -178,9 +178,9 @@ const typingSession = new DebouncedSession(
   {
     initialAccumulation: () => ({ keyCount: 0 }),
     hasActivity: (accumulation) => accumulation.keyCount > 0,
-    onStart: () => log.info('[Interaction Monitor] Typing session started'),
+    onStart: () => log.debug('[Interaction Monitor] Typing session started'),
     emit: (accumulation, subWindowStart, lastEventTime) => {
-      log.info(
+      log.debug(
         `[Interaction Monitor] Typing session: ${accumulation.keyCount} keys over ${lastEventTime - subWindowStart}ms`,
       )
       notifyInteraction({
@@ -211,9 +211,9 @@ const scrollSession = new DebouncedSession(
       direction: 'vertical',
     }),
     hasActivity: (accumulation) => accumulation.eventCount > 0,
-    onStart: () => log.info('[Interaction Monitor] Scroll session started'),
+    onStart: () => log.debug('[Interaction Monitor] Scroll session started'),
     emit: (accumulation, subWindowStart, lastEventTime) => {
-      log.info(
+      log.debug(
         `[Interaction Monitor] Scroll session: ${accumulation.amount} rotation over ${lastEventTime - subWindowStart}ms`,
       )
       notifyInteraction({
@@ -333,7 +333,7 @@ function handleAppWatcherEvent(event: AppWatcherEvent): void {
   cachedWindowTitle = current.title
   cachedDisplayId = resolvedDisplayId
 
-  log.info(
+  log.debug(
     `[Interaction Monitor] App changed from ${previousWindow?.processName ?? '(none)'} to ${current.processName}`,
   )
 
@@ -452,7 +452,7 @@ export function stopInteractionMonitoring(): void {
  */
 export function onInteraction(callback: OnInteractionCallback): void {
   interactionCallbacks.push(callback)
-  log.info(`[Interaction Monitor] Callback registered (total: ${interactionCallbacks.length})`)
+  log.debug(`[Interaction Monitor] Callback registered (total: ${interactionCallbacks.length})`)
 }
 
 /**
@@ -466,7 +466,7 @@ export function clearInteractionCallback(callback: OnInteractionCallback): void 
     return
   }
   interactionCallbacks.splice(interactionCallbacks.indexOf(callback), 1)
-  log.info(`[Interaction Monitor] Callback removed (total: ${interactionCallbacks.length})`)
+  log.debug(`[Interaction Monitor] Callback removed (total: ${interactionCallbacks.length})`)
 }
 
 /**

--- a/src/main/recorder/native-screenshot.ts
+++ b/src/main/recorder/native-screenshot.ts
@@ -145,9 +145,10 @@ export class ScreenshotDaemon implements ScreenCaptureBackend {
       const msg = chunk.toString().trim()
       if (!msg) return
       // The daemon uses stderr for all diagnostics, including normal lifecycle
-      // chatter ("Stream started"). Only surface genuine problems at warn; the
-      // rest is debug. Hard crashes still surface via the 'close'/'error' handlers.
-      if (/fail|error|invalid|dropped/i.test(msg)) {
+      // chatter ("Stream started") and routine frame drops under load. Only
+      // surface genuine problems at warn; the rest is debug. Hard crashes still
+      // surface via the 'close'/'error' handlers.
+      if (/fail|error|invalid/i.test(msg)) {
         log.warn(`[ScreenshotDaemon:stderr] ${msg}`)
       } else {
         log.debug(`[ScreenshotDaemon:stderr] ${msg}`)

--- a/src/main/recorder/native-screenshot.ts
+++ b/src/main/recorder/native-screenshot.ts
@@ -143,8 +143,14 @@ export class ScreenshotDaemon implements ScreenCaptureBackend {
 
     proc.stderr?.on('data', (chunk) => {
       const msg = chunk.toString().trim()
-      if (msg) {
+      if (!msg) return
+      // The daemon uses stderr for all diagnostics, including normal lifecycle
+      // chatter ("Stream started"). Only surface genuine problems at warn; the
+      // rest is debug. Hard crashes still surface via the 'close'/'error' handlers.
+      if (/fail|error|invalid|dropped/i.test(msg)) {
         log.warn(`[ScreenshotDaemon:stderr] ${msg}`)
+      } else {
+        log.debug(`[ScreenshotDaemon:stderr] ${msg}`)
       }
     })
 

--- a/src/main/semantic/service.ts
+++ b/src/main/semantic/service.ts
@@ -477,10 +477,16 @@ export class ActivitySemanticService implements SemanticServiceContract {
 
   private recordLlmSuccess(): void {
     const now = Date.now()
+    const recoveredFrom = this.llmHealth.consecutiveFailures
     this.llmHealth.consecutiveFailures = 0
     this.llmHealth.lastError = null
     this.llmHealth.lastAttemptAt = now
     this.llmHealth.lastSuccessAt = now
+    if (recoveredFrom > 0) {
+      log.info(
+        `[ActivitySemanticService] LLM recovered after ${recoveredFrom} consecutive failure(s)`,
+      )
+    }
   }
 
   private updateLlmHealthFromDiagnostics(diagnostics: SemanticRunDiagnostics): void {
@@ -491,10 +497,15 @@ export class ActivitySemanticService implements SemanticServiceContract {
       return
     }
 
+    const wasHealthy = this.llmHealth.consecutiveFailures === 0
     const lastFailure = actionableFailures[actionableFailures.length - 1]
     this.llmHealth.consecutiveFailures += 1
     this.llmHealth.lastError = lastFailure?.error ?? 'Unknown LLM error'
     this.llmHealth.lastAttemptAt = Date.now()
+    // Log only the passing→failing transition; per-request failures would be noise.
+    if (wasHealthy) {
+      log.warn(`[ActivitySemanticService] LLM started failing: ${this.llmHealth.lastError}`)
+    }
   }
 
   private async runConnectionTest(): Promise<void> {

--- a/src/main/storage/migrator.ts
+++ b/src/main/storage/migrator.ts
@@ -32,6 +32,7 @@ export function runMigrations(db: Database.Database): void {
   const appliedRows = db.prepare('SELECT name FROM schema_migrations').all() as { name: string }[]
   const applied = new Set(appliedRows.map((r) => r.name))
 
+  let appliedCount = 0
   for (const migration of migrations) {
     if (applied.has(migration.name)) continue
 
@@ -44,6 +45,13 @@ export function runMigrations(db: Database.Database): void {
       )
     })()
     log.info(`Migration applied: ${migration.name}`)
+    appliedCount++
+  }
+
+  if (appliedCount > 0) {
+    log.info(`Database schema: applied ${appliedCount} migration(s), now at ${migrations.length}`)
+  } else {
+    log.debug(`Database schema up to date (${migrations.length} migrations)`)
   }
 }
 

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -390,7 +390,7 @@ function logCaptureSettingsChanges(previous: CaptureSettings, updated: CaptureSe
   for (const field of scalarFields) {
     if (previous[field] !== updated[field]) {
       log.info(
-        `[settings] user changed ${field}: ${String(previous[field])} → ${String(updated[field])}`,
+        `[Settings] user changed ${field}: ${String(previous[field])} → ${String(updated[field])}`,
       )
     }
   }
@@ -403,7 +403,7 @@ function logCaptureSettingsChanges(previous: CaptureSettings, updated: CaptureSe
     const before = previous[field] as string[]
     const after = updated[field] as string[]
     if (JSON.stringify(before) !== JSON.stringify(after)) {
-      log.info(`[settings] user changed ${field}: ${before.length} → ${after.length} entries`)
+      log.info(`[Settings] user changed ${field}: ${before.length} → ${after.length} entries`)
     }
   }
 }
@@ -534,10 +534,10 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     }
 
     if (deps.capture.isCapturingNow()) {
-      log.info('[settings] user stopped capture')
+      log.info('[Settings] user stopped capture')
       deps.capture.requestStopCapture()
     } else {
-      log.info('[settings] user started capture')
+      log.info('[Settings] user started capture')
       deps.capture.requestStartCapture()
     }
 
@@ -613,7 +613,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       deps.captureSettingsManager.setActiveVendor(vendor)
       applyVendorSwitch(deps, deps.captureSettingsManager.get())
       if (previousVendor !== vendor) {
-        log.info(`[settings] user changed active vendor: ${previousVendor} → ${vendor}`)
+        log.info(`[Settings] user changed active vendor: ${previousVendor} → ${vendor}`)
       }
       return { success: true }
     } catch (error) {

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -364,12 +364,76 @@ async function buildStats(): Promise<MainWindowStats> {
 }
 
 /**
+ * Log user-initiated capture-settings changes as a concise per-field timeline.
+ * Only fields that actually changed are logged; arrays are reported by entry
+ * count so a single line stays readable. High-signal, low-frequency — exactly
+ * the breadcrumbs needed when debugging "why did X stop working".
+ */
+function logCaptureSettingsChanges(previous: CaptureSettings, updated: CaptureSettings): void {
+  const scalarFields: (keyof CaptureSettings)[] = [
+    'autoStartEnabled',
+    'visualThreshold',
+    'maxScreenshotsForLlm',
+    'minActivityDurationMs',
+    'maxActivityDurationMs',
+    'semanticRequestTimeoutMs',
+    'semanticPipelineMode',
+    'captureHotkeyAccelerator',
+    'excludePrivateBrowsing',
+    'activeVendor',
+    'semanticVideoModel',
+    'semanticSnapshotModel',
+    'patternDetectionModel',
+    'patternDetectionEnabled',
+    'uploadDetailLevel',
+  ]
+  for (const field of scalarFields) {
+    if (previous[field] !== updated[field]) {
+      log.info(
+        `[settings] user changed ${field}: ${String(previous[field])} → ${String(updated[field])}`,
+      )
+    }
+  }
+  const arrayFields: (keyof CaptureSettings)[] = [
+    'excludedApps',
+    'excludedWindowTitlePatterns',
+    'excludedUrlPatterns',
+  ]
+  for (const field of arrayFields) {
+    const before = previous[field] as string[]
+    const after = updated[field] as string[]
+    if (JSON.stringify(before) !== JSON.stringify(after)) {
+      log.info(`[settings] user changed ${field}: ${before.length} → ${after.length} entries`)
+    }
+  }
+}
+
+/**
  * Initialize IPC handlers for the main window
  */
 export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
   deps = dependencies
 
   log.info('[MainWindow] Initializing IPC handlers...')
+
+  // Wrap an IPC handler so an otherwise-silent throw/rejection is logged in the
+  // main process before it propagates to the renderer as a rejected invoke().
+  // Use for handlers that don't already shape errors into their own
+  // { success, error } result.
+  const handle = (
+    channel: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fn: (event: IpcMainInvokeEvent, ...args: any[]) => unknown,
+  ): void => {
+    ipcMain.handle(channel, async (event, ...args) => {
+      try {
+        return await fn(event, ...args)
+      } catch (error) {
+        log.error(`[MainWindow] IPC '${channel}' failed:`, error)
+        throw error
+      }
+    })
+  }
 
   ipcMain.handle(
     'main-window:getEditionConfig',
@@ -387,7 +451,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     }
     return deps.accessProvider.getAccessState()
   })
-  ipcMain.handle('main-window:refreshAccessState', async () => {
+  handle('main-window:refreshAccessState', async () => {
     if (!deps) {
       return {
         edition: DEFAULT_EDITION,
@@ -413,6 +477,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
         return { success: true }
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Activation failed'
+        log.warn('[MainWindow] Enterprise license activation failed:', error)
         return { success: false, error: message }
       }
     },
@@ -437,6 +502,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Consent request failed'
+      log.warn(`[MainWindow] Consent decision (${outcome}) failed:`, error)
       return { success: false, error: message }
     }
   })
@@ -455,11 +521,11 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     }
   })
 
-  ipcMain.handle('main-window:getStatus', () => {
+  handle('main-window:getStatus', () => {
     return buildStatus()
   })
 
-  ipcMain.handle('main-window:toggleCapture', () => {
+  handle('main-window:toggleCapture', () => {
     if (!deps) {
       return {
         capturing: false,
@@ -468,8 +534,10 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     }
 
     if (deps.capture.isCapturingNow()) {
+      log.info('[settings] user stopped capture')
       deps.capture.requestStopCapture()
     } else {
+      log.info('[settings] user started capture')
       deps.capture.requestStartCapture()
     }
 
@@ -528,6 +596,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
+      log.warn(`[MainWindow] Failed to delete credentials for ${vendor}:`, error)
       return { success: false, error: message }
     }
   })
@@ -540,11 +609,16 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: false, error: `Unknown vendor: ${vendor}` }
     }
     try {
+      const previousVendor = deps.captureSettingsManager.get().activeVendor
       deps.captureSettingsManager.setActiveVendor(vendor)
       applyVendorSwitch(deps, deps.captureSettingsManager.get())
+      if (previousVendor !== vendor) {
+        log.info(`[settings] user changed active vendor: ${previousVendor} → ${vendor}`)
+      }
       return { success: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
+      log.warn(`[MainWindow] Failed to set active vendor to ${vendor}:`, error)
       return { success: false, error: message }
     }
   })
@@ -575,7 +649,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     return deps.semanticService.getLlmHealthStatus()
   })
 
-  ipcMain.handle('main-window:testLlmConnection', async () => {
+  handle('main-window:testLlmConnection', async () => {
     if (!deps) return
     await deps.semanticService.testConnection()
   })
@@ -627,28 +701,28 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     }
   })
 
-  ipcMain.handle('main-window:startCheckout', async (_event, plan: SubscriptionPlan) => {
+  handle('main-window:startCheckout', async (_event, plan: SubscriptionPlan) => {
     if (!deps) return
     await deps.accessProvider.startCheckout(plan)
   })
 
-  ipcMain.handle('main-window:openSubscriptionPortal', async () => {
+  handle('main-window:openSubscriptionPortal', async () => {
     if (!deps) return
     await deps.accessProvider.openSubscriptionPortal()
   })
 
-  ipcMain.handle('main-window:getSubscriptionStatus', () => {
+  handle('main-window:getSubscriptionStatus', () => {
     if (!deps) return 'idle'
     return deps.accessProvider.getAccessState().customerSubscriptionStatus ?? 'idle'
   })
 
   // Patterns
-  ipcMain.handle('main-window:getPatterns', () => {
+  handle('main-window:getPatterns', () => {
     if (!deps) return []
     return deps.storage.patterns.getAllPatterns()
   })
 
-  ipcMain.handle('main-window:getPatternDetail', (_event: IpcMainInvokeEvent, id: string) => {
+  handle('main-window:getPatternDetail', (_event: IpcMainInvokeEvent, id: string) => {
     if (!deps) return null
     const detail = deps.storage.patterns.getPatternDetail(id)
     if (!detail) return null
@@ -692,6 +766,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
+      log.warn(`[MainWindow] Failed to approve pattern ${id}:`, error)
       return { success: false, error: message }
     }
   })
@@ -703,6 +778,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
+      log.warn(`[MainWindow] Failed to reject pattern ${id}:`, error)
       return { success: false, error: message }
     }
   })
@@ -714,6 +790,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
+      log.warn(`[MainWindow] Failed to complete pattern ${id}:`, error)
       return { success: false, error: message }
     }
   })
@@ -725,6 +802,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       return { success: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
+      log.warn(`[MainWindow] Failed to uncomplete pattern ${id}:`, error)
       return { success: false, error: message }
     }
   })
@@ -909,6 +987,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
         deps.captureSettingsManager.save(sanitized)
         deps.captureSettingsManager.applyToConstants()
         const updated = deps.captureSettingsManager.get()
+        logCaptureSettingsChanges(previous, updated)
         syncAutoStartSetting(updated.autoStartEnabled)
         deps.capture.updateActivityWindowConfig({
           minActivityDurationMs: updated.minActivityDurationMs,


### PR DESCRIPTION
## Why

The production log file was dominated by per-interaction noise (typing/click/scroll sessions, window-closed, activity drops) emitted at `info`, while genuinely useful events (startup state, capture lifecycle, migrations) and many failure paths were missing, mis-leveled, or silently swallowed. Goal: make the `info`+ stream read as a high-signal timeline of what the app did and what went wrong, keeping verbose interaction detail under `debug` (dev / `DEBUG_PIPELINE`).

Scope is **main process only** — no renderer logger/bridge, no log-call deletions. Noise is handled purely by lowering levels (the prod file filter is `info`, so `debug` is dropped but stays available in dev).

## Changes

- **Demote noise to `debug`** — typing/click/scroll sessions, app-changed, callback register/remove (`interaction-monitor.ts`); "Window closed…" (`event-capturer.ts`); drop/short/trim lines (`activity-producer.ts`).
- **Fix wrong-level logs** — MCP startup success messages were `log.error` → now `info`/`warn` (`mcp/server.ts`). Verified safe: the standalone stdio entry redirects stdout→stderr, so this can't corrupt the JSON-RPC channel.
- **Wrap silently-rejecting async IPC handlers** — a local `handle()` wrapper logs + rethrows, applied to the previously-unwrapped handlers in `main-window.ts` (`testLlmConnection`, `startCheckout`, `openSubscriptionPortal`, `getStatus`, `toggleCapture`, `getPatterns`, etc.).
- **Log swallowed failures** — capture-state persist (now includes the value), file-sweep skip count, MCP storage-close, and the license/consent/credentials/vendor + pattern-mutation handlers.
- **Lifecycle one-liners** — app **version**+edition at boot, migration count, pipeline start/stop, and **transition-only** LLM health (passing↔failing; no per-request noise).
- **User-action logging** at the IPC layer — "user started/stopped capture", vendor switch, and a per-field capture-settings diff (`from → to`, incl. sync detail level and model fields). Never logs secrets; first-launch defaults don't emit "user changed…" because logging lives at the handler, not the settings manager.

## Verification

- `npm run lint` (0 errors), `npm run format:check` (clean), `npm run test` (825 passed, 33 integration skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up (second commit)

Two more sources of log noise/wrong-level, found from a live log:

- **CustomerAccess HTML body dump** — a non-OK `/v2/subscription/key` response logged a 200-char excerpt of *any* body, so a backend HTML 404 "Page not found" page dumped a slab of markup. Now the excerpt is only included for JSON bodies; otherwise we log just status + content-type.
- **ScreenshotDaemon stderr** — was forwarded wholesale at `warn`, but the Swift daemon writes normal lifecycle messages ("Stream started") to stderr too. Now error-ish lines go to `warn` and the rest to `debug`; hard crashes still surface via the close/error handlers.
