### PR TITLE
fix(recorder): stop display flapping at the source

### DIFF
--- a/src/main/activity-transformer-types.ts
+++ b/src/main/activity-transformer-types.ts
@@ -3,6 +3,11 @@ import type { Activity } from './activity-types'
 export interface ActivityVideoFrameInput {
   filepath: string
   timestamp: number
+  // Source frame resolution, when known. Used to normalize the stitched video to
+  // the dominant (work-display) resolution and letterbox off-display frames of a
+  // different size, instead of letting the first frame stretch the whole canvas.
+  width?: number
+  height?: number
 }
 
 export interface ActivityVideoAsset {

--- a/src/main/activity-transformer.test.ts
+++ b/src/main/activity-transformer.test.ts
@@ -102,9 +102,9 @@ describe('DefaultActivityTransformer', () => {
     expect(stitcher.stitch).toHaveBeenCalledWith({
       activityId: 'activity-1',
       frames: [
-        { filepath: '/screenshots/frame-0.png', timestamp: 1000 },
-        { filepath: '/screenshots/frame-1.png', timestamp: 1100 },
-        { filepath: '/screenshots/frame-2.png', timestamp: 1200 },
+        { filepath: '/screenshots/frame-0.png', timestamp: 1000, width: 1920, height: 1080 },
+        { filepath: '/screenshots/frame-1.png', timestamp: 1100, width: 1920, height: 1080 },
+        { filepath: '/screenshots/frame-2.png', timestamp: 1200, width: 1920, height: 1080 },
       ],
       outputPath: '/output/activity-1.mp4',
     })

--- a/src/main/activity-transformer.ts
+++ b/src/main/activity-transformer.ts
@@ -34,6 +34,8 @@ export class DefaultActivityTransformer implements ActivityTransformer {
     const frames: ActivityVideoFrameInput[] = activity.frames.map((f) => ({
       filepath: f.frame.filepath,
       timestamp: f.frame.timestamp,
+      width: f.frame.width,
+      height: f.frame.height,
     }))
 
     const shouldStitchVideo = this.config.getPipelinePreference?.() !== 'image'

--- a/src/main/eval/promote-fixture.ts
+++ b/src/main/eval/promote-fixture.ts
@@ -105,9 +105,9 @@ function deriveAppMix(windows: EventWindow[]): string[] {
 /**
  * Stitches fixture frames into one session video for golden review. When
  * `endTimestampMs` is given (the last activity's end), trailing frames past it
- * are dropped and a terminal marker is pinned at the end so the video stops there
- * — otherwise the stitcher holds the final real frame for a full inter-frame
- * interval and the video runs ~1s past the transcript.
+ * are dropped and the final real frame is pinned to that end so the video stops
+ * at the transcript end. The stitcher caps its own trailing hold, so the video
+ * runs at most one frame-duration past `endTimestampMs`.
  */
 async function stitchSessionVideo(
   fixtureDir: string,
@@ -135,6 +135,8 @@ async function stitchSessionVideo(
       frames: clip.map((f) => ({
         filepath: path.resolve(fixtureDir, f.filepath),
         timestamp: f.timestamp,
+        width: f.width,
+        height: f.height,
       })),
       outputPath,
     })

--- a/src/main/recorder/interaction-monitor.test.ts
+++ b/src/main/recorder/interaction-monitor.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { EVENT_CAPTURER_CONFIG, INTERACTION_MONITOR_CONFIG } from '@constants'
 import type { InteractionContext } from '../../shared/types'
+import { resolveAppWatcherDisplay } from './app-watcher-display'
 
 // --- Mocks -----------------------------------------------------------------
 // Defined via vi.hoisted so they are initialized before the hoisted vi.mock
@@ -202,6 +203,45 @@ describe('interaction-monitor session emission', () => {
     vi.advanceTimersByTime(INTERACTION_MONITOR_CONFIG.TYPING_DEBOUNCE_MS)
     expect(emitted.map((c) => c.type)).toEqual(['app_change', 'keyboard'])
     expect(emitted[1].timestamp).toBe(1000)
+  })
+
+  it('suppresses a same-window display flap (same identity, different display, ~same ts)', () => {
+    // One macOS focus change emits app_change + window_change; each recomputes
+    // displayId from a transiently-stale AX frame, so they disagree (2 then 1)
+    // while sharing a near-identical timestamp. The second must be dropped so it
+    // neither re-steers capture to the blank display nor opens a 0ms window.
+    vi.mocked(resolveAppWatcherDisplay).mockReturnValueOnce({
+      displayId: 2,
+      source: 'event_display_id',
+    })
+    appChange('Chrome', 'Doc — Chrome', 1000)
+    vi.mocked(resolveAppWatcherDisplay).mockReturnValueOnce({
+      displayId: 1,
+      source: 'event_display_id',
+    })
+    appChange('Chrome', 'Doc — Chrome', 1001)
+
+    // Only the first read propagates; capture stays on display 2.
+    expect(emitted.map((c) => c.type)).toEqual(['app_change'])
+    expect(emitted[0].displayId).toBe(2)
+  })
+
+  it('does NOT suppress a genuine cross-display move (same identity, different display, seconds apart)', () => {
+    // A real window/focus move to another display is well outside the coalesce
+    // window, so it must still switch capture.
+    vi.mocked(resolveAppWatcherDisplay).mockReturnValueOnce({
+      displayId: 2,
+      source: 'event_display_id',
+    })
+    appChange('Chrome', 'Doc — Chrome', 1000)
+    vi.mocked(resolveAppWatcherDisplay).mockReturnValueOnce({
+      displayId: 1,
+      source: 'event_display_id',
+    })
+    appChange('Chrome', 'Doc — Chrome', 1000 + 600) // 600ms later > DISPLAY_FLAP_COALESCE_MS
+
+    expect(emitted.map((c) => c.type)).toEqual(['app_change', 'app_change'])
+    expect(emitted[1].displayId).toBe(1)
   })
 })
 

--- a/src/main/recorder/interaction-monitor.ts
+++ b/src/main/recorder/interaction-monitor.ts
@@ -6,12 +6,22 @@ import { addAppWatcherListener, AppWatcherEvent } from './app-watcher'
 import { resolveAppWatcherDisplay } from './app-watcher-display'
 import log from '../logger'
 
+// A single macOS focus change fires two+ native emissions (app_change +
+// window_change), each recomputing displayId from a transiently-stale AX frame,
+// so they can disagree on which display the window is on while sharing a
+// truncated-ms timestamp. Within this window, a same-identity app_change whose
+// displayId differs from the one we just propagated is treated as that spurious
+// flap and suppressed. A genuine cross-display move is seconds apart, so it is
+// well outside this window and still switches capture.
+const DISPLAY_FLAP_COALESCE_MS = 500
+
 // State
 let isRunning = false
 
 // App change state
 let previousWindow: NonNullable<InteractionContext['activeWindow']> | null = null
 let previousWindowDisplayId: number | null = null
+let previousWindowTimestamp: number | null = null
 
 // Display resolution state (used by keyboard/scroll handlers)
 let cachedDisplayId: number | null = null
@@ -310,15 +320,32 @@ function handleAppWatcherEvent(event: AppWatcherEvent): void {
   }
   const resolvedDisplayId = resolvedDisplay.displayId
 
-  // Skip if nothing actually changed
-  if (
-    previousWindow &&
+  // A single focus change can emit twice with the same window identity. If the
+  // two reads also agree on display, it is a plain duplicate; if they disagree
+  // within the coalesce window, it is the display flap (see DISPLAY_FLAP_COALESCE_MS).
+  // Either way the re-fire carries no new information — suppress it so it neither
+  // re-steers capture (blank monitor) nor opens a 0ms event window.
+  const sameWindowIdentity =
+    previousWindow !== null &&
     previousWindow.title === current.title &&
     previousWindow.processName === current.processName &&
     previousWindow.hwnd === current.hwnd &&
-    previousWindowDisplayId === resolvedDisplayId
-  ) {
+    previousWindow.bundleId === current.bundleId
+
+  if (sameWindowIdentity && previousWindowDisplayId === resolvedDisplayId) {
     log.debug(`[Interaction Monitor] Skipping duplicate: ${current.processName} "${current.title}"`)
+    return
+  }
+
+  if (
+    sameWindowIdentity &&
+    previousWindowTimestamp !== null &&
+    Math.abs(event.timestamp - previousWindowTimestamp) <= DISPLAY_FLAP_COALESCE_MS
+  ) {
+    log.debug(
+      `[Interaction Monitor] Skipping display flap: ${current.processName} "${current.title}" ` +
+        `display ${previousWindowDisplayId}->${resolvedDisplayId} within ${DISPLAY_FLAP_COALESCE_MS}ms`,
+    )
     return
   }
 
@@ -347,6 +374,7 @@ function handleAppWatcherEvent(event: AppWatcherEvent): void {
 
   previousWindow = current
   previousWindowDisplayId = resolvedDisplayId
+  previousWindowTimestamp = event.timestamp
 
   // Notify all callbacks
   log.debug(
@@ -428,6 +456,7 @@ export function stopInteractionMonitoring(): void {
     scrollSession.reset()
     previousWindow = null
     previousWindowDisplayId = null
+    previousWindowTimestamp = null
     cachedDisplayId = null
     cachedWindowTitle = null
 

--- a/src/main/recorder/swift/app-watcher.swift
+++ b/src/main/recorder/swift/app-watcher.swift
@@ -193,7 +193,12 @@ func buildEvent(type: String, app: NSRunningApplication, title: String) -> [Stri
         dict["url"] = url
     }
 
-    if let frame = focusedWindowFrame(forPid: pid) {
+    // A degenerate AX frame (zero/negative size) shows up transiently mid focus
+    // transition and would classify onto the primary (often idle) display. Omit
+    // bounds/displayId entirely so downstream keeps the prior display instead of
+    // flapping to a blank monitor.
+    if let frame = focusedWindowFrame(forPid: pid),
+       frame.size.width > 0, frame.size.height > 0 {
         dict["windowBounds"] = [
             "x": frame.origin.x,
             "y": frame.origin.y,
@@ -206,6 +211,43 @@ func buildEvent(type: String, app: NSRunningApplication, title: String) -> [Stri
     }
 
     return dict
+}
+
+// MARK: - Coalesced emission
+
+// A single focus change fires several native notifications in quick succession
+// (didActivateApplication + kAXFocusedWindowChanged + kAXTitleChanged), and the
+// focused window's AX frame is transiently stale/partial mid-transition — so
+// reading displayId per-notification produces duplicate, display-flapping
+// events. We coalesce: every notification (re)schedules a single emit after a
+// short settle delay; only the last one survives, and it reads the now-settled
+// frontmost window once. A genuine app/tab change still emits once the focus
+// holds past the settle delay.
+let settleDelayMs = 120
+var pendingEmitWork: DispatchWorkItem?
+var pendingEmitType = "window_change"
+
+func scheduleEmit(type: String) {
+    // app_change is the stronger signal (an app switch); a window_change that
+    // lands in the same settle window must not downgrade it.
+    if type == "app_change" {
+        pendingEmitType = "app_change"
+    } else if pendingEmitWork == nil {
+        pendingEmitType = type
+    }
+
+    pendingEmitWork?.cancel()
+
+    let work = DispatchWorkItem {
+        pendingEmitWork = nil
+        let emitType = pendingEmitType
+        pendingEmitType = "window_change"
+        guard let app = NSWorkspace.shared.frontmostApplication else { return }
+        let title = windowTitle(forPid: app.processIdentifier) ?? ""
+        emit(buildEvent(type: emitType, app: app, title: title))
+    }
+    pendingEmitWork = work
+    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(settleDelayMs), execute: work)
 }
 
 // MARK: - AXObserver for focused-window changes within an app
@@ -245,19 +287,10 @@ func tearDownTitleObserver() {
 }
 
 /// Callback fired when the focused window's title changes (e.g. browser tab switch).
-let titleCallback: AXObserverCallback = { _, element, _, _ in
-    guard let app = NSWorkspace.shared.frontmostApplication else { return }
-
-    var titleValue: AnyObject?
-    let title: String
-    if AXUIElementCopyAttributeValue(element, kAXTitleAttribute as CFString, &titleValue) == .success,
-       let t = titleValue as? String {
-        title = t
-    } else {
-        title = ""
-    }
-
-    emit(buildEvent(type: "window_change", app: app, title: title))
+let titleCallback: AXObserverCallback = { _, _, _, _ in
+    // The settled emit re-reads the focused window's title, so we only need to
+    // (re)schedule here.
+    scheduleEmit(type: "window_change")
 }
 
 func setupTitleObserver(forPid pid: pid_t) {
@@ -283,19 +316,10 @@ func setupTitleObserver(forPid pid: pid_t) {
 }
 
 /// Callback fired when the focused window changes within the observed app.
-let axCallback: AXObserverCallback = { _, element, _, _ in
+let axCallback: AXObserverCallback = { _, _, _, _ in
     guard let app = NSWorkspace.shared.frontmostApplication else { return }
 
-    var titleValue: AnyObject?
-    let title: String
-    if AXUIElementCopyAttributeValue(element, kAXTitleAttribute as CFString, &titleValue) == .success,
-       let t = titleValue as? String {
-        title = t
-    } else {
-        title = windowTitle(forPid: app.processIdentifier) ?? ""
-    }
-
-    emit(buildEvent(type: "window_change", app: app, title: title))
+    scheduleEmit(type: "window_change")
 
     // Re-target title observer to the newly focused window
     setupTitleObserver(forPid: app.processIdentifier)
@@ -333,8 +357,9 @@ nc.addObserver(forName: NSWorkspace.didActivateApplicationNotification,
                object: nil, queue: .main) { notification in
     guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
 
-    let title = windowTitle(forPid: app.processIdentifier) ?? ""
-    emit(buildEvent(type: "app_change", app: app, title: title))
+    // Coalesce the activation with the AX focus/title notifications it triggers
+    // into a single settled emit.
+    scheduleEmit(type: "app_change")
 
     // Set up AX observer for window changes within this new app
     setupAXObserver(forPid: app.processIdentifier)

--- a/src/main/video/video-stitcher.test.ts
+++ b/src/main/video/video-stitcher.test.ts
@@ -156,7 +156,74 @@ describe('FfmpegVideoStitcher', () => {
     expect(manifestContent).toContain('duration 1.500000')
 
     mockChild.emit('close', 0)
-    await expect(promise).resolves.toMatchObject({ durationMs: 3_500 })
+    // Real inter-frame gaps 500 + 1500, plus a trailing hold capped to the 1000ms
+    // default (the last gap was 1500ms but the final-frame hold is bounded).
+    await expect(promise).resolves.toMatchObject({ durationMs: 3_000 })
+  })
+
+  it('caps the trailing hold so a long final idle gap does not inflate duration', async () => {
+    const childProcess = await import('child_process')
+    const tempDir = createTempDir()
+    const frameA = createFrame(tempDir, 'a.png')
+    const frameB = createFrame(tempDir, 'b.png')
+
+    const mockChild = createMockChildProcess()
+    vi.mocked(childProcess.spawn).mockReturnValue(
+      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
+    )
+
+    const stitcher = new FfmpegVideoStitcher()
+    const promise = stitcher.stitch({
+      activityId: 'activity-cap',
+      frames: [
+        { filepath: frameA, timestamp: 0 },
+        { filepath: frameB, timestamp: 10_000 },
+      ],
+      outputPath: path.join(tempDir, 'out.mp4'),
+    })
+
+    mockChild.emit('close', 0)
+    // 10s real gap (frame A held while screen was static) + a 1s capped trailing
+    // hold for the final frame — not 10s + 10s (the over-run bug).
+    await expect(promise).resolves.toMatchObject({ durationMs: 11_000 })
+  })
+
+  it('normalizes mixed-resolution frames to the modal canvas with letterbox padding', async () => {
+    const childProcess = await import('child_process')
+    const tempDir = createTempDir()
+    const work1 = createFrame(tempDir, 'w1.png')
+    const work2 = createFrame(tempDir, 'w2.png')
+    const work3 = createFrame(tempDir, 'w3.png')
+    const offDisplay = createFrame(tempDir, 'off.png')
+
+    const mockChild = createMockChildProcess()
+    vi.mocked(childProcess.spawn).mockReturnValue(
+      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
+    )
+
+    const stitcher = new FfmpegVideoStitcher()
+    const promise = stitcher.stitch({
+      activityId: 'activity-canvas',
+      frames: [
+        // The off-display frame is first by timestamp; without normalization it
+        // would lock the canvas to 1920x1248 and stretch the work frames.
+        { filepath: offDisplay, timestamp: 1_000, width: 1920, height: 1248 },
+        { filepath: work1, timestamp: 2_000, width: 1920, height: 1080 },
+        { filepath: work2, timestamp: 3_000, width: 1920, height: 1080 },
+        { filepath: work3, timestamp: 4_000, width: 1920, height: 1080 },
+      ],
+      outputPath: path.join(tempDir, 'out.mp4'),
+    })
+
+    const [, args] = vi.mocked(childProcess.spawn).mock.calls[0]
+    const vfValue = args[args.indexOf('-vf') + 1]
+    // Modal resolution is 1920x1080 (3 work frames vs 1 off-display frame).
+    expect(vfValue).toBe(
+      'scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,setsar=1',
+    )
+
+    mockChild.emit('close', 0)
+    await promise
   })
 
   it('sorts frames by timestamp before writing concat manifest', async () => {

--- a/src/main/video/video-stitcher.ts
+++ b/src/main/video/video-stitcher.ts
@@ -24,14 +24,81 @@ function escapeConcatPath(filepath: string): string {
 
 function sortFramesByTimestamp(frames: ActivityVideoFrameInput[]): ActivityVideoFrameInput[] {
   return frames
-    .map((frame, index) => ({ ...frame, index }))
+    .map((frame, index) => ({ frame, index }))
     .sort((left, right) => {
-      if (left.timestamp !== right.timestamp) {
-        return left.timestamp - right.timestamp
+      if (left.frame.timestamp !== right.frame.timestamp) {
+        return left.frame.timestamp - right.frame.timestamp
       }
       return left.index - right.index
     })
-    .map(({ filepath, timestamp }) => ({ filepath, timestamp }))
+    .map(({ frame }) => frame)
+}
+
+/**
+ * Pick the canvas resolution for the stitched video: the most-common frame size
+ * among the inputs. The work display dominates the frame count, so transient
+ * off-display frames (captured at a different resolution) get letterboxed to the
+ * work resolution instead of stretching the whole video. Returns null when no
+ * frame carries dimensions, in which case the caller keeps the legacy filter.
+ */
+function targetCanvasSize(
+  frames: ActivityVideoFrameInput[],
+): { width: number; height: number } | null {
+  const counts = new Map<string, { width: number; height: number; count: number }>()
+  for (const frame of frames) {
+    if (
+      typeof frame.width !== 'number' ||
+      typeof frame.height !== 'number' ||
+      frame.width <= 0 ||
+      frame.height <= 0
+    ) {
+      continue
+    }
+    const key = `${frame.width}x${frame.height}`
+    const existing = counts.get(key)
+    if (existing) {
+      existing.count++
+    } else {
+      counts.set(key, { width: frame.width, height: frame.height, count: 1 })
+    }
+  }
+
+  let best: { width: number; height: number; count: number } | null = null
+  for (const entry of counts.values()) {
+    if (
+      best === null ||
+      entry.count > best.count ||
+      // Deterministic tie-break: prefer the larger area.
+      (entry.count === best.count && entry.width * entry.height > best.width * best.height)
+    ) {
+      best = entry
+    }
+  }
+  if (best === null) {
+    return null
+  }
+
+  // yuv420p requires even dimensions.
+  return {
+    width: Math.max(2, Math.floor(best.width / 2) * 2),
+    height: Math.max(2, Math.floor(best.height / 2) * 2),
+  }
+}
+
+/**
+ * Build the ffmpeg `-vf` value. With known dimensions, scale each frame to fit
+ * the target canvas preserving aspect ratio, then pad (letterbox) to the exact
+ * canvas — no stretching. Without dimensions, fall back to the legacy
+ * round-to-even scale.
+ */
+function buildScaleFilter(canvas: { width: number; height: number } | null): string {
+  if (canvas === null) {
+    return 'scale=trunc(iw/2)*2:trunc(ih/2)*2'
+  }
+  return (
+    `scale=${canvas.width}:${canvas.height}:force_original_aspect_ratio=decrease,` +
+    `pad=${canvas.width}:${canvas.height}:(ow-iw)/2:(oh-ih)/2,setsar=1`
+  )
 }
 
 function assertFrames(frames: ActivityVideoFrameInput[]): void {
@@ -57,7 +124,11 @@ function deriveFrameDurationsMs(frames: ActivityVideoFrameInput[]): number[] {
     durationsMs.push(delta > 0 ? delta : DEFAULT_FRAME_DURATION_MS)
   }
 
-  durationsMs.push(durationsMs[durationsMs.length - 1] ?? DEFAULT_FRAME_DURATION_MS)
+  // The final frame has no successor to bound its on-screen time. Hold it for the
+  // last inter-frame gap, but cap the hold so a long idle gap before the last
+  // frame can't tack seconds of frozen video onto the end (the over-run bug).
+  const lastGapMs = durationsMs[durationsMs.length - 1] ?? DEFAULT_FRAME_DURATION_MS
+  durationsMs.push(Math.min(lastGapMs, DEFAULT_FRAME_DURATION_MS))
   return durationsMs
 }
 
@@ -187,6 +258,7 @@ export class FfmpegVideoStitcher implements ActivityVideoStitcher {
     const frames = sortFramesByTimestamp(input.frames)
     const frameDurationsMs = deriveFrameDurationsMs(frames)
     const durationMs = frameDurationsMs.reduce((sum, value) => sum + value, 0)
+    const scaleFilter = buildScaleFilter(targetCanvasSize(frames))
 
     const outputPath = path.resolve(input.outputPath)
     fs.mkdirSync(path.dirname(outputPath), { recursive: true })
@@ -219,7 +291,7 @@ export class FfmpegVideoStitcher implements ActivityVideoStitcher {
         '-crf',
         FFMPEG_VIDEO_CRF,
         '-vf',
-        'scale=trunc(iw/2)*2:trunc(ih/2)*2',
+        scaleFilter,
         '-pix_fmt',
         'yuv420p',
         '-movflags',


### PR DESCRIPTION
## Problem

Captured video intermittently showed a **blank/wrong monitor** (Finder wallpaper / idle laptop display) instead of the screen the user was working on.

**Root cause:** a single macOS focus change fires several native emissions from `app-watcher.swift` (`app_change` + AX focused-window + AX title), each independently recomputing `displayId` from a **transiently-stale AX frame**. The reads disagree on the display while sharing a truncated-ms timestamp, and nothing reconciled them downstream — `setDisplayId` is last-write-wins and the dedup guard failed open on a displayId mismatch. This produced four symptoms from one bug: blank capture, 0ms `no_frames` windows, hallucinated summaries (blank frames narrated from metadata), and a mis-sized/over-long stitched video.

## Fix

**Native — `app-watcher.swift` (true root cause, order-independent)**
- Coalesce the focus-change emissions into **one settled emit** via a ~120ms-debounced `DispatchWorkItem` that re-reads the now-settled frontmost window, so the transient/duplicate read never leaves the process.
- Reject degenerate AX frames (omit `windowBounds`/`displayId` when width/height ≤ 0).
- Launch `app_change` + `ready` stay immediate.

**TS — `interaction-monitor.ts` (tested safety net)**
- Widen the dedup guard to suppress a same window-identity (`title`+`process`+`hwnd`+`bundleId`) `app_change` whose `displayId` differs within `DISPLAY_FLAP_COALESCE_MS = 500`. Kills the 0ms-window symptom always; defense-in-depth for blank capture. A genuine cross-display move is seconds apart and still switches capture. +2 regression tests.

**Video stitcher — `video-stitcher.ts` (separate symptom of the same fixture)**
- Plumb frame `width`/`height` through `ActivityVideoFrameInput` and normalize the canvas to the **modal (work-display) resolution** with letterbox-pad, instead of letting the first frame stretch the whole video.
- Cap the trailing hold to `DEFAULT_FRAME_DURATION_MS` so a long final idle gap can't add seconds of frozen video.

## Verification

- Lint: 0 errors. Full suite: **833 passed**, 0 failed. New regression tests for the flap dedup, the trailing-hold cap, and canvas normalization.
- `npm run build:swift` compiles; watcher starts cleanly and emits valid JSON.
- Real-ffmpeg check on the `jaro-2026-06-19-08-05` fixture: output is now **1920×1080** (was 1920×1248, work frames stretched) and **99.57s** (was 111.64s).

## Notes for reviewers

- **The native coalescing needs manual confirmation on a real dual-monitor Mac** (`npm run build:swift` → `npm run debug:app-watcher`): switch focus across displays and confirm one event per switch with a stable `displayId`. There is no Swift unit-test harness.
- The ~120ms settle adds minor latency to focus-change detection and collapses sub-120ms app flicks into the landing app — acceptable for capture targeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)