### PR TITLE
refactor(integrations): remove legacy npx-CLI MCP detector (DEU-25)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@
  * MemoryLane - Main Process Entry Point
  *
  * Tray app running the timeline-first pipeline.
- * The MCP server is provided by the CLI package (@deusxmachina-dev/memorylane-cli).
+ * The MCP server is the app itself run as Node (see integrations/app-mcp-entry).
  */
 
 // Side-effect import: sets process.env.PATH for onnxruntime DLLs on Windows.

--- a/src/main/integrations/claude-code.ts
+++ b/src/main/integrations/claude-code.ts
@@ -10,12 +10,7 @@ import * as path from 'node:path'
 import * as os from 'node:os'
 import log from '../logger'
 import { buildAppMcpEntry, getMcpEntryScriptPath } from './app-mcp-entry'
-import {
-  detectLegacyAppSignal,
-  detectLegacyNpxSignal,
-  extractDbPathArg,
-  isCurrentAppEntry,
-} from './migration-utils'
+import { detectLegacyAppSignal, extractDbPathArg, isCurrentAppEntry } from './migration-utils'
 import { app } from 'electron'
 import type { McpEntryStatus } from '../../shared/types'
 
@@ -98,7 +93,7 @@ export function getClaudeCodeStatus(): McpEntryStatus {
   const currentScript = getMcpEntryScriptPath()
   if (isCurrentAppEntry(existing, currentExe, currentScript)) return 'current'
 
-  const signal = detectLegacyNpxSignal(existing) ?? detectLegacyAppSignal(existing)
+  const signal = detectLegacyAppSignal(existing)
   return signal !== null ? 'stale' : 'current'
 }
 

--- a/src/main/integrations/claude-desktop.ts
+++ b/src/main/integrations/claude-desktop.ts
@@ -18,12 +18,7 @@ import * as path from 'node:path'
 import * as os from 'node:os'
 import log from '../logger'
 import { buildAppMcpEntry, getMcpEntryScriptPath } from './app-mcp-entry'
-import {
-  detectLegacyAppSignal,
-  detectLegacyNpxSignal,
-  extractDbPathArg,
-  isCurrentAppEntry,
-} from './migration-utils'
+import { detectLegacyAppSignal, extractDbPathArg, isCurrentAppEntry } from './migration-utils'
 import { app } from 'electron'
 import type { McpEntryStatus } from '../../shared/types'
 
@@ -146,7 +141,7 @@ function classifyConfigPath(
   const existing = config.mcpServers?.[MCP_SERVER_KEY]
   if (!existing) return 'not-registered'
   if (isCurrentAppEntry(existing, currentExe, currentScript)) return 'current'
-  const signal = detectLegacyNpxSignal(existing) ?? detectLegacyAppSignal(existing)
+  const signal = detectLegacyAppSignal(existing)
   return signal !== null ? 'stale' : 'current'
 }
 
