### PR TITLE
gzip device uploads + run DB prep off the main thread

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/main/index.ts'),
           'mcp-entry': resolve(__dirname, 'src/main/mcp-entry.ts'),
+          'upload-prep-worker': resolve(__dirname, 'src/main/services/upload-prep-worker.ts'),
         },
         external: [
           'uiohook-napi',

--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -7,6 +7,18 @@ vi.mock('./strip-database-for-upload', () => ({
   stripDatabaseForUpload: vi.fn(),
 }))
 
+// Resolve gzip via a microtask (using the real gzipSync output) so it stays
+// deterministic under fake timers, while still producing genuine gzip bytes.
+vi.mock('zlib', async (importActual) => {
+  const actual = await importActual<typeof import('zlib')>()
+  return {
+    ...actual,
+    gzip: (buf: Buffer, cb: (err: Error | null, res: Buffer) => void) => {
+      cb(null, actual.gzipSync(buf))
+    },
+  }
+})
+
 function mockFetchResponse(status: number, body: object | string) {
   return vi.fn(async () => ({
     ok: status >= 200 && status < 300,

--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -3,21 +3,16 @@ import * as zlib from 'zlib'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DatabaseUploadSync } from './database-upload-sync'
 
-vi.mock('./strip-database-for-upload', () => ({
-  stripDatabaseForUpload: vi.fn(),
+// The real prep runs in a utilityProcess (electron) and does SQLite work;
+// stub it with an in-process gzip of the backup file so the upload flow stays
+// deterministic and produces genuine gzip bytes for the round-trip assertion.
+vi.mock('./upload-prep', () => ({
+  prepareUploadInWorker: async (tempPath: string) => {
+    const fs = await import('fs')
+    const zlib = await import('zlib')
+    return zlib.gzipSync(fs.readFileSync(tempPath))
+  },
 }))
-
-// Resolve gzip via a microtask (using the real gzipSync output) so it stays
-// deterministic under fake timers, while still producing genuine gzip bytes.
-vi.mock('zlib', async (importActual) => {
-  const actual = await importActual<typeof import('zlib')>()
-  return {
-    ...actual,
-    gzip: (buf: Buffer, cb: (err: Error | null, res: Buffer) => void) => {
-      cb(null, actual.gzipSync(buf))
-    },
-  }
-})
 
 function mockFetchResponse(status: number, body: object | string) {
   return vi.fn(async () => ({

--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import * as zlib from 'zlib'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DatabaseUploadSync } from './database-upload-sync'
 
@@ -60,6 +61,45 @@ describe('DatabaseUploadSync', () => {
     expect(init.body).toBeInstanceOf(FormData)
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer device-hex-id')
     expect((init.body as FormData).has('device_id')).toBe(false)
+  })
+
+  it('gzip-compresses the uploaded database', async () => {
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_123',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => true,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => null,
+      recordUploadAt: () => {},
+    })
+
+    sync.start()
+    await vi.advanceTimersByTimeAsync?.(0).catch(() => undefined)
+    await sync.stop()
+
+    const [, init] = fetchMock.mock.calls[0]
+    const part = (init.body as FormData).get('file') as Blob
+    expect(part).toBeInstanceOf(Blob)
+
+    const bytes = Buffer.from(await part.arrayBuffer())
+    // gzip magic bytes — the server detects compression by these.
+    expect(bytes[0]).toBe(0x1f)
+    expect(bytes[1]).toBe(0x8b)
+    // and it round-trips back to the exact backup content.
+    expect(zlib.gunzipSync(bytes).toString()).toBe('dbcontent')
   })
 
   it('skips upload when not activated', async () => {

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -1,12 +1,17 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
+import { promisify } from 'util'
 import * as zlib from 'zlib'
 import log from '../logger'
 import { isSameDay } from './pattern-detector/helpers'
 import { stripDatabaseForUpload, type StripOptions } from './strip-database-for-upload'
 
 const DEFAULT_UPLOAD_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+// Async gzip so compressing the DB runs on libuv's threadpool, not the main
+// thread — a synchronous gzip of a large DB freezes the app (blocks IPC + UI).
+const gzipAsync = promisify(zlib.gzip)
 
 export interface DatabaseUploadStorage {
   backupToFile(destinationPath: string): Promise<void>
@@ -149,8 +154,9 @@ export class DatabaseUploadSync {
       // compresses ~5-10x, which shrinks the request body and shortens the
       // transfer. The server detects gzip by magic bytes and inflates it, so
       // no Content-Encoding header is needed and older raw uploads still work.
+      // Compress async so a large DB doesn't block the main thread.
       const fileBuffer = fs.readFileSync(tempPath)
-      const gzipped = zlib.gzipSync(fileBuffer)
+      const gzipped = await gzipAsync(fileBuffer)
       const formData = new FormData()
       formData.append('file', new Blob([gzipped]), 'memorylane.db.gz')
 

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
+import * as zlib from 'zlib'
 import log from '../logger'
 import { isSameDay } from './pattern-detector/helpers'
 import { stripDatabaseForUpload, type StripOptions } from './strip-database-for-upload'
@@ -144,9 +145,14 @@ export class DatabaseUploadSync {
       await this.storage.backupToFile(tempPath)
       stripDatabaseForUpload(tempPath, this.getStripOptions())
 
+      // gzip the (already stripped + VACUUMed) DB before upload. SQLite
+      // compresses ~5-10x, which shrinks the request body and shortens the
+      // transfer. The server detects gzip by magic bytes and inflates it, so
+      // no Content-Encoding header is needed and older raw uploads still work.
       const fileBuffer = fs.readFileSync(tempPath)
+      const gzipped = zlib.gzipSync(fileBuffer)
       const formData = new FormData()
-      formData.append('file', new Blob([fileBuffer]), 'memorylane.db')
+      formData.append('file', new Blob([gzipped]), 'memorylane.db.gz')
 
       const base = this.getBackendUrl().replace(/\/?$/, '/')
       const url = new URL('api/device/upload', base)

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -1,17 +1,23 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { promisify } from 'util'
-import * as zlib from 'zlib'
 import log from '../logger'
 import { isSameDay } from './pattern-detector/helpers'
-import { stripDatabaseForUpload, type StripOptions } from './strip-database-for-upload'
+import { type StripOptions } from './strip-database-for-upload'
 
 const DEFAULT_UPLOAD_INTERVAL_MS = 24 * 60 * 60 * 1000
 
-// Async gzip so compressing the DB runs on libuv's threadpool, not the main
-// thread — a synchronous gzip of a large DB freezes the app (blocks IPC + UI).
-const gzipAsync = promisify(zlib.gzip)
+/** Strip + VACUUM + gzip a backup DB into the bytes to upload. */
+export type PrepareUpload = (tempPath: string, stripOptions: StripOptions) => Promise<Buffer>
+
+// The default runs the prep in a short-lived utilityProcess: VACUUM and the
+// column-drop rewrite are synchronous, CPU-heavy SQLite work and would freeze
+// the UI if run on the main thread. Lazily imported so unit tests (which inject
+// their own prepareUpload) never pull in electron.
+const defaultPrepareUpload: PrepareUpload = async (tempPath, stripOptions) => {
+  const { prepareUploadInWorker } = await import('./upload-prep')
+  return prepareUploadInWorker(tempPath, stripOptions)
+}
 
 export interface DatabaseUploadStorage {
   backupToFile(destinationPath: string): Promise<void>
@@ -29,6 +35,9 @@ export interface DatabaseUploadSyncParams {
   /** Persist the timestamp (ms) of a successful upload. */
   recordUploadAt: (ts: number) => void
   intervalMs?: number
+  /** Strip + compress the backup DB. Defaults to a utilityProcess worker;
+   *  injectable so tests don't spawn a process. */
+  prepareUpload?: PrepareUpload
 }
 
 export class DatabaseUploadSync {
@@ -41,6 +50,7 @@ export class DatabaseUploadSync {
   private readonly getLastUploadAt: () => number | null
   private readonly recordUploadAt: (ts: number) => void
   private readonly intervalMs: number
+  private readonly prepareUpload: PrepareUpload
   private timer: ReturnType<typeof setInterval> | null = null
   private uploadRunning = false
   private rerunRequested = false
@@ -56,6 +66,7 @@ export class DatabaseUploadSync {
     this.getLastUploadAt = params.getLastUploadAt
     this.recordUploadAt = params.recordUploadAt
     this.intervalMs = params.intervalMs ?? DEFAULT_UPLOAD_INTERVAL_MS
+    this.prepareUpload = params.prepareUpload ?? defaultPrepareUpload
   }
 
   public start(): void {
@@ -148,15 +159,13 @@ export class DatabaseUploadSync {
 
     try {
       await this.storage.backupToFile(tempPath)
-      stripDatabaseForUpload(tempPath, this.getStripOptions())
 
-      // gzip the (already stripped + VACUUMed) DB before upload. SQLite
-      // compresses ~5-10x, which shrinks the request body and shortens the
-      // transfer. The server detects gzip by magic bytes and inflates it, so
-      // no Content-Encoding header is needed and older raw uploads still work.
-      // Compress async so a large DB doesn't block the main thread.
-      const fileBuffer = fs.readFileSync(tempPath)
-      const gzipped = await gzipAsync(fileBuffer)
+      // Strip (drop sensitive columns/tables + VACUUM) and gzip the backup in a
+      // worker process — that work is synchronous, CPU-heavy SQLite I/O and
+      // would freeze the UI if it ran on the main thread. gzip shrinks the body
+      // ~5-10x; the server detects gzip by magic bytes and inflates it, so no
+      // Content-Encoding header is needed and older raw uploads still work.
+      const gzipped = await this.prepareUpload(tempPath, this.getStripOptions())
       const formData = new FormData()
       formData.append('file', new Blob([gzipped]), 'memorylane.db.gz')
 

--- a/src/main/services/upload-prep-worker.test.ts
+++ b/src/main/services/upload-prep-worker.test.ts
@@ -1,0 +1,63 @@
+import Database from 'better-sqlite3'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import * as zlib from 'zlib'
+import { afterEach, describe, expect, it } from 'vitest'
+import { prepareUploadSync } from './upload-prep-worker'
+
+describe('prepareUploadSync', () => {
+  const tempFiles: string[] = []
+
+  afterEach(() => {
+    for (const f of tempFiles) fs.rmSync(f, { force: true })
+    tempFiles.length = 0
+  })
+
+  function makeDb(): string {
+    const p = path.join(os.tmpdir(), `.prep-test-${process.pid}.${Math.random()}.db`)
+    tempFiles.push(p)
+    const db = new Database(p)
+    db.exec('CREATE TABLE activities (id TEXT PRIMARY KEY, title TEXT, ocr_text TEXT)')
+    db.exec('CREATE TABLE pattern_detection_runs (id INTEGER PRIMARY KEY)')
+    db.prepare('INSERT INTO activities VALUES (?, ?, ?)').run('a1', 'one', 'ocr one')
+    db.prepare('INSERT INTO activities VALUES (?, ?, ?)').run('a2', 'two', 'ocr two')
+    db.prepare('INSERT INTO pattern_detection_runs (id) VALUES (1)').run()
+    db.close()
+    return p
+  }
+
+  it('strips sensitive tables/columns and returns gzip bytes that round-trip', () => {
+    const dbPath = makeDb()
+
+    const gz = prepareUploadSync(dbPath, { detailLevel: 'summary' })
+
+    // Output is real gzip…
+    expect(gz[0]).toBe(0x1f)
+    expect(gz[1]).toBe(0x8b)
+
+    // …and inflates to a valid SQLite DB with the sensitive bits removed.
+    const outPath = path.join(os.tmpdir(), `.prep-out-${process.pid}.${Math.random()}.db`)
+    tempFiles.push(outPath)
+    fs.writeFileSync(outPath, zlib.gunzipSync(gz))
+
+    const db = new Database(outPath, { readonly: true })
+    try {
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+        .all()
+        .map((r) => (r as { name: string }).name)
+      expect(tables).not.toContain('pattern_detection_runs')
+
+      const cols = (db.prepare('PRAGMA table_info(activities)').all() as { name: string }[]).map(
+        (c) => c.name,
+      )
+      expect(cols).not.toContain('ocr_text')
+
+      // Activity rows themselves are preserved.
+      expect((db.prepare('SELECT COUNT(*) AS n FROM activities').get() as { n: number }).n).toBe(2)
+    } finally {
+      db.close()
+    }
+  })
+})

--- a/src/main/services/upload-prep-worker.ts
+++ b/src/main/services/upload-prep-worker.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs'
+import * as zlib from 'zlib'
+import { stripDatabaseForUpload, type StripOptions } from './strip-database-for-upload'
+
+export interface UploadPrepRequest {
+  tempPath: string
+  stripOptions: StripOptions
+}
+
+export type UploadPrepResponse = { ok: true; gzip: ArrayBuffer } | { ok: false; error: string }
+
+/**
+ * Strip the backup DB (drop sensitive tables/columns + VACUUM), then read and
+ * gzip it. Every step here is synchronous, CPU/IO-heavy SQLite work, so this
+ * MUST run off the Electron main thread (inside a utilityProcess) — otherwise
+ * the VACUUM/column-rewrite freezes the UI.
+ */
+export function prepareUploadSync(tempPath: string, stripOptions: StripOptions): Buffer {
+  stripDatabaseForUpload(tempPath, stripOptions)
+  return zlib.gzipSync(fs.readFileSync(tempPath))
+}
+
+// utilityProcess child wiring. `process.parentPort` only exists when this file
+// is run as a forked utilityProcess; guarding it keeps the module import-safe
+// for unit tests that exercise `prepareUploadSync` directly.
+interface ParentPortLike {
+  on(event: 'message', listener: (e: { data: UploadPrepRequest }) => void): void
+  postMessage(message: UploadPrepResponse, transfer?: ArrayBuffer[]): void
+}
+const parentPort = (process as unknown as { parentPort?: ParentPortLike }).parentPort
+if (parentPort) {
+  parentPort.on('message', ({ data }) => {
+    try {
+      const buf = prepareUploadSync(data.tempPath, data.stripOptions)
+      // Copy out an exact-size ArrayBuffer and transfer it (zero-copy) so a
+      // large compressed blob doesn't get structured-cloned across the boundary.
+      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+      parentPort.postMessage({ ok: true, gzip: ab }, [ab])
+    } catch (err) {
+      parentPort.postMessage({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })
+}

--- a/src/main/services/upload-prep.ts
+++ b/src/main/services/upload-prep.ts
@@ -1,0 +1,51 @@
+import { app, utilityProcess } from 'electron'
+import * as path from 'path'
+import type { StripOptions } from './strip-database-for-upload'
+import type { UploadPrepRequest, UploadPrepResponse } from './upload-prep-worker'
+
+// Built alongside index.js (see electron.vite.config.ts rollup input).
+// app.getAppPath() resolves to the asar root when packaged and to the project
+// root in dev, so the same relative layout works for both.
+function workerScriptPath(): string {
+  return path.join(app.getAppPath(), 'out', 'main', 'upload-prep-worker.js')
+}
+
+/**
+ * Run the upload prep (strip + VACUUM + gzip) in a short-lived utilityProcess
+ * so the heavy synchronous SQLite work never blocks the main thread. The child
+ * is killed once it returns the compressed buffer (or fails).
+ */
+export function prepareUploadInWorker(
+  tempPath: string,
+  stripOptions: StripOptions,
+): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    const child = utilityProcess.fork(workerScriptPath(), [], { serviceName: 'upload-prep' })
+    let settled = false
+
+    const settle = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      fn()
+      child.kill()
+    }
+
+    child.on('message', (msg: UploadPrepResponse) => {
+      if (msg.ok) settle(() => resolve(Buffer.from(msg.gzip)))
+      else settle(() => reject(new Error(msg.error)))
+    })
+
+    child.on('exit', (code) => {
+      if (!settled) {
+        settled = true
+        reject(new Error(`upload-prep worker exited before responding (code ${code})`))
+      }
+    })
+
+    // Send the task once the child is ready to receive messages.
+    child.once('spawn', () => {
+      const req: UploadPrepRequest = { tempPath, stripOptions }
+      child.postMessage(req)
+    })
+  })
+}

--- a/src/main/services/upload-prep.ts
+++ b/src/main/services/upload-prep.ts
@@ -10,6 +10,11 @@ function workerScriptPath(): string {
   return path.join(app.getAppPath(), 'out', 'main', 'upload-prep-worker.js')
 }
 
+// Generous upper bound for strip + VACUUM + gzip. If the worker exceeds this it
+// is almost certainly hung; we kill it and reject so a stuck child can't leave
+// the upload `inFlight` promise unresolved (which would wedge every later run).
+const WORKER_TIMEOUT_MS = 2 * 60 * 1000
+
 /**
  * Run the upload prep (strip + VACUUM + gzip) in a short-lived utilityProcess
  * so the heavy synchronous SQLite work never blocks the main thread. The child
@@ -26,9 +31,15 @@ export function prepareUploadInWorker(
     const settle = (fn: () => void): void => {
       if (settled) return
       settled = true
+      clearTimeout(timer)
       fn()
       child.kill()
     }
+
+    const timer = setTimeout(() => {
+      settle(() => reject(new Error(`upload-prep worker timed out after ${WORKER_TIMEOUT_MS}ms`)))
+    }, WORKER_TIMEOUT_MS)
+    timer.unref?.()
 
     child.on('message', (msg: UploadPrepResponse) => {
       if (msg.ok) settle(() => resolve(Buffer.from(msg.gzip)))
@@ -36,10 +47,7 @@ export function prepareUploadInWorker(
     })
 
     child.on('exit', (code) => {
-      if (!settled) {
-        settled = true
-        reject(new Error(`upload-prep worker exited before responding (code ${code})`))
-      }
+      settle(() => reject(new Error(`upload-prep worker exited before responding (code ${code})`)))
     })
 
     // Send the task once the child is ready to receive messages.


### PR DESCRIPTION
## What

Two changes to device DB sync:

1. **gzip the upload.** The (stripped + VACUUMed) SQLite is gzip-compressed before POSTing to `/api/device/upload`. SQLite compresses ~5–10×, shrinking the request body and shortening each upload's transfer window. The server detects gzip by magic bytes and inflates it, so this is **backward compatible** (older clients keep sending raw DBs).
2. **Run the prep in a `utilityProcess`.** `stripDatabaseForUpload` runs a synchronous `VACUUM` + an `ALTER TABLE … DROP COLUMN` table rewrite. On the Electron **main thread** that froze the UI (beachball) during "sync remote". Strip + read + gzip now run in a short-lived `utilityProcess`, so the main thread never blocks regardless of DB size.

## How

- `upload-prep-worker.ts` — the forked entry. `prepareUploadSync` does strip + gzip; the `parentPort` wiring returns the compressed bytes (transferred zero-copy). Added as an electron-vite build input → `out/main/upload-prep-worker.js`; `better-sqlite3` stays external and loads in the child as it does in main.
- `upload-prep.ts` — forks the worker, sends the task, resolves the gzip buffer, kills the child.
- `database-upload-sync.ts` — delegates to an injectable `prepareUpload` (defaults to the worker, lazily imported so unit tests don't pull in electron). No compression runs in the main process anymore.

## Pairs with

Server-side inflate + bounded zip-bomb guard: `memorylane-enterprise-admin` PR #100 (handles both raw and gzip uploads, so these can land in either order).

## Tests

`upload-prep-worker` test exercises the real strip+gzip (sensitive table/column dropped, rows preserved, gzip round-trips). Upload-sync suite stubs `./upload-prep`. Full client suite green (**829 passed**); `npm run build` emits the worker entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)