### PR TITLE
fix(logs-export): snapshot log files to avoid yazl byte-count crash

### DIFF
--- a/src/main/ui/logs-export.ts
+++ b/src/main/ui/logs-export.ts
@@ -79,7 +79,9 @@ export async function exportLogsZip({
     }
 
     outputPath = ensureZipExtension(saveResult.filePath)
-    await createZipWithFiles(logFiles, outputPath)
+    // Snapshot: the active log file is appended to while we zip, and yazl's
+    // streaming addFile would throw on the resulting size mismatch.
+    await createZipWithFiles(logFiles, outputPath, { snapshot: true })
 
     return { success: true, outputPath }
   } catch (error) {

--- a/src/main/ui/zip.test.ts
+++ b/src/main/ui/zip.test.ts
@@ -22,6 +22,26 @@ function listZipEntries(zipPath: string): Promise<string[]> {
   })
 }
 
+function readZipEntry(zipPath: string, entryName: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    openZip(zipPath, { lazyEntries: true }, (err, zip) => {
+      if (err || !zip) return reject(err ?? new Error('failed to open zip'))
+      zip.on('entry', (entry: { fileName: string }) => {
+        if (entry.fileName !== entryName) return zip.readEntry()
+        zip.openReadStream(entry, (streamErr, stream) => {
+          if (streamErr || !stream) return reject(streamErr ?? new Error('failed to read entry'))
+          const chunks: Buffer[] = []
+          stream.on('data', (c: Buffer) => chunks.push(c))
+          stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+          stream.on('error', reject)
+        })
+      })
+      zip.on('error', reject)
+      zip.readEntry()
+    })
+  })
+}
+
 describe('buildTimestampedZipName', () => {
   it('formats a zero-padded timestamp with the given prefix', () => {
     const name = buildTimestampedZipName('memorylane-logs-export', new Date(2026, 5, 1, 9, 8, 7))
@@ -63,5 +83,29 @@ describe('createZipWithFiles', () => {
     expect(fs.existsSync(outputZip)).toBe(true)
     const entries = (await listZipEntries(outputZip)).sort()
     expect(entries).toEqual(['main.log', 'main.old.log'])
+  })
+
+  it('snapshot mode bundles file contents without streaming from disk', async () => {
+    const a = path.join(dir, 'main.log')
+    fs.writeFileSync(a, 'log line one\nlog line two\n')
+    const outputZip = path.join(dir, 'out.zip')
+
+    await createZipWithFiles([a], outputZip, { snapshot: true })
+
+    expect(await listZipEntries(outputZip)).toEqual(['main.log'])
+    expect(await readZipEntry(outputZip, 'main.log')).toBe('log line one\nlog line two\n')
+  })
+
+  it('snapshot mode captures bytes at call time even if the file is appended afterwards', async () => {
+    const a = path.join(dir, 'main.log')
+    fs.writeFileSync(a, 'before')
+    const outputZip = path.join(dir, 'out.zip')
+
+    await createZipWithFiles([a], outputZip, { snapshot: true })
+    // A concurrent writer (e.g. the logger) grows the file; the already-written
+    // zip must still hold exactly the snapshot bytes, never a corrupt size.
+    fs.appendFileSync(a, 'AFTER-APPEND')
+
+    expect(await readZipEntry(outputZip, 'main.log')).toBe('before')
   })
 })

--- a/src/main/ui/zip.ts
+++ b/src/main/ui/zip.ts
@@ -21,6 +21,20 @@ export function ensureZipExtension(filePath: string): string {
   return filePath.toLowerCase().endsWith('.zip') ? filePath : `${filePath}.zip`
 }
 
+export interface CreateZipOptions {
+  /**
+   * Read each input fully into memory and add it as a buffer instead of
+   * streaming from disk. yazl's streaming `addFile` stats the file for its
+   * size up front and then throws "file data stream has unexpected number of
+   * bytes" if the file grows while it's being read. That happens for files
+   * being written concurrently — e.g. the active app log, which the logger
+   * keeps appending to during an export. Snapshotting sidesteps the race at
+   * the cost of buffering, so use it only for small, live files (not large
+   * static ones like a database backup).
+   */
+  snapshot?: boolean
+}
+
 /**
  * Bundle `inputPaths` into a zip at `outputZipPath`, each as a flat entry named
  * by its basename. Creates the output directory if needed.
@@ -28,8 +42,20 @@ export function ensureZipExtension(filePath: string): string {
 export async function createZipWithFiles(
   inputPaths: string[],
   outputZipPath: string,
+  options: CreateZipOptions = {},
 ): Promise<void> {
   await fsPromises.mkdir(path.dirname(outputZipPath), { recursive: true })
+
+  // Read snapshot bytes before opening the zip stream so a concurrent writer
+  // can't change the file's length mid-stream.
+  const snapshots = options.snapshot
+    ? await Promise.all(
+        inputPaths.map(async (inputPath) => ({
+          name: path.basename(inputPath),
+          data: await fsPromises.readFile(inputPath),
+        })),
+      )
+    : null
 
   await new Promise<void>((resolve, reject) => {
     const zipFile = new yazl.ZipFile()
@@ -44,8 +70,14 @@ export async function createZipWithFiles(
     output.once('close', resolve)
 
     zipFile.outputStream.pipe(output)
-    for (const inputPath of inputPaths) {
-      zipFile.addFile(inputPath, path.basename(inputPath))
+    if (snapshots) {
+      for (const { name, data } of snapshots) {
+        zipFile.addBuffer(data, name)
+      }
+    } else {
+      for (const inputPath of inputPaths) {
+        zipFile.addFile(inputPath, path.basename(inputPath))
+      }
     }
     zipFile.end()
   })


### PR DESCRIPTION
## Problem

Exporting logs (Settings → Data → Export logs) crashes the main process:

```
Uncaught Exception:
Error: file data stream has unexpected number of bytes
    at ByteCounter.<anonymous> (node_modules/yazl/index.js:187:99)
```

yazl's streaming `addFile` stats each file for its size up front, then validates the streamed byte count against that size. The **active** app log is appended to by the logger *while the export runs*, so the file grows mid-stream and the counts mismatch → throw. (It's especially easy to hit now that the app logs more user/lifecycle events.)

## Fix

Add an opt-in `snapshot` mode to the shared `createZipWithFiles`:
- **snapshot** reads each input fully into a buffer (via `addBuffer`) *before* opening the zip stream, so a concurrent writer can't change the length mid-stream.
- Logs export uses `{ snapshot: true }` — log files are small and live.
- **Database export is unchanged** (streaming `addFile`): its input is a single static backup that can be hundreds of MB and shouldn't be buffered into memory.

## Tests

- `snapshot mode bundles file contents without streaming from disk` — verifies entry contents round-trip.
- `snapshot mode captures bytes at call time even if the file is appended afterwards` — appends to the source after the call and asserts the zip still holds exactly the snapshot bytes (the regression).
- Existing streaming/DB-export behavior and `logs-export` tests still pass.

`npm run lint` (0 errors), affected tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)