@@ -158,8 +153,8 @@ function classifyConfigPath(
  * Per-path classification:
  *   'current'        — entry matches the running app, or a foreign entry sits
  *                      at the memorylane key (conservative: don't stomp).
- *   'stale'          — entry matches a legacy shape we own (v0 Electron-as-
- *                      node, v1 npx CLI, moved .app).
+ *   'stale'          — entry matches an app-as-node shape we own but points
+ *                      at a different .app (moved, upgraded, or other edition).
  *   'not-registered' — no memorylane entry at this path.
  *
  * Reduction across all discovered paths:

--- a/src/main/integrations/cursor.ts
+++ b/src/main/integrations/cursor.ts
@@ -10,12 +10,7 @@ import * as path from 'node:path'
 import * as os from 'node:os'
 import log from '../logger'
 import { buildAppMcpEntry, getMcpEntryScriptPath } from './app-mcp-entry'
-import {
-  detectLegacyAppSignal,
-  detectLegacyNpxSignal,
-  extractDbPathArg,
-  isCurrentAppEntry,
-} from './migration-utils'
+import { detectLegacyAppSignal, extractDbPathArg, isCurrentAppEntry } from './migration-utils'
 import { app } from 'electron'
 import type { McpEntryStatus } from '../../shared/types'
 
@@ -97,7 +92,7 @@ export function getCursorStatus(): McpEntryStatus {
   const currentScript = getMcpEntryScriptPath()
   if (isCurrentAppEntry(existing, currentExe, currentScript)) return 'current'
 
-  const signal = detectLegacyNpxSignal(existing) ?? detectLegacyAppSignal(existing)
+  const signal = detectLegacyAppSignal(existing)
   return signal !== null ? 'stale' : 'current'
 }
 

--- a/src/main/integrations/migration-utils.test.ts
+++ b/src/main/integrations/migration-utils.test.ts
@@ -1,75 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import {
-  detectLegacyAppSignal,
-  detectLegacyNpxSignal,
-  extractDbPathArg,
-  isCurrentAppEntry,
-} from './migration-utils'
+import { detectLegacyAppSignal, extractDbPathArg, isCurrentAppEntry } from './migration-utils'
 
 // Fixed paths used to stand in for the "current" app's exe + mcp-entry.js
 // so these tests don't need to import electron.
 const CURRENT_EXE = '/Applications/MemoryLane.app/Contents/MacOS/MemoryLane'
 const CURRENT_SCRIPT =
   '/Applications/MemoryLane.app/Contents/Resources/app.asar/out/main/mcp-entry.js'
-
-describe('detectLegacyNpxSignal', () => {
-  it('matches the canonical v1 CLI entry', () => {
-    expect(
-      detectLegacyNpxSignal({
-        command: 'npx',
-        args: ['-y', '-p', '@deusxmachina-dev/memorylane-cli', 'memorylane-mcp'],
-      }),
-    ).toBe('npx-memorylane-cli')
-  })
-
-  it('matches the v1 entry with stdio type', () => {
-    expect(
-      detectLegacyNpxSignal({
-        type: 'stdio',
-        command: 'npx',
-        args: ['-y', '-p', '@deusxmachina-dev/memorylane-cli', 'memorylane-mcp'],
-      } as never),
-    ).toBe('npx-memorylane-cli')
-  })
-
-  it('matches the v1 entry with preserved --db-path args', () => {
-    expect(
-      detectLegacyNpxSignal({
-        command: 'npx',
-        args: [
-          '-y',
-          '-p',
-          '@deusxmachina-dev/memorylane-cli',
-          'memorylane-mcp',
-          '--db-path',
-          '/tmp/team.db',
-        ],
-      }),
-    ).toBe('npx-memorylane-cli')
-  })
-
-  it('rejects an npx entry pointing at a different package', () => {
-    expect(
-      detectLegacyNpxSignal({
-        command: 'npx',
-        args: ['-y', 'some-other-mcp'],
-      }),
-    ).toBe(null)
-  })
-
-  it('rejects a non-npx command', () => {
-    expect(
-      detectLegacyNpxSignal({
-        command: 'node',
-        args: ['@deusxmachina-dev/memorylane-cli'],
-      }),
-    ).toBe(null)
-  })
-
-  it('handles undefined', () => {
-    expect(detectLegacyNpxSignal(undefined)).toBe(null)
-  })
-})
 
 describe('detectLegacyAppSignal', () => {
   it('detects an entry with ELECTRON_RUN_AS_NODE env', () => {

--- a/src/main/integrations/migration-utils.ts
+++ b/src/main/integrations/migration-utils.ts
@@ -2,14 +2,10 @@
  * Shared helpers for detecting stale vs current MemoryLane MCP entries
  * across Claude Desktop, Claude Code, and Cursor configs.
  *
- * Timeline of entry shapes:
- *   v0 (pre-v0.18) — Electron app-as-node: command=MemoryLane binary,
- *                    args=[.../mcp-entry.js], env={ELECTRON_RUN_AS_NODE: '1'}.
- *   v1 (v0.18+)    — CLI via npx: command='npx',
- *                    args=['-y', '-p', '@deusxmachina-dev/memorylane-cli', 'memorylane-mcp'].
- *   v2 (current)   — Electron app-as-node again, now with multi-DB support
- *                    and shared server code. Same shape as v0 but the .app
- *                    path may vary (user moved it, upgraded, switched edition).
+ * The current entry shape is Electron app-as-node: command=MemoryLane binary,
+ * args=[.../mcp-entry.js], env={ELECTRON_RUN_AS_NODE: '1'}. An entry is stale
+ * when it has that shape but points at a different .app (user moved it,
+ * upgraded, or switched edition).
  *
  * The per-integration `getXStatus` helpers use these fingerprints to surface a
  * 'stale' state in the Integrations UI so the user can reconnect explicitly —
@@ -28,27 +24,13 @@ export interface McpEntryShape {
  * can pinpoint why an entry was treated as stale.
  */
 export type LegacySignal =
-  | 'npx-memorylane-cli'
   | 'electron-run-as-node-env'
   | 'mcp-entry-js-arg'
   | 'packaged-app-binary'
 
 /**
- * Detects the v1 CLI shape: `npx ... @deusxmachina-dev/memorylane-cli`.
- */
-export function detectLegacyNpxSignal(entry: McpEntryShape | undefined): LegacySignal | null {
-  if (!entry || typeof entry !== 'object') return null
-  if (entry.command !== 'npx') return null
-  if (!Array.isArray(entry.args)) return null
-  const hit = entry.args.some(
-    (arg) => typeof arg === 'string' && arg.includes('@deusxmachina-dev/memorylane-cli'),
-  )
-  return hit ? 'npx-memorylane-cli' : null
-}
-
-/**
- * Detects any Electron app-as-node shape (v0 or an outdated v2 pointing at a
- * moved `.app`). This is deliberately broad — the caller should first check
+ * Detects any Electron app-as-node shape pointing at a moved `.app`. This is
+ * deliberately broad — the caller should first check
  * `isCurrentAppEntry` against the current app's exe + script path and only
  * call into `detectLegacyAppSignal` as a fallback.
  */

--- a/src/main/integrations/status.test.ts
+++ b/src/main/integrations/status.test.ts
@@ -107,11 +107,6 @@ const CURRENT_ENTRY = {
   env: { ELECTRON_RUN_AS_NODE: '1' },
 }
 
-const STALE_NPX_ENTRY = {
-  command: 'npx',
-  args: ['-y', '-p', '@deusxmachina-dev/memorylane-cli', 'memorylane-mcp'],
-}
-
 const STALE_MOVED_APP_ENTRY = {
   command: '/Applications/MemoryLane-old.app/Contents/MacOS/MemoryLane',
   args: ['/Applications/MemoryLane-old.app/Contents/Resources/app.asar/out/main/mcp-entry.js'],
@@ -154,11 +149,6 @@ describe('getClaudeDesktopStatus', () => {
     expect(getClaudeDesktopStatus()).toBe('current')
   })
 
-  it('stale when entry is the old npx CLI shape', () => {
-    writeClaudeDesktopConfig(STALE_NPX_ENTRY)
-    expect(getClaudeDesktopStatus()).toBe('stale')
-  })
-
   it('stale when entry points at a moved .app', () => {
     writeClaudeDesktopConfig(STALE_MOVED_APP_ENTRY)
     expect(getClaudeDesktopStatus()).toBe('stale')
@@ -198,12 +188,12 @@ describe.runIf(process.platform === 'win32')('getClaudeDesktopStatus — Windows
   })
 
   it('stale when only the MSIX path has a legacy entry', () => {
-    writeMsixConfig(STALE_NPX_ENTRY)
+    writeMsixConfig(STALE_MOVED_APP_ENTRY)
     expect(getClaudeDesktopStatus()).toBe('stale')
   })
 
   it('stale when classic is stale and MSIX is current', () => {
-    writeClaudeDesktopConfig(STALE_NPX_ENTRY)
+    writeClaudeDesktopConfig(STALE_MOVED_APP_ENTRY)
     writeMsixConfig(CURRENT_ENTRY)
     expect(getClaudeDesktopStatus()).toBe('stale')
   })
@@ -312,8 +302,8 @@ describe('getClaudeCodeStatus', () => {
     expect(getClaudeCodeStatus()).toBe('current')
   })
 
-  it('stale when entry is the npx CLI shape', () => {
-    writeClaudeCodeSettings(STALE_NPX_ENTRY)
+  it('stale when entry points at a moved .app', () => {
+    writeClaudeCodeSettings(STALE_MOVED_APP_ENTRY)
     expect(getClaudeCodeStatus()).toBe('stale')
   })
 })


### PR DESCRIPTION
## What

Removes `detectLegacyNpxSignal` — the last remnant of the old "migrate baked MCP into the npx CLI" era (DEU-25).

The auto-migration script itself was already removed in #122, which made the Electron app the MCP entrypoint again. This drops the leftover npx-CLI fingerprint now that users have migrated off the npx CLI.

## Kept (still load-bearing)

`detectLegacyAppSignal`, the `'stale'` status state, and the Reconnect button stay — they power the "App path changed — reconnect" prompt for moved apps and the Windows MSIX dual-write case.

## Behavior change

A leftover npx entry now classifies as `'current'` (the conservative don't-stomp branch) instead of `'stale'`. That's the intended outcome — npx-CLI users are exactly the population whose stale handling is being retired.

## Changes

- `migration-utils.ts` — delete `detectLegacyNpxSignal`, drop the `'npx-memorylane-cli'` variant from `LegacySignal`, refresh the module doc comment.
- `claude-code.ts` / `cursor.ts` / `claude-desktop.ts` — status fns call `detectLegacyAppSignal` only; drop unused import; trim the stale "v1 npx CLI" doc line.
- `migration-utils.test.ts` / `status.test.ts` — remove npx→stale assertions; repoint MSIX/Claude-Code stale cases to the moved-`.app` shape.
- `index.ts` — fix an outdated comment claiming the MCP server comes from the CLI package.

## Verification

- `npm run lint` → 0 errors
- `npm test -- migration-utils status` → 32 passed, 13 skipped (Windows-MSIX-only block)

Closes DEU-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)