### PR TITLE
feat(eval): label golden time lines with app/tld + backfill script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eval-summaries": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/eval-summaries.ts",
     "eval-tasks": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/eval-tasks.ts",
     "export-day": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/export-day.ts",
+    "backfill-golden-tld": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/backfill-golden-tld.ts",
     "mcpb:pack": "npx @anthropic-ai/mcpb pack mcpb/",
     "cli:build": "cd packages/cli && npm run build",
     "cli:test": "cd packages/cli && npm test",

--- a/scripts/backfill-golden-tld.ts
+++ b/scripts/backfill-golden-tld.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env npx tsx
+/**
+ * Backfills the `· App · tld` scanning label onto the time line of existing
+ * `golden.md` fixtures. New goldens get this for free from `renderGoldenMd`; this
+ * script brings already-committed goldens up to the same format.
+ *
+ * It does NOT regenerate the golden (your hand-edited summaries and boundaries
+ * are preserved). It re-runs the same no-LLM scaffold replay that seeds a fresh
+ * golden — `replayFixture` + `ScaffoldTransformer` — to recover the producer's
+ * `tld` per activity (the exact value a fresh seed would emit), matches each
+ * golden block to a replayed span by time overlap, and rewrites only that block's
+ * time line in place: `mm:ss → mm:ss` → `mm:ss → mm:ss · App[ · tld]`. Every
+ * other line (summaries, DROPPED markers, `---`, comments) is left byte-for-byte.
+ * Re-running is a no-op (the label is recomputed identically).
+ *
+ * Usage:
+ *   npm run backfill-golden-tld                         (all fixtures)
+ *   npm run backfill-golden-tld -- --fixture jaro-2026-06-22-12-21
+ *   npm run backfill-golden-tld -- --dry-run            (print, don't write)
+ *   npm run backfill-golden-tld -- --root <fixtures-dir>
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { replayFixture, ScaffoldTransformer } from '../src/main/eval/replay-harness'
+import {
+  HEADER_RE,
+  TIME_RE,
+  formatTimeLine,
+  parseGoldenMd,
+  type GoldenActivity,
+} from '../src/main/eval/golden-md'
+
+const DEFAULT_FIXTURES_ROOT = path.resolve('evals/semantic-summary/fixtures')
+
+interface Args {
+  fixtures: string[]
+  root: string
+  dryRun: boolean
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2)
+  const a: Args = { fixtures: [], root: DEFAULT_FIXTURES_ROOT, dryRun: false }
+  for (let i = 0; i < argv.length; i++) {
+    const next = (): string | undefined => argv[++i]
+    switch (argv[i]) {
+      case '--fixture':
+      case '--fixtures':
+        a.fixtures.push(
+          ...(next() ?? '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean),
+        )
+        break
+      case '--root':
+        a.root = path.resolve(next() ?? DEFAULT_FIXTURES_ROOT)
+        break
+      case '--dry-run':
+        a.dryRun = true
+        break
+      default:
+        console.warn(`Unknown arg: ${argv[i]}`)
+    }
+  }
+  return a
+}
+
+interface Span {
+  startOffsetMs: number
+  endOffsetMs: number
+  tld?: string
+}
+
+/** Best-overlap tld for a golden block's [start,end] offset span. Zero-length
+ *  spans (e.g. a `0:00 → 0:00` DROPPED block) fall back to point containment. */
+function tldForSpan(startMs: number, endMs: number, spans: Span[]): string | undefined {
+  let best: string | undefined
+  let bestScore = 0
+  for (const s of spans) {
+    if (!s.tld) continue
+    const score =
+      startMs === endMs
+        ? s.startOffsetMs <= startMs && startMs <= s.endOffsetMs
+          ? 1
+          : 0
+        : Math.max(0, Math.min(endMs, s.endOffsetMs) - Math.max(startMs, s.startOffsetMs))
+    if (score > bestScore) {
+      bestScore = score
+      best = s.tld
+    }
+  }
+  return best
+}
+
+interface FixtureResult {
+  name: string
+  blocks: number
+  labelled: number
+  withTld: number
+  changed: boolean
+  error?: string
+}
+
+async function backfillFixture(fixtureDir: string, dryRun: boolean): Promise<FixtureResult> {
+  const name = path.basename(fixtureDir)
+  const goldenPath = path.join(fixtureDir, 'golden.md')
+  if (!fs.existsSync(goldenPath)) {
+    return { name, blocks: 0, labelled: 0, withTld: 0, changed: false, error: 'no golden.md' }
+  }
+
+  const text = fs.readFileSync(goldenPath, 'utf8')
+  const blocks: GoldenActivity[] = parseGoldenMd(text)
+
+  const { activities, droppedActivities, sessionStartMs } = await replayFixture({
+    fixtureDir,
+    transformer: new ScaffoldTransformer(),
+  })
+  const spans: Span[] = [...activities, ...droppedActivities].map((a) => ({
+    startOffsetMs: a.startTimestamp - sessionStartMs,
+    endOffsetMs: a.endTimestamp - sessionStartMs,
+    tld: a.tld,
+  }))
+
+  // Walk lines and rewrite each block's first time line in document order. The
+  // k-th `## ` header pairs with blocks[k]; its first following TIME line is the
+  // one we patch. appName comes from the header (blocks[k]) so the label always
+  // matches it; only the tld is freshly recovered.
+  const lines = text.split('\n')
+  let blockIdx = -1
+  let awaitingTime = false
+  let labelled = 0
+  let withTld = 0
+  for (let i = 0; i < lines.length; i++) {
+    if (HEADER_RE.test(lines[i])) {
+      blockIdx++
+      awaitingTime = true
+      continue
+    }
+    if (awaitingTime && TIME_RE.test(lines[i])) {
+      awaitingTime = false
+      const block = blocks[blockIdx]
+      if (!block) continue
+      const tld = tldForSpan(block.startOffsetMs, block.endOffsetMs, spans)
+      const leadingWs = lines[i].match(/^\s*/)?.[0] ?? ''
+      lines[i] =
+        leadingWs + formatTimeLine(block.startOffsetMs, block.endOffsetMs, block.appName, tld)
+      labelled++
+      if (tld) withTld++
+    }
+  }
+
+  const updated = lines.join('\n')
+  const changed = updated !== text
+  if (changed && !dryRun) fs.writeFileSync(goldenPath, updated, 'utf8')
+
+  return { name, blocks: blocks.length, labelled, withTld, changed }
+}
+
+function listFixtureDirs(root: string, only: string[]): string[] {
+  if (!fs.existsSync(root)) throw new Error(`Fixtures root not found: ${root}`)
+  const all = fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
+  const wanted = only.length ? all.filter((n) => only.includes(n)) : all
+  return wanted.map((n) => path.join(root, n))
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs()
+  const dirs = listFixtureDirs(args.root, args.fixtures)
+  if (dirs.length === 0) {
+    console.error('No matching fixtures.')
+    process.exit(1)
+  }
+
+  console.log(
+    `Backfilling tld labels in ${dirs.length} fixture(s)${args.dryRun ? ' (dry run)' : ''}\n`,
+  )
+  const results: FixtureResult[] = []
+  for (const dir of dirs) {
+    try {
+      results.push(await backfillFixture(dir, args.dryRun))
+    } catch (err) {
+      results.push({
+        name: path.basename(dir),
+        blocks: 0,
+        labelled: 0,
+        withTld: 0,
+        changed: false,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  for (const r of results) {
+    if (r.error) {
+      console.log(`  ✗ ${r.name} — ${r.error}`)
+    } else {
+      const tag = r.changed ? (args.dryRun ? 'would update' : 'updated') : 'unchanged'
+      console.log(
+        `  ${r.changed ? '✓' : '·'} ${r.name} — ${tag}: ${r.labelled}/${r.blocks} blocks labelled, ${r.withTld} with tld`,
+      )
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/main/eval/golden-md.test.ts
+++ b/src/main/eval/golden-md.test.ts
@@ -69,6 +69,40 @@ describe('renderGoldenMd → parseGoldenMd round-trip', () => {
     })
   })
 
+  it('renders the `· App · tld` label and parses the tld back', () => {
+    const acts = [
+      replayActivity({ activityId: 'a1', appName: 'Code', tld: undefined }),
+      replayActivity({
+        activityId: 'a2',
+        appName: 'Google Chrome',
+        windowTitle: 'Customers - Google Drive',
+        tld: 'drive.google.com',
+        startTimestamp: 1_090_000,
+        endTimestamp: 1_130_000,
+      }),
+    ]
+    const md = renderGoldenMd('x', acts)
+    // Native app: app name only. Web: app name · domain.
+    expect(md).toContain('0:00 → 1:30 · Code')
+    expect(md).toContain('1:30 → 2:10 · Google Chrome · drive.google.com')
+
+    const parsed = parseGoldenMd(md)
+    expect(parsed[0].tld).toBeUndefined()
+    expect(parsed[1].tld).toBe('drive.google.com')
+    // appName/windowTitle still come from the `## ` header, unaffected by the label.
+    expect(parsed[1]).toMatchObject({
+      appName: 'Google Chrome',
+      windowTitle: 'Customers - Google Drive',
+    })
+  })
+
+  it('still parses legacy time lines that have no label', () => {
+    const md = ['# Golden — x', '## 1. Code — auth.ts', '0:00 → 1:30', 'Did a thing.'].join('\n')
+    const parsed = parseGoldenMd(md)
+    expect(parsed[0]).toMatchObject({ appName: 'Code', startOffsetMs: 0, endOffsetMs: 90_000 })
+    expect(parsed[0].tld).toBeUndefined()
+  })
+
   it('anchors offsets to sessionStartMs (the video clock), not the first block', () => {
     // First kept activity starts 10s after the session/video zero.
     const acts = [replayActivity({ startTimestamp: 1_010_000, endTimestamp: 1_040_000 })]

--- a/src/main/eval/golden-md.ts
+++ b/src/main/eval/golden-md.ts
@@ -17,19 +17,22 @@ import type { ReplayActivity } from './types'
  *   # Golden — <fixture>
  *
  *   ## 1. Code — auth.ts
- *   00:00 → 01:30
+ *   0:00 → 1:30 · Code
  *
  *   Stepped through the auth middleware in the debugger and inspected headers.
  *
  *   ---
  *
  *   ## 2. Chrome — github.com
- *   01:30 → 02:10
+ *   1:30 → 2:10 · Chrome · github.com
  *
  *   Reviewed the open PR's diff for the token-refresh change.
  *
- * Times are mm:ss from session start. The leading number in the header is for
- * humans only — matching is by time overlap, not index.
+ * Times are mm:ss from session start. The `· App · tld` label after the range is
+ * a human-facing scanning aid (app name, then domain when it's a web activity);
+ * it's reconstructed from the producer, not authoritative — appName/windowTitle
+ * are read from the `## ` header. The leading number in the header is for humans
+ * only — matching is by time overlap, not index.
  */
 
 export interface GoldenActivity {
@@ -37,6 +40,8 @@ export interface GoldenActivity {
   index: number
   appName: string
   windowTitle?: string
+  /** Domain of a web activity, recovered from the time-line `· App · tld` label. */
+  tld?: string
   startOffsetMs: number
   endOffsetMs: number
   /**
@@ -48,14 +53,42 @@ export interface GoldenActivity {
   summary: string
 }
 
-const HEADER_RE = /^##\s+(?:(\d+)\.\s*)?(.+?)(?:\s+—\s+(.+))?\s*$/
-const TIME_RE = /^\s*(\d+):(\d{2})\s*(?:->|→)\s*(\d+):(\d{2})\s*$/
+export const HEADER_RE = /^##\s+(?:(\d+)\.\s*)?(.+?)(?:\s+—\s+(.+))?\s*$/
+// The optional trailing group is the `· App · tld` scanning label (or a bare
+// `· App`); older goldens have none. It's captured but appName is taken from the
+// header, so the label is advisory.
+export const TIME_RE = /^\s*(\d+):(\d{2})\s*(?:->|→)\s*(\d+):(\d{2})\s*(?:·(.*))?$/
 
 export function formatOffset(ms: number): string {
   const total = Math.max(0, Math.round(ms / 1000))
   const m = Math.floor(total / 60)
   const s = total % 60
   return `${m}:${String(s).padStart(2, '0')}`
+}
+
+/**
+ * The single source of truth for a golden block's time line:
+ * `mm:ss → mm:ss · App[ · tld]`. Shared by the scaffold renderer and the
+ * tld backfill so both emit byte-identical lines.
+ */
+export function formatTimeLine(
+  startOffsetMs: number,
+  endOffsetMs: number,
+  appName: string,
+  tld?: string,
+): string {
+  const label = tld ? `${appName} · ${tld}` : appName
+  return `${formatOffset(startOffsetMs)} → ${formatOffset(endOffsetMs)} · ${label}`
+}
+
+/** Pulls the `tld` out of a time-line label (`App · tld` → `tld`; `App` → none). */
+function parseTldFromLabel(label: string | undefined): string | undefined {
+  if (!label) return undefined
+  const segs = label
+    .split('·')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  return segs.length >= 2 ? segs[segs.length - 1] : undefined
 }
 
 function parseOffset(min: string, sec: string): number {
@@ -82,7 +115,12 @@ export function renderGoldenMd(
     const title = act.windowTitle ? ` — ${act.windowTitle}` : ''
     lines.push(`## ${i + 1}. ${act.appName}${title}`)
     lines.push(
-      `${formatOffset(act.startTimestamp - sessionStart)} → ${formatOffset(act.endTimestamp - sessionStart)}`,
+      formatTimeLine(
+        act.startTimestamp - sessionStart,
+        act.endTimestamp - sessionStart,
+        act.appName,
+        act.tld,
+      ),
     )
     lines.push('')
     if (act.dropped) {
@@ -112,12 +150,14 @@ export function parseGoldenMd(text: string): GoldenActivity[] {
     // Find the time line, then everything after it (until `---`) is the summary.
     let startOffsetMs = 0
     let endOffsetMs = 0
+    let tld: string | undefined
     let timeLineIdx = -1
     for (let i = 1; i < block.length; i++) {
       const tm = block[i].match(TIME_RE)
       if (tm) {
         startOffsetMs = parseOffset(tm[1], tm[2])
         endOffsetMs = parseOffset(tm[3], tm[4])
+        tld = parseTldFromLabel(tm[5])
         timeLineIdx = i
         break
       }
@@ -136,6 +176,7 @@ export function parseGoldenMd(text: string): GoldenActivity[] {
       index: out.length + 1,
       appName,
       windowTitle,
+      tld,
       startOffsetMs,
       endOffsetMs,
       dropped: dropped || undefined,


### PR DESCRIPTION
## What

Golden activity time lines now carry an app/domain scanning label:

```
## 6. Google Chrome — Customers - Google Drive - Google Chrome - Jaroslav (MemoryLane)
0:11 → 0:23 · Google Chrome · drive.google.com
```

Native apps get just `· Code` (no domain). Makes each block scannable against the review video.

## How

- **`formatTimeLine()`** in `golden-md.ts` is the single source of truth for the `mm:ss → mm:ss · App[ · tld]` line, shared by the scaffold renderer (`renderGoldenMd`) and the backfill.
- Parser relaxed: `TIME_RE` tolerates both the new label and **legacy unlabeled** lines, and recovers `tld` on parse (`GoldenActivity.tld`).
- **`npm run backfill-golden-tld`** (`--fixture`, `--dry-run`, `--root`) relabels existing goldens. It re-runs the same **no-LLM scaffold replay** (`replayFixture` + `ScaffoldTransformer`) that seeds a fresh golden, so the recovered `tld` is the exact value a new seed would emit, then rewrites **only the time line** — summaries, boundaries, DROPPED markers, and comments are preserved byte-for-byte. Idempotent.

Existing fixtures (in the separate `memorylane-evals` repo) were backfilled separately.

## Notes

- `· newtab` appears where the captured URL was `chrome://newtab/` (host = `newtab`) — faithful to the producer's actual `tld`, not a backfill artifact.

## Test

- `golden-md.test.ts`: +2 tests (label round-trip, legacy unlabeled lines). Full eval suite 68/68 pass.
- prettier + eslint clean; node typecheck clean for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)