### PR TITLE
Drop Molmo from the video summarization pipeline

### DIFF
--- a/src/main/activity-semantic-service.test.ts
+++ b/src/main/activity-semantic-service.test.ts
@@ -62,7 +62,6 @@ vi.mock('sharp', () => ({
 const DEFAULT_VIDEO_MODELS = [
   'google/gemini-2.5-flash-lite-preview-09-2025',
   'google/gemini-2.5-flash',
-  'allenai/molmo-2-8b',
 ]
 
 const DEFAULT_SNAPSHOT_MODELS = [
@@ -442,9 +441,7 @@ describe('ActivitySemanticService', () => {
     const { service, fetchMock } = setupService()
     fetchMock.setHandler(({ body }) => {
       if (body.model === DEFAULT_VIDEO_MODELS[0]) return httpError(500, { error: 'primary failed' })
-      if (body.model === DEFAULT_VIDEO_MODELS[1])
-        return httpError(500, { error: 'secondary failed' })
-      return chatCompletionResponse('third model summary')
+      return chatCompletionResponse('fallback model summary')
     })
 
     const result = await service.summarizeFromVideo({
@@ -452,7 +449,7 @@ describe('ActivitySemanticService', () => {
       videoPath,
     })
 
-    expect(result.summary).toBe('third model summary')
+    expect(result.summary).toBe('fallback model summary')
     expect(fetchMock.calls.map((c) => c.body.model)).toEqual(DEFAULT_VIDEO_MODELS)
     expect(service.getLlmHealthStatus().state).toBe('active')
   })
@@ -605,7 +602,9 @@ describe('ActivitySemanticService', () => {
     expect(fetchMock.calls.map((c) => c.body.model)).toEqual(DEFAULT_VIDEO_MODELS)
     const diagnostics = service.getLastRunDiagnostics()
     expect(diagnostics?.pipelinePreference).toBe('video')
-    expect(diagnostics?.attempts.map((a) => a.mode)).toEqual(['video', 'video', 'video'])
+    expect(diagnostics?.attempts.map((a) => a.mode)).toEqual(
+      DEFAULT_VIDEO_MODELS.map(() => 'video'),
+    )
     expect(diagnostics?.chosenMode).toBeNull()
   })
 

--- a/src/main/semantic/constants.ts
+++ b/src/main/semantic/constants.ts
@@ -12,10 +12,6 @@ export const MODEL_PRICING_USD_PER_MILLION: Record<
     input_tokens_per_million: 0.3,
     completion_tokens_per_million: 2.5,
   },
-  'allenai/molmo-2-8b': {
-    input_tokens_per_million: 0.2,
-    completion_tokens_per_million: 0.2,
-  },
   'mistralai/mistral-small-3.2-24b-instruct': {
     input_tokens_per_million: 0.08,
     completion_tokens_per_million: 0.2,

--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -32,7 +32,6 @@ export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
     semanticVideo: [
       { id: 'google/gemini-2.5-flash-lite-preview-09-2025', label: 'Gemini 2.5 Flash Lite' },
       { id: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
-      { id: 'allenai/molmo-2-8b', label: 'Molmo 2 8B' },
     ],
     semanticSnapshot: [
       { id: 'mistralai/mistral-small-3.2-24b-instruct', label: 'Mistral Small 3.2' },


### PR DESCRIPTION
## What

Removes `allenai/molmo-2-8b` from the semantic video summarization pipeline. It was the **third fallback video model** for the OpenRouter vendor and only ran if both Gemini video models (2.5 Flash Lite, 2.5 Flash) failed.

## Why

OpenRouter users keep the two Gemini video models, which are cheaper and better. Native vendors (Google) and custom OpenAI-compatible endpoints never referenced Molmo.

## Changes

The pipeline (`src/main/semantic/`) is model-agnostic, so this is config-only:

- `src/shared/vendor-defaults.ts` — drop the Molmo entry from `openrouter.semanticVideo`
- `src/main/semantic/constants.ts` — drop the now-dead Molmo pricing entry
- `src/main/activity-semantic-service.test.ts` — drop Molmo from the `DEFAULT_VIDEO_MODELS` fixture; adjust two tests that assumed a 3-model chain (one now fails the first model and succeeds on the second; the other derives the attempt count from `DEFAULT_VIDEO_MODELS.length`)

Left `findings/video-token-benchmark.md` untouched — it's a historical benchmark artifact, not part of the shipping pipeline.

## Verification

- `grep -rin molmo src/` → no matches
- `npm run lint` → 0 errors
- `npm run test -- activity-semantic-service` → 31 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)