### PR TITLE
feat(capture): timed pause with auto-resume (DEU-139)

### DIFF
--- a/src/main/capture-orchestrator.test.ts
+++ b/src/main/capture-orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createCaptureCoordinator } from './capture-orchestrator'
 
 function createCaptureMock() {
@@ -84,5 +84,89 @@ describe('createCaptureCoordinator', () => {
     expect(capture.startCapture).toHaveBeenCalledTimes(1)
     expect(userContextBuilder.scheduleRun).toHaveBeenCalledTimes(1)
     expect(patternDetector.scheduleRun).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('createCaptureCoordinator timed pause', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function makeCoordinator(overrides?: { isPaused?: () => boolean }) {
+    const capture = createCaptureMock()
+    const stateManager = createCaptureStateManagerMock()
+    const onStateChanged = vi.fn()
+    const coordinator = createCaptureCoordinator({
+      capture,
+      captureStateManager: stateManager as never,
+      isPaused: overrides?.isPaused ?? (() => false),
+      userContextBuilder: { scheduleRun: vi.fn() } as never,
+      patternDetector: { scheduleRun: vi.fn() } as never,
+      onStateChanged,
+    })
+    return { capture, stateManager, onStateChanged, coordinator }
+  }
+
+  it('stops capture and records a deadline without disabling the preference', () => {
+    const { capture, stateManager, onStateChanged, coordinator } = makeCoordinator()
+
+    coordinator.controls.pauseCapture(30 * 60_000)
+
+    expect(capture.stopCapture).toHaveBeenCalledTimes(1)
+    expect(stateManager.setCaptureEnabled).not.toHaveBeenCalled()
+    expect(coordinator.controls.isUserPaused()).toBe(true)
+    expect(coordinator.controls.getPauseState().pausedUntilMs).not.toBeNull()
+    expect(onStateChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('auto-resumes capture when the timer elapses', () => {
+    const { capture, coordinator } = makeCoordinator()
+
+    coordinator.controls.pauseCapture(30 * 60_000)
+    expect(capture.startCapture).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(30 * 60_000)
+
+    expect(capture.startCapture).toHaveBeenCalledTimes(1)
+    expect(coordinator.controls.isUserPaused()).toBe(false)
+    expect(coordinator.controls.getPauseState().pausedUntilMs).toBeNull()
+  })
+
+  it('resumeCapture starts capture immediately and cancels the timer', () => {
+    const { capture, coordinator } = makeCoordinator()
+
+    coordinator.controls.pauseCapture(30 * 60_000)
+    coordinator.controls.resumeCapture()
+
+    expect(capture.startCapture).toHaveBeenCalledTimes(1)
+    expect(coordinator.controls.isUserPaused()).toBe(false)
+
+    // Timer must not fire a second start after a manual resume.
+    vi.advanceTimersByTime(30 * 60_000)
+    expect(capture.startCapture).toHaveBeenCalledTimes(1)
+  })
+
+  it('requestStopCapture cancels an active pause and disables the preference', () => {
+    const { stateManager, coordinator } = makeCoordinator()
+
+    coordinator.controls.pauseCapture(30 * 60_000)
+    coordinator.controls.requestStopCapture()
+
+    expect(coordinator.controls.isUserPaused()).toBe(false)
+    expect(stateManager.setCaptureEnabled).toHaveBeenCalledWith(false)
+  })
+
+  it('resumeCaptureIfDesired does not override an active pause', () => {
+    const { capture, coordinator } = makeCoordinator()
+
+    coordinator.controls.pauseCapture(30 * 60_000)
+    coordinator.resumeCaptureIfDesired('resume')
+
+    expect(capture.startCapture).not.toHaveBeenCalled()
+    expect(coordinator.controls.isUserPaused()).toBe(true)
   })
 })

--- a/src/main/capture-orchestrator.ts
+++ b/src/main/capture-orchestrator.ts
@@ -36,9 +36,11 @@ export function createCaptureCoordinator(params: {
    */
   patternDetector: { scheduleRun(): void } | null
   /**
-   * Notifies the UI (tray + renderer) after a pause/resume so the displayed
-   * state stays in sync even on paths with no direct caller (e.g. the
-   * auto-resume timer firing). Optional so tests can omit it.
+   * Notifies the UI (tray + renderer) after any capture-state transition
+   * (start/stop/pause/resume) so the displayed state stays in sync — including
+   * on paths with no direct caller (e.g. the auto-resume timer firing). This is
+   * the single sync point: callers should not refresh the tray/renderer
+   * themselves. Optional so tests can omit it.
    */
   onStateChanged?: () => void
 }): {
@@ -84,21 +86,30 @@ export function createCaptureCoordinator(params: {
   const requestStartCapture = (): void => {
     // Starting un-pauses: a manual start overrides any active timed pause.
     clearPauseTimer()
-    if (!persistCaptureEnabled(true)) return
+    if (!persistCaptureEnabled(true)) {
+      notifyStateChanged()
+      return
+    }
     if (params.isPaused()) {
       log.info('[Main] Capture preference enabled while paused; will start on resume')
+      notifyStateChanged()
       return
     }
     params.capture.startCapture()
     scheduleBackgroundAnalyzers()
+    notifyStateChanged()
   }
 
   const requestStopCapture = (): void => {
     // Indefinite "turn off": cancel any timed pause so it can't auto-resume.
     clearPauseTimer()
-    if (!persistCaptureEnabled(false)) return
+    if (!persistCaptureEnabled(false)) {
+      notifyStateChanged()
+      return
+    }
     void params.capture.forceClose()
     params.capture.stopCapture()
+    notifyStateChanged()
   }
 
   // Resume from a timed pause: start capture if it's still the desired state.

--- a/src/main/capture-orchestrator.ts
+++ b/src/main/capture-orchestrator.ts
@@ -7,6 +7,16 @@ export interface CaptureCoordinatorControls {
   isCapturingNow(): boolean
   requestStartCapture(): void
   requestStopCapture(): void
+  /**
+   * Temporarily pause capture for `durationMs`, then auto-resume. The persisted
+   * capture preference stays enabled — this is an in-memory pause only, so an
+   * app restart resumes capture. Re-pausing while paused replaces the timer.
+   */
+  pauseCapture(durationMs: number): void
+  /** Resume immediately from a timed pause (clears the auto-resume timer). */
+  resumeCapture(): void
+  isUserPaused(): boolean
+  getPauseState(): { pausedUntilMs: number | null }
   stopCaptureForShutdown(): void
   forceClose(): Promise<void>
   updateActivityWindowConfig(input: {
@@ -25,14 +35,41 @@ export function createCaptureCoordinator(params: {
    * TaskMiner (selected by the ML_TASK_MINING flag) can be passed in.
    */
   patternDetector: { scheduleRun(): void } | null
+  /**
+   * Notifies the UI (tray + renderer) after a pause/resume so the displayed
+   * state stays in sync even on paths with no direct caller (e.g. the
+   * auto-resume timer firing). Optional so tests can omit it.
+   */
+  onStateChanged?: () => void
 }): {
   controls: CaptureCoordinatorControls
   resumeCaptureIfDesired(reason: 'startup' | 'resume'): void
 } {
+  let pauseTimer: ReturnType<typeof setTimeout> | null = null
+  let pausedUntilMs: number | null = null
+
   const scheduleBackgroundAnalyzers = (): void => {
     params.userContextBuilder?.scheduleRun()
     params.patternDetector?.scheduleRun()
   }
+
+  const notifyStateChanged = (): void => {
+    try {
+      params.onStateChanged?.()
+    } catch (error) {
+      log.warn('[Main] capture onStateChanged listener threw:', error)
+    }
+  }
+
+  const clearPauseTimer = (): void => {
+    if (pauseTimer) {
+      clearTimeout(pauseTimer)
+      pauseTimer = null
+    }
+    pausedUntilMs = null
+  }
+
+  const isUserPaused = (): boolean => pausedUntilMs !== null
 
   const persistCaptureEnabled = (enabled: boolean): boolean => {
     try {
@@ -45,6 +82,8 @@ export function createCaptureCoordinator(params: {
   }
 
   const requestStartCapture = (): void => {
+    // Starting un-pauses: a manual start overrides any active timed pause.
+    clearPauseTimer()
     if (!persistCaptureEnabled(true)) return
     if (params.isPaused()) {
       log.info('[Main] Capture preference enabled while paused; will start on resume')
@@ -55,17 +94,60 @@ export function createCaptureCoordinator(params: {
   }
 
   const requestStopCapture = (): void => {
+    // Indefinite "turn off": cancel any timed pause so it can't auto-resume.
+    clearPauseTimer()
     if (!persistCaptureEnabled(false)) return
     void params.capture.forceClose()
     params.capture.stopCapture()
   }
 
+  // Resume from a timed pause: start capture if it's still the desired state.
+  // Used both by the manual "resume now" control and by the auto-resume timer.
+  const resumeCapture = (): void => {
+    clearPauseTimer()
+    if (!params.captureStateManager.isCaptureEnabled()) {
+      notifyStateChanged()
+      return
+    }
+    if (!params.capture.isCapturingNow() && !params.isPaused()) {
+      log.info('[Main] Resuming capture from timed pause')
+      params.capture.startCapture()
+      scheduleBackgroundAnalyzers()
+    }
+    notifyStateChanged()
+  }
+
+  const pauseCapture = (durationMs: number): void => {
+    const clamped = Number.isFinite(durationMs) && durationMs > 0 ? Math.floor(durationMs) : 0
+    if (clamped <= 0) return
+
+    if (pauseTimer) clearTimeout(pauseTimer)
+    pausedUntilMs = Date.now() + clamped
+    pauseTimer = setTimeout(() => {
+      pauseTimer = null
+      pausedUntilMs = null
+      resumeCapture()
+    }, clamped)
+    pauseTimer.unref?.()
+
+    // Keep the persisted preference enabled — the intent stays "capture on",
+    // we're only taking a break. Halt capture now.
+    void params.capture.forceClose()
+    params.capture.stopCapture()
+    log.info(`[Main] Capture paused for ${Math.round(clamped / 1000)}s`)
+    notifyStateChanged()
+  }
+
   const stopCaptureForShutdown = (): void => {
+    clearPauseTimer()
     params.capture.stopCapture()
   }
 
   const resumeCaptureIfDesired = (reason: 'startup' | 'resume'): void => {
     if (!params.captureStateManager.isCaptureEnabled()) return
+    // A timed pause is in-memory: on startup there is none, but on power-resume
+    // an active pause must win so unlocking doesn't cut a pause short.
+    if (isUserPaused()) return
     if (params.capture.isCapturingNow() || params.isPaused()) return
 
     log.info(`[Main] Starting capture from persisted preference (${reason})`)
@@ -79,6 +161,10 @@ export function createCaptureCoordinator(params: {
       isCapturingNow: () => params.capture.isCapturingNow(),
       requestStartCapture,
       requestStopCapture,
+      pauseCapture,
+      resumeCapture,
+      isUserPaused,
+      getPauseState: () => ({ pausedUntilMs }),
       stopCaptureForShutdown,
       forceClose: () => params.capture.forceClose(),
       updateActivityWindowConfig: (input) => params.capture.updateActivityWindowConfig(input),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -232,12 +232,19 @@ app.on('ready', async () => {
     isPaused: shouldPause,
     userContextBuilder,
     patternDetector: scheduledMiner,
+    onStateChanged: () => {
+      void updateTrayMenu()
+      void sendStatusToRenderer()
+    },
   })
 
   const hotkeyManager = createCaptureHotkeyManager({
     platform: process.platform,
     onTriggered: (accelerator) => {
-      if (captureCoordinator.controls.isCapturingNow()) {
+      if (captureCoordinator.controls.isUserPaused()) {
+        captureCoordinator.controls.resumeCapture()
+        log.info(`[Main] Capture resumed from pause by hotkey (${accelerator})`)
+      } else if (captureCoordinator.controls.isCapturingNow()) {
         captureCoordinator.controls.requestStopCapture()
         log.info(`[Main] Capture stopped by hotkey (${accelerator})`)
       } else {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -251,8 +251,7 @@ app.on('ready', async () => {
         captureCoordinator.controls.requestStartCapture()
         log.info(`[Main] Capture started by hotkey (${accelerator})`)
       }
-      void updateTrayMenu()
-      void sendStatusToRenderer()
+      // Tray + renderer are refreshed by the coordinator's onStateChanged.
     },
   })
 

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -89,6 +89,9 @@ interface MainWindowDependencies {
     isCapturingNow: () => boolean
     requestStartCapture: () => void
     requestStopCapture: () => void
+    pauseCapture: (durationMs: number) => void
+    resumeCapture: () => void
+    getPauseState: () => { pausedUntilMs: number | null }
     forceClose: () => Promise<void>
     updateActivityWindowConfig: (input: {
       minActivityDurationMs: number
@@ -184,6 +187,7 @@ function buildStatus(): MainWindowStatus {
   return {
     capturing: deps?.capture.isCapturingNow() ?? false,
     captureHotkeyLabel: deps?.getCaptureHotkeyLabel() ?? '',
+    pausedUntilMs: deps?.capture.getPauseState().pausedUntilMs ?? null,
   }
 }
 
@@ -526,12 +530,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
   })
 
   handle('main-window:toggleCapture', () => {
-    if (!deps) {
-      return {
-        capturing: false,
-        captureHotkeyLabel: '',
-      }
-    }
+    if (!deps) return buildStatus()
 
     if (deps.capture.isCapturingNow()) {
       log.info('[Settings] user stopped capture')
@@ -543,6 +542,22 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
 
     void updateTrayMenu()
 
+    return buildStatus()
+  })
+
+  handle('main-window:pauseCapture', (_event, durationMs: number) => {
+    if (!deps) return buildStatus()
+    log.info(`[Settings] user paused capture for ${Math.round((durationMs ?? 0) / 1000)}s`)
+    deps.capture.pauseCapture(durationMs)
+    void updateTrayMenu()
+    return buildStatus()
+  })
+
+  handle('main-window:resumeCapture', () => {
+    if (!deps) return buildStatus()
+    log.info('[Settings] user resumed capture from pause')
+    deps.capture.resumeCapture()
+    void updateTrayMenu()
     return buildStatus()
   })
 

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -540,16 +540,18 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       deps.capture.requestStartCapture()
     }
 
-    void updateTrayMenu()
-
+    // Tray + renderer are refreshed by the coordinator's onStateChanged.
     return buildStatus()
   })
 
   handle('main-window:pauseCapture', (_event, durationMs: number) => {
     if (!deps) return buildStatus()
-    log.info(`[Settings] user paused capture for ${Math.round((durationMs ?? 0) / 1000)}s`)
+    if (!Number.isFinite(durationMs) || durationMs <= 0) {
+      log.warn(`[Settings] ignoring pauseCapture with invalid duration: ${durationMs}`)
+      return buildStatus()
+    }
+    log.info(`[Settings] user paused capture for ${Math.round(durationMs / 1000)}s`)
     deps.capture.pauseCapture(durationMs)
-    void updateTrayMenu()
     return buildStatus()
   })
 
@@ -557,7 +559,6 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     if (!deps) return buildStatus()
     log.info('[Settings] user resumed capture from pause')
     deps.capture.resumeCapture()
-    void updateTrayMenu()
     return buildStatus()
   })
 

--- a/src/main/ui/tray.ts
+++ b/src/main/ui/tray.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import log from '../logger'
 import { formatBytes, formatNumber } from '../utils/formatters'
 import type { StorageService } from '../storage'
-import { sendStatusToRenderer, openMainWindow } from './main-window'
+import { openMainWindow } from './main-window'
 import { getUpdateState, quitAndInstall } from '../updater'
 import { createTrayPrivacyState } from './tray-privacy-state'
 import { CAPTURE_PAUSE_CONFIG } from '../../shared/constants'
@@ -127,20 +127,14 @@ const buildCaptureMenuItems = (state: {
   isUserPaused: boolean
   pausedUntilMs: number | null
 }): Electron.MenuItemConstructorOptions[] => {
-  const refresh = (): void => {
-    void updateTrayMenu()
-    void sendStatusToRenderer()
-  }
-
+  // Click handlers only invoke a coordinator control; the resulting
+  // onStateChanged refreshes the tray menu and renderer.
   if (state.isUserPaused && state.pausedUntilMs !== null) {
     return [
       { label: `Paused — resumes ${formatRemaining(state.pausedUntilMs)}`, enabled: false },
       {
         label: 'Resume Capture Now',
-        click: () => {
-          deps!.capture.resumeCapture()
-          refresh()
-        },
+        click: () => deps!.capture.resumeCapture(),
       },
     ]
   }
@@ -151,18 +145,12 @@ const buildCaptureMenuItems = (state: {
         label: 'Pause Capture',
         submenu: CAPTURE_PAUSE_CONFIG.PRESETS_MINUTES.map((minutes) => ({
           label: `Pause for ${formatDuration(minutes)}`,
-          click: () => {
-            deps!.capture.pauseCapture(minutes * 60_000)
-            refresh()
-          },
+          click: () => deps!.capture.pauseCapture(minutes * 60_000),
         })),
       },
       {
         label: 'Turn Off Capture',
-        click: () => {
-          deps!.capture.requestStopCapture()
-          refresh()
-        },
+        click: () => deps!.capture.requestStopCapture(),
       },
     ]
   }
@@ -170,10 +158,7 @@ const buildCaptureMenuItems = (state: {
   return [
     {
       label: 'Start Capture',
-      click: () => {
-        deps!.capture.requestStartCapture()
-        refresh()
-      },
+      click: () => deps!.capture.requestStartCapture(),
     },
   ]
 }

--- a/src/main/ui/tray.ts
+++ b/src/main/ui/tray.ts
@@ -10,16 +10,40 @@ import type { StorageService } from '../storage'
 import { sendStatusToRenderer, openMainWindow } from './main-window'
 import { getUpdateState, quitAndInstall } from '../updater'
 import { createTrayPrivacyState } from './tray-privacy-state'
+import { CAPTURE_PAUSE_CONFIG } from '../../shared/constants'
 
 interface TrayDependencies {
   capture: {
     isCapturingNow: () => boolean
     requestStartCapture: () => void
     requestStopCapture: () => void
+    pauseCapture: (durationMs: number) => void
+    resumeCapture: () => void
+    getPauseState: () => { pausedUntilMs: number | null }
     stopCaptureForShutdown: () => void
     forceClose: () => Promise<void>
   }
   storage: StorageService
+}
+
+// Tray menus are static once set; while paused we periodically rebuild so the
+// "resumes in N min" countdown stays roughly fresh if the user opens the menu.
+const PAUSE_REFRESH_MS = 30_000
+let pauseRefreshTimer: ReturnType<typeof setTimeout> | null = null
+
+const clearPauseRefreshTimer = (): void => {
+  if (pauseRefreshTimer) {
+    clearTimeout(pauseRefreshTimer)
+    pauseRefreshTimer = null
+  }
+}
+
+const formatDuration = (minutes: number): string => (minutes === 60 ? '1 hour' : `${minutes} min`)
+
+const formatRemaining = (pausedUntilMs: number): string => {
+  const remainingMs = Math.max(0, pausedUntilMs - Date.now())
+  const minutes = Math.ceil(remainingMs / 60_000)
+  return minutes <= 1 ? 'less than a minute' : `~${minutes} min`
 }
 
 let tray: Tray | null = null
@@ -37,6 +61,7 @@ export const setPrivacyBlockedState = (blocked: boolean): void => {
 
 app.on('before-quit', () => {
   trayPrivacyState.dispose()
+  clearPauseRefreshTimer()
 
   if (tray) {
     tray.destroy()
@@ -92,20 +117,97 @@ const buildUsageStatsSubmenu = async (): Promise<Electron.MenuItemConstructorOpt
 }
 
 /**
+ * Build the capture-control menu items for the current state:
+ * - paused: a status line + "Resume Capture Now"
+ * - capturing: "Pause Capture ▸ (15/30/60 min)" + "Turn Off Capture"
+ * - off: "Start Capture"
+ */
+const buildCaptureMenuItems = (state: {
+  isCapturing: boolean
+  isUserPaused: boolean
+  pausedUntilMs: number | null
+}): Electron.MenuItemConstructorOptions[] => {
+  const refresh = (): void => {
+    void updateTrayMenu()
+    void sendStatusToRenderer()
+  }
+
+  if (state.isUserPaused && state.pausedUntilMs !== null) {
+    return [
+      { label: `Paused — resumes ${formatRemaining(state.pausedUntilMs)}`, enabled: false },
+      {
+        label: 'Resume Capture Now',
+        click: () => {
+          deps!.capture.resumeCapture()
+          refresh()
+        },
+      },
+    ]
+  }
+
+  if (state.isCapturing) {
+    return [
+      {
+        label: 'Pause Capture',
+        submenu: CAPTURE_PAUSE_CONFIG.PRESETS_MINUTES.map((minutes) => ({
+          label: `Pause for ${formatDuration(minutes)}`,
+          click: () => {
+            deps!.capture.pauseCapture(minutes * 60_000)
+            refresh()
+          },
+        })),
+      },
+      {
+        label: 'Turn Off Capture',
+        click: () => {
+          deps!.capture.requestStopCapture()
+          refresh()
+        },
+      },
+    ]
+  }
+
+  return [
+    {
+      label: 'Start Capture',
+      click: () => {
+        deps!.capture.requestStartCapture()
+        refresh()
+      },
+    },
+  ]
+}
+
+/**
  * Update the tray context menu with current state
  */
 export const updateTrayMenu = async (): Promise<void> => {
   if (!tray || !deps) return
 
   const isCapturing = deps.capture.isCapturingNow()
+  const { pausedUntilMs } = deps.capture.getPauseState()
+  const isUserPaused = pausedUntilMs !== null
   const { isPrivacyBlocked, blockedRecently } = trayPrivacyState.getStatus(isCapturing)
+
+  // Keep the countdown label fresh while paused; stop refreshing otherwise.
+  clearPauseRefreshTimer()
+  if (isUserPaused) {
+    pauseRefreshTimer = setTimeout(() => {
+      pauseRefreshTimer = null
+      void updateTrayMenu()
+    }, PAUSE_REFRESH_MS)
+    pauseRefreshTimer.unref?.()
+  }
+
   const versionSuffix = ` (v${app.getVersion()})`
   tray.setToolTip(
-    isPrivacyBlocked
-      ? `MemoryLane - Capture Paused (Privacy Rule)${versionSuffix}`
-      : blockedRecently
-        ? `MemoryLane - Capture Recently Paused (Privacy Rule)${versionSuffix}`
-        : `MemoryLane - Screen Capture${versionSuffix}`,
+    isUserPaused
+      ? `MemoryLane - Capture Paused (resumes ${formatRemaining(pausedUntilMs)})${versionSuffix}`
+      : isPrivacyBlocked
+        ? `MemoryLane - Capture Paused (Privacy Rule)${versionSuffix}`
+        : blockedRecently
+          ? `MemoryLane - Capture Recently Paused (Privacy Rule)${versionSuffix}`
+          : `MemoryLane - Screen Capture${versionSuffix}`,
   )
 
   const usageStatsSubmenu = await buildUsageStatsSubmenu()
@@ -137,18 +239,7 @@ export const updateTrayMenu = async (): Promise<void> => {
             { type: 'separator' as const },
           ]
         : []),
-    {
-      label: isCapturing ? 'Stop Capture' : 'Start Capture',
-      click: () => {
-        if (isCapturing) {
-          deps!.capture.requestStopCapture()
-        } else {
-          deps!.capture.requestStartCapture()
-        }
-        void updateTrayMenu()
-        void sendStatusToRenderer()
-      },
-    },
+    ...buildCaptureMenuItems({ isCapturing, isUserPaused, pausedUntilMs }),
     { type: 'separator' },
     {
       label: 'Usage Stats',

--- a/src/main/ui/tray.ts
+++ b/src/main/ui/tray.ts
@@ -10,7 +10,7 @@ import type { StorageService } from '../storage'
 import { openMainWindow } from './main-window'
 import { getUpdateState, quitAndInstall } from '../updater'
 import { createTrayPrivacyState } from './tray-privacy-state'
-import { CAPTURE_PAUSE_CONFIG } from '../../shared/constants'
+import { CAPTURE_PAUSE_CONFIG, formatPauseDuration } from '../../shared/constants'
 
 interface TrayDependencies {
   capture: {
@@ -37,8 +37,6 @@ const clearPauseRefreshTimer = (): void => {
     pauseRefreshTimer = null
   }
 }
-
-const formatDuration = (minutes: number): string => (minutes === 60 ? '1 hour' : `${minutes} min`)
 
 const formatRemaining = (pausedUntilMs: number): string => {
   const remainingMs = Math.max(0, pausedUntilMs - Date.now())
@@ -144,7 +142,7 @@ const buildCaptureMenuItems = (state: {
       {
         label: 'Pause Capture',
         submenu: CAPTURE_PAUSE_CONFIG.PRESETS_MINUTES.map((minutes) => ({
-          label: `Pause for ${formatDuration(minutes)}`,
+          label: `Pause for ${formatPauseDuration(minutes)}`,
           click: () => deps!.capture.pauseCapture(minutes * 60_000),
         })),
       },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,6 +26,8 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
   // Capture control
   getStatus: () => ipcRenderer.invoke('main-window:getStatus'),
   toggleCapture: () => ipcRenderer.invoke('main-window:toggleCapture'),
+  pauseCapture: (durationMs: number) => ipcRenderer.invoke('main-window:pauseCapture', durationMs),
+  resumeCapture: () => ipcRenderer.invoke('main-window:resumeCapture'),
   onStatusChanged: (callback: (status: unknown) => void) => {
     const handler = (_event: unknown, status: unknown): void => callback(status)
     ipcRenderer.on('main-window:statusChanged', handler)

--- a/src/renderer/pages/main-window/MainWindowApp.tsx
+++ b/src/renderer/pages/main-window/MainWindowApp.tsx
@@ -419,35 +419,26 @@ export function MainWindowApp(): React.JSX.Element {
     [],
   )
 
-  const handleToggle = useCallback(async () => {
-    setToggling(true)
-    try {
-      applyStatus(await api.toggleCapture())
-    } finally {
-      setToggling(false)
-    }
-  }, [api, applyStatus])
-
-  const handlePause = useCallback(
-    async (durationMs: number) => {
+  // Run a capture-control IPC call with the `toggling` busy flag and apply the
+  // returned status. Shared by toggle/pause/resume — they differ only in call.
+  const runStatusAction = useCallback(
+    async (action: () => Promise<{ capturing: boolean; pausedUntilMs: number | null }>) => {
       setToggling(true)
       try {
-        applyStatus(await api.pauseCapture(durationMs))
+        applyStatus(await action())
       } finally {
         setToggling(false)
       }
     },
-    [api, applyStatus],
+    [applyStatus],
   )
 
-  const handleResume = useCallback(async () => {
-    setToggling(true)
-    try {
-      applyStatus(await api.resumeCapture())
-    } finally {
-      setToggling(false)
-    }
-  }, [api, applyStatus])
+  const handleToggle = useCallback(() => runStatusAction(api.toggleCapture), [api, runStatusAction])
+  const handlePause = useCallback(
+    (durationMs: number) => runStatusAction(() => api.pauseCapture(durationMs)),
+    [api, runStatusAction],
+  )
+  const handleResume = useCallback(() => runStatusAction(api.resumeCapture), [api, runStatusAction])
 
   const advance = useCallback(
     (id: OnboardingStepId) => () => {

--- a/src/renderer/pages/main-window/MainWindowApp.tsx
+++ b/src/renderer/pages/main-window/MainWindowApp.tsx
@@ -59,6 +59,7 @@ export function MainWindowApp(): React.JSX.Element {
   )
   const [activeVendor, setActiveVendor] = useState<Vendor>('openrouter')
   const [capturing, setCapturing] = useState(false)
+  const [pausedUntilMs, setPausedUntilMs] = useState<number | null>(null)
   const [toggling, setToggling] = useState(false)
   const [stats, setStats] = useState<MainWindowStats | null>(null)
   const [mcpStatus, setMcpStatus] = useState<McpRegistrationStatus | null>(null)
@@ -302,9 +303,11 @@ export function MainWindowApp(): React.JSX.Element {
   useEffect(() => {
     void api.getStatus().then((status) => {
       setCapturing(status.capturing)
+      setPausedUntilMs(status.pausedUntilMs)
     })
     const unsubscribe = api.onStatusChanged((status) => {
       setCapturing(status.capturing)
+      setPausedUntilMs(status.pausedUntilMs)
       void loadStats()
       void loadPatterns()
       void activitiesRefreshRef.current()
@@ -401,21 +404,50 @@ export function MainWindowApp(): React.JSX.Element {
       void refreshOnFocus()
       void api.getStatus().then((status) => {
         setCapturing(status.capturing)
+        setPausedUntilMs(status.pausedUntilMs)
       })
     }
     window.addEventListener('focus', handleFocus)
     return () => window.removeEventListener('focus', handleFocus)
   }, [api, refreshOnFocus])
 
+  const applyStatus = useCallback(
+    (status: { capturing: boolean; pausedUntilMs: number | null }) => {
+      setCapturing(status.capturing)
+      setPausedUntilMs(status.pausedUntilMs)
+    },
+    [],
+  )
+
   const handleToggle = useCallback(async () => {
     setToggling(true)
     try {
-      const status = await api.toggleCapture()
-      setCapturing(status.capturing)
+      applyStatus(await api.toggleCapture())
     } finally {
       setToggling(false)
     }
-  }, [api])
+  }, [api, applyStatus])
+
+  const handlePause = useCallback(
+    async (durationMs: number) => {
+      setToggling(true)
+      try {
+        applyStatus(await api.pauseCapture(durationMs))
+      } finally {
+        setToggling(false)
+      }
+    },
+    [api, applyStatus],
+  )
+
+  const handleResume = useCallback(async () => {
+    setToggling(true)
+    try {
+      applyStatus(await api.resumeCapture())
+    } finally {
+      setToggling(false)
+    }
+  }, [api, applyStatus])
 
   const advance = useCallback(
     (id: OnboardingStepId) => () => {
@@ -537,6 +569,9 @@ export function MainWindowApp(): React.JSX.Element {
       capturing={capturing}
       toggling={toggling}
       onToggleCapture={() => void handleToggle()}
+      pausedUntilMs={pausedUntilMs}
+      onPauseCapture={(durationMs) => void handlePause(durationMs)}
+      onResumeCapture={() => void handleResume()}
       vendor={activeVendor}
       llmHealth={llmHealth}
       configured={isConfigured}

--- a/src/renderer/pages/main-window/components/CaptureControlSection.tsx
+++ b/src/renderer/pages/main-window/components/CaptureControlSection.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+import { Menu } from '@base-ui/react/menu'
+import { CaretDownIcon } from '@phosphor-icons/react'
 import { Button } from '@components/ui/button'
 import { CAPTURE_PAUSE_CONFIG } from '@/shared/constants'
 
@@ -140,24 +142,22 @@ export function CaptureControlSection({
     )
   }
 
-  // Expanded: paused — countdown + resume.
+  // Expanded: paused — the play icon is the resume action; the label shows the
+  // live auto-resume countdown rather than a redundant "Resume now".
   if (isPaused) {
     return (
-      <div className="flex flex-col gap-1.5">
-        <p className="text-center text-xs text-muted-foreground">
-          Paused — resumes in {countdown ?? '…'}
-        </p>
-        <Button
-          className="w-full"
-          variant="default"
-          size="lg"
-          disabled={toggling}
-          onClick={onResume}
-        >
-          <PlayIcon />
-          <span className="ml-2">Resume now</span>
-        </Button>
-      </div>
+      <Button
+        className="w-full"
+        variant="default"
+        size="lg"
+        disabled={toggling}
+        onClick={onResume}
+        aria-label="Resume now"
+        title="Resume now"
+      >
+        <PlayIcon />
+        <span className="ml-2">Resumes in {countdown ?? '…'}</span>
+      </Button>
     )
   }
 
@@ -171,11 +171,16 @@ export function CaptureControlSection({
     )
   }
 
-  // Expanded: capturing — primary "Pause for 30 min" + other durations + turn off.
+  // Expanded: capturing — split button. Primary action pauses for the default
+  // duration; a "more" menu holds the other presets and the de-emphasized
+  // "Turn off" so stopping capture entirely isn't a one-tap action.
+  const otherPresets = CAPTURE_PAUSE_CONFIG.PRESETS_MINUTES.filter(
+    (m) => m !== CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES,
+  )
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex w-full gap-px">
       <Button
-        className="w-full"
+        className="flex-1 rounded-r-none border-primary"
         variant="default"
         size="lg"
         disabled={toggling}
@@ -186,24 +191,43 @@ export function CaptureControlSection({
           Pause for {formatDuration(CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES)}
         </span>
       </Button>
-      <div className="flex items-center justify-center gap-1">
-        {CAPTURE_PAUSE_CONFIG.PRESETS_MINUTES.filter(
-          (m) => m !== CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES,
-        ).map((minutes) => (
-          <Button
-            key={minutes}
-            variant="ghost"
-            size="xs"
-            disabled={toggling}
-            onClick={() => onPause?.(minutes * 60_000)}
-          >
-            {formatDuration(minutes)}
-          </Button>
-        ))}
-        <Button variant="ghost" size="xs" disabled={toggling} onClick={onToggle}>
-          Turn off
-        </Button>
-      </div>
+      <Menu.Root>
+        <Menu.Trigger
+          render={
+            <Button
+              variant="default"
+              size="lg"
+              disabled={toggling}
+              aria-label="More capture options"
+              className="rounded-l-none border-primary px-2"
+            />
+          }
+        >
+          <CaretDownIcon />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner side="bottom" align="end" sideOffset={6} className="z-50">
+            <Menu.Popup className="min-w-40 rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-none">
+              {otherPresets.map((minutes) => (
+                <Menu.Item
+                  key={minutes}
+                  className="flex cursor-default items-center rounded-md px-2 py-1.5 text-sm outline-none data-highlighted:bg-muted data-highlighted:text-foreground"
+                  onClick={() => onPause?.(minutes * 60_000)}
+                >
+                  Pause for {formatDuration(minutes)}
+                </Menu.Item>
+              ))}
+              <div className="my-1 h-px bg-border" />
+              <Menu.Item
+                className="flex cursor-default items-center rounded-md px-2 py-1.5 text-sm text-muted-foreground outline-none data-highlighted:bg-muted data-highlighted:text-foreground"
+                onClick={onToggle}
+              >
+                Turn off capture
+              </Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
     </div>
   )
 }

--- a/src/renderer/pages/main-window/components/CaptureControlSection.tsx
+++ b/src/renderer/pages/main-window/components/CaptureControlSection.tsx
@@ -1,11 +1,60 @@
 import * as React from 'react'
 import { Button } from '@components/ui/button'
+import { CAPTURE_PAUSE_CONFIG } from '@/shared/constants'
 
 interface CaptureControlSectionProps {
   capturing: boolean
   toggling: boolean
   onToggle: () => void
   compact?: boolean
+  /**
+   * Pause feature. When `pausedUntilMs`/`onPause`/`onResume` are provided the
+   * control renders the three-state pause UI; otherwise it falls back to the
+   * plain Start/Stop toggle (used during onboarding).
+   */
+  pausedUntilMs?: number | null
+  onPause?: (durationMs: number) => void
+  onResume?: () => void
+}
+
+const PlayIcon = (): React.JSX.Element => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+    <path d="M8 5v14l11-7z" />
+  </svg>
+)
+
+const StopIcon = (): React.JSX.Element => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+    <rect x="6" y="6" width="12" height="12" rx="1" />
+  </svg>
+)
+
+const PauseIcon = (): React.JSX.Element => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+    <rect x="6" y="5" width="4" height="14" rx="1" />
+    <rect x="14" y="5" width="4" height="14" rx="1" />
+  </svg>
+)
+
+const formatDuration = (minutes: number): string => (minutes === 60 ? '1 hour' : `${minutes} min`)
+
+const formatCountdown = (remainingMs: number): string => {
+  const total = Math.max(0, Math.ceil(remainingMs / 1000))
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+/** Live MM:SS countdown to `deadlineMs`, recomputed each second. */
+function useCountdown(deadlineMs: number | null): string | null {
+  const [now, setNow] = React.useState(() => Date.now())
+  React.useEffect(() => {
+    if (deadlineMs === null) return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [deadlineMs])
+  if (deadlineMs === null) return null
+  return formatCountdown(deadlineMs - now)
 }
 
 export function CaptureControlSection({
@@ -13,28 +62,148 @@ export function CaptureControlSection({
   toggling,
   onToggle,
   compact = false,
+  pausedUntilMs = null,
+  onPause,
+  onResume,
 }: CaptureControlSectionProps): React.JSX.Element {
-  const label = capturing ? 'Stop Capture' : 'Start Capture'
+  const pauseEnabled = typeof onPause === 'function'
+  const isPaused = pauseEnabled && pausedUntilMs !== null
+  const countdown = useCountdown(isPaused ? pausedUntilMs : null)
+
+  // Legacy Start/Stop toggle (onboarding, or when pause props are absent).
+  if (!pauseEnabled) {
+    const label = capturing ? 'Stop Capture' : 'Start Capture'
+    return (
+      <Button
+        className="w-full"
+        variant={capturing ? 'destructive' : 'default'}
+        size={compact ? 'icon-lg' : 'lg'}
+        disabled={toggling}
+        onClick={onToggle}
+        aria-label={label}
+        title={compact ? label : undefined}
+      >
+        {capturing ? <StopIcon /> : <PlayIcon />}
+        {!compact && <span className="ml-2">{label}</span>}
+      </Button>
+    )
+  }
+
+  const defaultPauseMs = CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES * 60_000
+
+  // Compact (collapsed sidebar): single icon button, no duration menu.
+  if (compact) {
+    if (isPaused) {
+      const label = countdown ? `Resume capture (${countdown})` : 'Resume capture'
+      return (
+        <Button
+          className="w-full"
+          variant="default"
+          size="icon-lg"
+          disabled={toggling}
+          onClick={onResume}
+          aria-label={label}
+          title={label}
+        >
+          <PlayIcon />
+        </Button>
+      )
+    }
+    if (capturing) {
+      const label = `Pause capture for ${formatDuration(CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES)}`
+      return (
+        <Button
+          className="w-full"
+          variant="secondary"
+          size="icon-lg"
+          disabled={toggling}
+          onClick={() => onPause?.(defaultPauseMs)}
+          aria-label={label}
+          title={label}
+        >
+          <PauseIcon />
+        </Button>
+      )
+    }
+    return (
+      <Button
+        className="w-full"
+        variant="default"
+        size="icon-lg"
+        disabled={toggling}
+        onClick={onToggle}
+        aria-label="Start Capture"
+        title="Start Capture"
+      >
+        <PlayIcon />
+      </Button>
+    )
+  }
+
+  // Expanded: paused — countdown + resume.
+  if (isPaused) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <p className="text-center text-xs text-muted-foreground">
+          Paused — resumes in {countdown ?? '…'}
+        </p>
+        <Button
+          className="w-full"
+          variant="default"
+          size="lg"
+          disabled={toggling}
+          onClick={onResume}
+        >
+          <PlayIcon />
+          <span className="ml-2">Resume now</span>
+        </Button>
+      </div>
+    )
+  }
+
+  // Expanded: off — start.
+  if (!capturing) {
+    return (
+      <Button className="w-full" variant="default" size="lg" disabled={toggling} onClick={onToggle}>
+        <PlayIcon />
+        <span className="ml-2">Start Capture</span>
+      </Button>
+    )
+  }
+
+  // Expanded: capturing — primary "Pause for 30 min" + other durations + turn off.
   return (
-    <Button
-      className="w-full"
-      variant={capturing ? 'destructive' : 'default'}
-      size={compact ? 'icon-lg' : 'lg'}
-      disabled={toggling}
-      onClick={onToggle}
-      aria-label={label}
-      title={compact ? label : undefined}
-    >
-      {capturing ? (
-        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-          <rect x="6" y="6" width="12" height="12" rx="1" />
-        </svg>
-      ) : (
-        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M8 5v14l11-7z" />
-        </svg>
-      )}
-      {!compact && <span className="ml-2">{label}</span>}
-    </Button>
+    <div className="flex flex-col gap-1.5">
+      <Button
+        className="w-full"
+        variant="default"
+        size="lg"
+        disabled={toggling}
+        onClick={() => onPause?.(defaultPauseMs)}
+      >
+        <PauseIcon />
+        <span className="ml-2">
+          Pause for {formatDuration(CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES)}
+        </span>
+      </Button>
+      <div className="flex items-center justify-center gap-1">
+        {CAPTURE_PAUSE_CONFIG.PRESETS_MINUTES.filter(
+          (m) => m !== CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES,
+        ).map((minutes) => (
+          <Button
+            key={minutes}
+            variant="ghost"
+            size="xs"
+            disabled={toggling}
+            onClick={() => onPause?.(minutes * 60_000)}
+          >
+            {formatDuration(minutes)}
+          </Button>
+        ))}
+        <Button variant="ghost" size="xs" disabled={toggling} onClick={onToggle}>
+          Turn off
+        </Button>
+      </div>
+    </div>
   )
 }

--- a/src/renderer/pages/main-window/components/CaptureControlSection.tsx
+++ b/src/renderer/pages/main-window/components/CaptureControlSection.tsx
@@ -41,18 +41,24 @@ const PauseIcon = (): React.JSX.Element => (
 const formatDuration = (minutes: number): string => (minutes === 60 ? '1 hour' : `${minutes} min`)
 
 const formatCountdown = (remainingMs: number): string => {
-  const total = Math.max(0, Math.ceil(remainingMs / 1000))
-  const m = Math.floor(total / 60)
-  const s = total % 60
-  return `${m}:${s.toString().padStart(2, '0')}`
+  const minutes = Math.max(0, Math.ceil(remainingMs / 60_000))
+  return minutes <= 1 ? '< 1 min' : `${minutes} min`
 }
 
-/** Live MM:SS countdown to `deadlineMs`, recomputed each second. */
+/**
+ * Minutes-remaining label until `deadlineMs`, recomputed every 30s. Coarse on
+ * purpose: a per-second stopwatch reads as distracting and the changing digit
+ * widths make the button jitter, so we round up to whole minutes.
+ */
 function useCountdown(deadlineMs: number | null): string | null {
   const [now, setNow] = React.useState(() => Date.now())
   React.useEffect(() => {
     if (deadlineMs === null) return
-    const id = setInterval(() => setNow(Date.now()), 1000)
+    // Refresh immediately: `now` may be stale from mount when the pause starts,
+    // which would otherwise over-count by up to one refresh interval (e.g. a
+    // 30-min pause briefly reading "31 min").
+    setNow(Date.now())
+    const id = setInterval(() => setNow(Date.now()), 30_000)
     return () => clearInterval(id)
   }, [deadlineMs])
   if (deadlineMs === null) return null
@@ -156,7 +162,7 @@ export function CaptureControlSection({
         title="Resume now"
       >
         <PlayIcon />
-        <span className="ml-2">Resumes in {countdown ?? '…'}</span>
+        <span className="ml-2 tabular-nums">Resumes in {countdown ?? '…'}</span>
       </Button>
     )
   }

--- a/src/renderer/pages/main-window/components/CaptureControlSection.tsx
+++ b/src/renderer/pages/main-window/components/CaptureControlSection.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react'
 import { Menu } from '@base-ui/react/menu'
-import { CaretDownIcon } from '@phosphor-icons/react'
+import {
+  CaretDownIcon,
+  PlayIcon as PlayGlyph,
+  PauseIcon as PauseGlyph,
+  StopIcon as StopGlyph,
+} from '@phosphor-icons/react'
 import { Button } from '@components/ui/button'
-import { CAPTURE_PAUSE_CONFIG } from '@/shared/constants'
+import { CAPTURE_PAUSE_CONFIG, formatPauseDuration } from '@/shared/constants'
 
 interface CaptureControlSectionProps {
   capturing: boolean
@@ -19,26 +24,10 @@ interface CaptureControlSectionProps {
   onResume?: () => void
 }
 
-const PlayIcon = (): React.JSX.Element => (
-  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-    <path d="M8 5v14l11-7z" />
-  </svg>
-)
-
-const StopIcon = (): React.JSX.Element => (
-  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-    <rect x="6" y="6" width="12" height="12" rx="1" />
-  </svg>
-)
-
-const PauseIcon = (): React.JSX.Element => (
-  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-    <rect x="6" y="5" width="4" height="14" rx="1" />
-    <rect x="14" y="5" width="4" height="14" rx="1" />
-  </svg>
-)
-
-const formatDuration = (minutes: number): string => (minutes === 60 ? '1 hour' : `${minutes} min`)
+// Thin wrappers fix the size/weight once so the call sites stay terse.
+const PlayIcon = (): React.JSX.Element => <PlayGlyph className="w-5 h-5" weight="fill" />
+const StopIcon = (): React.JSX.Element => <StopGlyph className="w-5 h-5" weight="fill" />
+const PauseIcon = (): React.JSX.Element => <PauseGlyph className="w-5 h-5" weight="fill" />
 
 const formatCountdown = (remainingMs: number): string => {
   const minutes = Math.max(0, Math.ceil(remainingMs / 60_000))
@@ -118,7 +107,7 @@ export function CaptureControlSection({
       )
     }
     if (capturing) {
-      const label = `Pause capture for ${formatDuration(CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES)}`
+      const label = `Pause capture for ${formatPauseDuration(CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES)}`
       return (
         <Button
           className="w-full"
@@ -194,7 +183,7 @@ export function CaptureControlSection({
       >
         <PauseIcon />
         <span className="ml-2">
-          Pause for {formatDuration(CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES)}
+          Pause for {formatPauseDuration(CAPTURE_PAUSE_CONFIG.DEFAULT_MINUTES)}
         </span>
       </Button>
       <Menu.Root>
@@ -220,7 +209,7 @@ export function CaptureControlSection({
                   className="flex cursor-default items-center rounded-md px-2 py-1.5 text-sm outline-none data-highlighted:bg-muted data-highlighted:text-foreground"
                   onClick={() => onPause?.(minutes * 60_000)}
                 >
-                  Pause for {formatDuration(minutes)}
+                  Pause for {formatPauseDuration(minutes)}
                 </Menu.Item>
               ))}
               <div className="my-1 h-px bg-border" />

--- a/src/renderer/pages/main-window/components/shell/Sidebar.tsx
+++ b/src/renderer/pages/main-window/components/shell/Sidebar.tsx
@@ -29,6 +29,9 @@ interface SidebarProps {
   capturing: boolean
   toggling: boolean
   onToggleCapture: () => void
+  pausedUntilMs: number | null
+  onPauseCapture: (durationMs: number) => void
+  onResumeCapture: () => void
   vendor: Vendor
   llmHealth: LlmHealthStatus | null
   configured: boolean
@@ -46,6 +49,9 @@ export function Sidebar({
   capturing,
   toggling,
   onToggleCapture,
+  pausedUntilMs,
+  onPauseCapture,
+  onResumeCapture,
   vendor,
   llmHealth,
   configured,
@@ -115,6 +121,9 @@ export function Sidebar({
         capturing={capturing}
         toggling={toggling}
         onToggle={onToggleCapture}
+        pausedUntilMs={pausedUntilMs}
+        onPause={onPauseCapture}
+        onResume={onResumeCapture}
         compact={collapsed}
       />
     </div>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -126,6 +126,10 @@ export const CAPTURE_PAUSE_CONFIG = {
   DEFAULT_MINUTES: 30,
 }
 
+// Label for a pause preset, shared by the tray menu and the main-window control.
+export const formatPauseDuration = (minutes: number): string =>
+  minutes === 60 ? '1 hour' : `${minutes} min`
+
 // Managed Key / Subscription Configuration
 export const MANAGED_KEY_CONFIG = {
   BACKEND_URL:

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -119,6 +119,13 @@ export const PATTERN_DETECTION_CONFIG = {
   SETTLE_DELAY_MS: 60 * 1000, // 1 min after unlock before running
 }
 
+// User-initiated timed capture pause (auto-resumes when the timer elapses).
+// Presets are shared between the tray menu and the main-window control.
+export const CAPTURE_PAUSE_CONFIG = {
+  PRESETS_MINUTES: [15, 30, 60] as const,
+  DEFAULT_MINUTES: 30,
+}
+
 // Managed Key / Subscription Configuration
 export const MANAGED_KEY_CONFIG = {
   BACKEND_URL:

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -179,6 +179,11 @@ export interface SettingsAPI {
 export interface MainWindowStatus {
   capturing: boolean
   captureHotkeyLabel: string
+  /**
+   * When capture is on a timed pause, the epoch-ms deadline at which it
+   * auto-resumes; null when not paused. Drives the renderer countdown.
+   */
+  pausedUntilMs: number | null
 }
 
 export interface ObservationState {
@@ -326,6 +331,8 @@ export interface MainWindowAPI {
   submitConsentDecision: (outcome: ConsentOutcome) => Promise<SaveResult>
   getStatus: () => Promise<MainWindowStatus>
   toggleCapture: () => Promise<MainWindowStatus>
+  pauseCapture: (durationMs: number) => Promise<MainWindowStatus>
+  resumeCapture: () => Promise<MainWindowStatus>
   onStatusChanged: (callback: (status: MainWindowStatus) => void) => () => void
   // Settings methods (merged from settingsAPI)
   getCredentialStatuses: () => Promise<Record<Vendor, VendorStatus>>


### PR DESCRIPTION
## Context

Capture was a binary **Start / Stop** toggle. Users who stopped it for a quick private moment often **forgot to turn it back on** and silently lost capture. [DEU-139](https://linear.app/deusxmachina/issue/DEU-139) asks for an in-app timed pause, modeled on NordVPN's "Pause for 15 min".

## What changed

The primary action is now a **timed pause that auto-resumes** (default **30 min**, presets **15 / 30 / 60**). An explicit **Turn off** remains for the rare all-day-off case.

State model — three user-visible states derived from the existing persisted `captureEnabled` + a new in-memory pause:
- **Capturing** — `captureEnabled && !paused && !powerPaused`
- **Paused** — timed; auto-resumes at `pausedUntilMs`; `captureEnabled` stays `true`
- **Off** — indefinite; `captureEnabled = false`

The pause is **in-memory only** (per product decision): on app restart capture resumes. `resumeCaptureIfDesired()` early-returns while paused, so unlocking the screen mid-pause won't cut it short.

### Surfaces
- **`capture-orchestrator`** — single owner of the run rule; adds `pauseCapture`/`resumeCapture`/`isUserPaused`/`getPauseState` + an `onStateChanged` notify. Start/stop/shutdown clear the pause timer.
- **Tray** — `Pause Capture ▸ (15 / 30 / 60 min)` + `Turn Off Capture` when capturing; `Resume Capture Now` + a remaining-time line when paused; paused tooltip; periodic countdown refresh.
- **IPC / preload / status** — `pausedUntilMs` added to `MainWindowStatus`; new `pauseCapture` / `resumeCapture` handlers (`toggleCapture` kept for off↔on).
- **Renderer** — three-state `CaptureControlSection` with a live MM:SS countdown; onboarding keeps the plain toggle (pause props optional). Capture hotkey resumes from pause.

## Testing
- `capture-orchestrator.test.ts`: 8 passing — pause stops without disabling the preference, auto-resume on timer, manual resume cancels the timer, `requestStopCapture` clears the pause, `resumeCaptureIfDesired` doesn't override a pause.
- Full suite: **843 passing** (2 failures are the pre-existing `embedding-bundle` test needing the `build/models` artifact, absent in a fresh worktree).
- Lint clean; Prettier clean; **zero new TypeScript errors** vs. base.

### Manual verification
1. Tray → "Pause Capture ▸ 15 min" → capture stops, menu/tooltip show paused; auto-resumes after the timer.
2. Main window "Pause for 30 min" → countdown ticks; "Resume now" restarts immediately.
3. "Turn off capture" → stays off across the window and across restart.
4. Pause, then restart the app → capture resumes (ephemeral pause).
5. Lock/unlock before the deadline → stays paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)