### PR TITLE
feat(eval): build-task-fixture — known keep task + dev-DB noise for task mining

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eval-summaries": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/eval-summaries.ts",
     "eval-tasks": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/eval-tasks.ts",
     "export-day": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/export-day.ts",
+    "build-task-fixture": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/build-task-fixture.ts",
     "backfill-golden-tld": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/backfill-golden-tld.ts",
     "mcpb:pack": "npx @anthropic-ai/mcpb pack mcpb/",
     "cli:build": "cd packages/cli && npm run build",

--- a/scripts/build-task-fixture.ts
+++ b/scripts/build-task-fixture.ts
@@ -11,14 +11,23 @@
  *                 precision — the miner must stitch the task across the
  *                 interruptions and exclude them from its set).
  *
- * Output: evals/task-mining/fixtures/<day>-jaro-contract[-multitask]/, each
- * `activities.jsonl` + `golden.md` + `manifest.json`. Deterministic; no LLM at
- * build time. The dev DB is read read-only.
+ * Recurring tasks: `--occurrences N` plants the task N times across the day, each
+ * in its own slice of noise (so the miner should surface N distinct sightings and
+ * cluster them). With N > 1 the occurrences are *varied* so they aren't identical
+ * copies (`--vary`):
+ *   - reorder (default): the steps are slightly reordered per occurrence (no LLM).
+ *   - llm:               the step summaries are paraphrased per occurrence via the
+ *                        active vendor's model (same meaning, different wording).
+ *   - none:              identical copies.
+ *
+ * Output: evals/task-mining/fixtures/<day>-jaro-contract[-multitask][-xN]/, each
+ * `activities.jsonl` + `golden.md` (one keep block per occurrence) + `manifest.json`.
+ * Deterministic unless `--vary llm`. The dev DB is read read-only.
  *
  * Usage:
  *   npm run build-task-fixture -- --noise-day 2026-06-10,2026-06-05 --keep-exclude 1
- *   npm run build-task-fixture -- --from jaro-2026-06-19-09-43 --noise-day 2026-06-10 \
- *     --placement multitask --keep-exclude 1 --title "..." --interruptions 4
+ *   npm run build-task-fixture -- --noise-day 2026-06-10 --occurrences 3 --placement multitask
+ *   npm run build-task-fixture -- --noise-day 2026-06-10 --occurrences 3 --vary llm
  *
  * --keep-exclude takes 1-based indices over the source's non-dropped blocks to
  * leave OUT of the golden `keep` task (they stay as day activities). For the
@@ -26,19 +35,29 @@
  * miner is scored on grounding precision (it must not absorb that activity).
  */
 
+import { config as loadEnv } from 'dotenv'
+loadEnv()
+
 import * as fs from 'fs'
 import * as path from 'path'
 import { StorageService } from '../src/main/storage'
 import { getDefaultDbPath } from '../src/main/paths'
+import { PATTERN_DETECTION_CONFIG } from '../src/shared/constants'
 import { loadGoldenMd } from '../src/main/eval/golden-md'
 import {
-  placeTask,
-  renderSightingGoldenMd,
+  applyParaphrasedSummaries,
+  cloneOccurrence,
+  placeOccurrences,
+  renderTaskFixtureGoldenMd,
   semanticGoldenToTask,
   toFixtureActivity,
   type PlacementMode,
+  type SemanticTaskResult,
 } from '../src/main/eval/task-fixture-build'
 import { TaskFixtureStore } from '../src/main/eval/task-fixture-store'
+import { callJsonJudge } from '../src/main/eval/llm-judge'
+import type { InferenceProvider } from '../src/main/llm'
+import { loadCliInferenceProvider } from './cli-inference-provider'
 import {
   TASK_FIXTURE_SCHEMA_VERSION,
   type TaskFixtureActivity,
@@ -56,6 +75,9 @@ const DEFAULT_DESCRIPTION =
   'Agreement and DPA templates into it, filled in the customer party names and engagement terms ' +
   '(party, Pilot type, term, fees, deployment schedule), and shared both documents with Petr.'
 
+type VaryMode = 'none' | 'reorder' | 'llm'
+const VARY_MODES: VaryMode[] = ['none', 'reorder', 'llm']
+
 interface CliArgs {
   from: string
   noiseDays: string[]
@@ -65,6 +87,9 @@ interface CliArgs {
   dbPath: string
   interruptions: number
   keepExclude: number[]
+  occurrences: number
+  vary: VaryMode | ''
+  varyModel: string
 }
 
 function parseArgs(): CliArgs {
@@ -83,6 +108,9 @@ function parseArgs(): CliArgs {
     dbPath: getDefaultDbPath(),
     interruptions: 3,
     keepExclude: [],
+    occurrences: 1,
+    vary: '',
+    varyModel: '',
   }
   for (let i = 0; i < args.length; i++) {
     const next = args[i + 1]
@@ -122,6 +150,19 @@ function parseArgs(): CliArgs {
         a.interruptions = Number(next)
         i++
         break
+      case '--occurrences':
+      case '--repeat':
+        a.occurrences = Math.max(1, Math.floor(Number(next)) || 1)
+        i++
+        break
+      case '--vary':
+        a.vary = next as VaryMode
+        i++
+        break
+      case '--vary-model':
+        a.varyModel = next
+        i++
+        break
     }
   }
   return a
@@ -138,7 +179,75 @@ function dayStartLocal(day: string): number {
   return new Date(y, m - 1, d).getTime()
 }
 
-function main(): void {
+/**
+ * Paraphrases an occurrence's step summaries via the active vendor's model: same
+ * meaning, different wording (a different day's run of the same recurring task).
+ * Falls back to the original summaries on any LLM/parse failure or length
+ * mismatch, so a bad call degrades the fixture rather than aborting the build.
+ */
+async function paraphraseSummaries(
+  provider: InferenceProvider,
+  model: string,
+  summaries: string[],
+  occurrenceIndex: number,
+): Promise<string[]> {
+  const prompt = [
+    'These are the ordered step summaries of one run of a recurring task someone',
+    'did on their computer. Rewrite EACH summary to describe the SAME action on a',
+    'different day: keep the meaning, the app/website, and the concrete action',
+    'identical, but vary the wording (verbs, phrasing, incidental detail). Do NOT',
+    'merge, split, add, or drop steps — return exactly as many rewrites as inputs,',
+    'in the same order.',
+    `This is occurrence #${occurrenceIndex}; make the wording clearly distinct.`,
+    '',
+    'Steps:',
+    ...summaries.map((s, i) => `${i + 1}. ${s}`),
+    '',
+    'Respond with ONLY JSON: {"summaries": ["<rewrite 1>", "<rewrite 2>", ...]}',
+  ].join('\n')
+
+  const res = await callJsonJudge<{ summaries?: unknown }>({
+    provider,
+    model,
+    content: [{ type: 'text', text: prompt }],
+    tag: 'task-vary',
+  })
+  const out = res?.parsed.summaries
+  if (!Array.isArray(out) || out.length !== summaries.length) {
+    console.warn(
+      `  ⚠ variation: paraphrase failed/mismatched for occurrence ${occurrenceIndex} — keeping original wording.`,
+    )
+    return summaries
+  }
+  return out.map((s, i) => (typeof s === 'string' && s.trim() ? s : summaries[i]))
+}
+
+/** Builds the N varied occurrences once — their content is independent of the
+ *  noise day / placement, so they're reused across every fixture written. */
+async function buildOccurrences(
+  base: SemanticTaskResult,
+  count: number,
+  vary: VaryMode,
+  llm: { provider: InferenceProvider; model: string } | null,
+): Promise<SemanticTaskResult[]> {
+  const occurrences: SemanticTaskResult[] = []
+  for (let k = 1; k <= count; k++) {
+    let occ = cloneOccurrence(base, { index: k, total: count, reorder: vary !== 'none' })
+    if (vary === 'llm' && llm) {
+      const rewritten = await paraphraseSummaries(
+        llm.provider,
+        llm.model,
+        occ.activities.map((a) => a.summary),
+        k,
+      )
+      occ = applyParaphrasedSummaries(occ, rewritten)
+    }
+    occurrences.push(occ)
+  }
+  return occurrences
+}
+
+async function main(): Promise<void> {
   const a = parseArgs()
 
   const valid: PlacementMode[] = ['contiguous', 'multitask']
@@ -147,10 +256,18 @@ function main(): void {
     console.error(`Unknown placement(s): ${bad.join(', ')}. Use contiguous and/or multitask.`)
     process.exit(1)
   }
+  if (a.vary && !VARY_MODES.includes(a.vary)) {
+    console.error(`Unknown --vary "${a.vary}". Use one of: ${VARY_MODES.join(', ')}.`)
+    process.exit(1)
+  }
   if (a.noiseDays.length === 0) {
     console.error('Pass --noise-day <YYYY-MM-DD>[,<YYYY-MM-DD>] (dev-DB day(s) to use as noise).')
     process.exit(1)
   }
+
+  // Default: vary recurring tasks (reorder, no LLM) so occurrences aren't clones;
+  // a single occurrence needs no variation.
+  const vary: VaryMode = a.vary || (a.occurrences > 1 ? 'reorder' : 'none')
 
   const goldenPath = path.join(SEMANTIC_ROOT, a.from, 'golden.md')
   const goldens = loadGoldenMd(goldenPath)
@@ -158,7 +275,7 @@ function main(): void {
     console.error(`No golden.md at ${goldenPath}`)
     process.exit(1)
   }
-  const { activities: task, block } = semanticGoldenToTask({
+  const base = semanticGoldenToTask({
     goldens,
     idPrefix: idPrefixFrom(a.from),
     title: a.title,
@@ -171,15 +288,34 @@ function main(): void {
     process.exit(1)
   }
 
+  // Only touch the LLM when actually paraphrasing — keeps the deterministic path
+  // free of credentials/network.
+  const llm =
+    vary === 'llm'
+      ? (() => {
+          const handle = loadCliInferenceProvider()
+          const model =
+            a.varyModel || handle.patternDetectionModel || PATTERN_DETECTION_CONFIG.MODEL
+          return { provider: handle.provider, model, vendor: handle.vendor }
+        })()
+      : null
+
   console.log('=== Build Task-Mining Fixture ===')
   console.log(
-    `From:       ${a.from} (${task.length} activities, ${block.activityIds.length} in the keep task` +
+    `From:        ${a.from} (${base.activities.length} activities, ${base.block.activityIds.length} in the keep task` +
       `${a.keepExclude.length ? `, excluded ${a.keepExclude.join(',')}` : ''})`,
   )
-  console.log(`DB:         ${a.dbPath}`)
-  console.log(`Noise days: ${a.noiseDays.join(', ')}`)
-  console.log(`Placements: ${a.placements.join(', ')}`)
+  console.log(`DB:          ${a.dbPath}`)
+  console.log(`Noise days:  ${a.noiseDays.join(', ')}`)
+  console.log(`Placements:  ${a.placements.join(', ')}`)
+  console.log(
+    `Occurrences: ${a.occurrences}${a.occurrences > 1 ? ` (vary: ${vary}${llm ? ` via ${llm.model}` : ''})` : ''}`,
+  )
   console.log('')
+
+  const occurrences = await buildOccurrences(base, a.occurrences, vary, llm)
+  const blocks = occurrences.map((o) => o.block)
+  const occActivities = occurrences.map((o) => o.activities)
 
   const storage = new StorageService(a.dbPath)
   const store = new TaskFixtureStore(FIXTURES_ROOT)
@@ -195,23 +331,32 @@ function main(): void {
       const noise: TaskFixtureActivity[] = stored.map((s) => toFixtureActivity(s, dayStart))
 
       for (const placement of a.placements) {
-        const placed = placeTask(task, noise, placement, { interruptions: a.interruptions })
-        const all = [...noise, ...placed].sort((x, y) => x.offsetMin - y.offsetMin)
-        const name = `${day}-jaro-contract${placement === 'multitask' ? '-multitask' : ''}`
-        const goldenMd = renderSightingGoldenMd(name, block, all)
+        const { placed, warnings } = placeOccurrences(occActivities, noise, placement, {
+          interruptions: a.interruptions,
+        })
+        const taskActivities = placed.flat()
+        const all = [...noise, ...taskActivities].sort((x, y) => x.offsetMin - y.offsetMin)
+        const suffix = `${placement === 'multitask' ? '-multitask' : ''}${a.occurrences > 1 ? `-x${a.occurrences}` : ''}`
+        const name = `${day}-jaro-contract${suffix}`
+        const goldenMd = renderTaskFixtureGoldenMd(name, blocks, all)
         const manifest: TaskFixtureManifest = {
           name,
           label: name,
-          description: placement,
+          description: a.occurrences > 1 ? `${placement} ×${a.occurrences} (${vary})` : placement,
           activityCount: all.length,
           sourceDay: day,
           schemaVersion: TASK_FIXTURE_SCHEMA_VERSION,
         }
         store.write(name, all, goldenMd, manifest)
-        const span = `${placed[0].offsetMin}–${placed[placed.length - 1].offsetMin}min`
+
+        const spans = placed
+          .map((p) => `${p[0].offsetMin}–${p[p.length - 1].offsetMin}min`)
+          .join(', ')
         console.log(
-          `  ✓ ${name}: ${noise.length} noise + ${placed.length} task = ${all.length} activities (task @ ${span})`,
+          `  ✓ ${name}: ${noise.length} noise + ${taskActivities.length} task ` +
+            `(${a.occurrences}×) = ${all.length} activities (@ ${spans})`,
         )
+        for (const w of warnings) console.warn(`    ⚠ ${w}`)
       }
     }
   } finally {
@@ -222,4 +367,7 @@ function main(): void {
   console.log('Next: score the miner —  npm run eval-tasks -- --fixture <name>')
 }
 
-main()
+main().catch((err) => {
+  console.error('Fatal:', err)
+  process.exit(1)
+})

--- a/scripts/build-task-fixture.ts
+++ b/scripts/build-task-fixture.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env npx tsx
+/**
+ * Builds task-mining fixtures by promoting a semantic-summary fixture's golden
+ * into a `keep` task and padding it with a real dev-DB day as noise, so the
+ * miner must *find* the task amid realistic activity.
+ *
+ * Two placement modes per day:
+ *   - contiguous: the task runs uninterrupted in a quiet gap (tests recall).
+ *   - multitask:  the task's steps are spread across the day's busiest window so
+ *                 unrelated activities fall *between* them (tests grounding
+ *                 precision — the miner must stitch the task across the
+ *                 interruptions and exclude them from its set).
+ *
+ * Output: evals/task-mining/fixtures/<day>-jaro-contract[-multitask]/, each
+ * `activities.jsonl` + `golden.md` + `manifest.json`. Deterministic; no LLM at
+ * build time. The dev DB is read read-only.
+ *
+ * Usage:
+ *   npm run build-task-fixture -- --noise-day 2026-06-10,2026-06-05 --keep-exclude 1
+ *   npm run build-task-fixture -- --from jaro-2026-06-19-09-43 --noise-day 2026-06-10 \
+ *     --placement multitask --keep-exclude 1 --title "..." --interruptions 4
+ *
+ * --keep-exclude takes 1-based indices over the source's non-dropped blocks to
+ * leave OUT of the golden `keep` task (they stay as day activities). For the
+ * jaro fixture, `--keep-exclude 1` drops the recorder-start activity so the
+ * miner is scored on grounding precision (it must not absorb that activity).
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { StorageService } from '../src/main/storage'
+import { getDefaultDbPath } from '../src/main/paths'
+import { loadGoldenMd } from '../src/main/eval/golden-md'
+import {
+  placeTask,
+  renderSightingGoldenMd,
+  semanticGoldenToTask,
+  toFixtureActivity,
+  type PlacementMode,
+} from '../src/main/eval/task-fixture-build'
+import { TaskFixtureStore } from '../src/main/eval/task-fixture-store'
+import {
+  TASK_FIXTURE_SCHEMA_VERSION,
+  type TaskFixtureActivity,
+  type TaskFixtureManifest,
+} from '../src/main/eval/task-types'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const SEMANTIC_ROOT = path.resolve('evals/semantic-summary/fixtures')
+const FIXTURES_ROOT = path.resolve('evals/task-mining/fixtures')
+
+const DEFAULT_FROM = 'jaro-2026-06-19-09-43'
+const DEFAULT_TITLE = 'Set up a new customer in Drive (folder + Services Agreement + DPA)'
+const DEFAULT_DESCRIPTION =
+  'Created a "new customer - test" folder in Google Drive, copied the MemoryLane Services ' +
+  'Agreement and DPA templates into it, filled in the customer party names and engagement terms ' +
+  '(party, Pilot type, term, fees, deployment schedule), and shared both documents with Petr.'
+
+interface CliArgs {
+  from: string
+  noiseDays: string[]
+  placements: PlacementMode[]
+  title: string
+  description: string
+  dbPath: string
+  interruptions: number
+  keepExclude: number[]
+}
+
+function parseArgs(): CliArgs {
+  const args = process.argv.slice(2)
+  const list = (s: string): string[] =>
+    s
+      .split(',')
+      .map((x) => x.trim())
+      .filter(Boolean)
+  const a: CliArgs = {
+    from: DEFAULT_FROM,
+    noiseDays: [],
+    placements: ['contiguous', 'multitask'],
+    title: DEFAULT_TITLE,
+    description: DEFAULT_DESCRIPTION,
+    dbPath: getDefaultDbPath(),
+    interruptions: 3,
+    keepExclude: [],
+  }
+  for (let i = 0; i < args.length; i++) {
+    const next = args[i + 1]
+    if (next === undefined) break
+    switch (args[i]) {
+      case '--from':
+        a.from = next
+        i++
+        break
+      case '--keep-exclude':
+        a.keepExclude = list(next).map(Number).filter(Number.isFinite)
+        i++
+        break
+      case '--noise-day':
+      case '--noise-days':
+        a.noiseDays.push(...list(next))
+        i++
+        break
+      case '--placement':
+      case '--placements':
+        a.placements = list(next) as PlacementMode[]
+        i++
+        break
+      case '--title':
+        a.title = next
+        i++
+        break
+      case '--description':
+        a.description = next
+        i++
+        break
+      case '--db-path':
+        a.dbPath = next
+        i++
+        break
+      case '--interruptions':
+        a.interruptions = Number(next)
+        i++
+        break
+    }
+  }
+  return a
+}
+
+/** jaro-2026-06-19-09-43 → jaro-2026-06-19 (drop a trailing -HH-MM time). */
+function idPrefixFrom(from: string): string {
+  return from.replace(/-\d{2}-\d{2}$/, '')
+}
+
+/** Local midnight (ms) for a YYYY-MM-DD day string. */
+function dayStartLocal(day: string): number {
+  const [y, m, d] = day.split('-').map(Number)
+  return new Date(y, m - 1, d).getTime()
+}
+
+function main(): void {
+  const a = parseArgs()
+
+  const valid: PlacementMode[] = ['contiguous', 'multitask']
+  const bad = a.placements.filter((p) => !valid.includes(p))
+  if (bad.length) {
+    console.error(`Unknown placement(s): ${bad.join(', ')}. Use contiguous and/or multitask.`)
+    process.exit(1)
+  }
+  if (a.noiseDays.length === 0) {
+    console.error('Pass --noise-day <YYYY-MM-DD>[,<YYYY-MM-DD>] (dev-DB day(s) to use as noise).')
+    process.exit(1)
+  }
+
+  const goldenPath = path.join(SEMANTIC_ROOT, a.from, 'golden.md')
+  const goldens = loadGoldenMd(goldenPath)
+  if (!goldens) {
+    console.error(`No golden.md at ${goldenPath}`)
+    process.exit(1)
+  }
+  const { activities: task, block } = semanticGoldenToTask({
+    goldens,
+    idPrefix: idPrefixFrom(a.from),
+    title: a.title,
+    description: a.description,
+    keepExclude: a.keepExclude,
+  })
+
+  if (!fs.existsSync(a.dbPath)) {
+    console.error(`Dev DB not found at ${a.dbPath}. Run the app first or pass --db-path.`)
+    process.exit(1)
+  }
+
+  console.log('=== Build Task-Mining Fixture ===')
+  console.log(
+    `From:       ${a.from} (${task.length} activities, ${block.activityIds.length} in the keep task` +
+      `${a.keepExclude.length ? `, excluded ${a.keepExclude.join(',')}` : ''})`,
+  )
+  console.log(`DB:         ${a.dbPath}`)
+  console.log(`Noise days: ${a.noiseDays.join(', ')}`)
+  console.log(`Placements: ${a.placements.join(', ')}`)
+  console.log('')
+
+  const storage = new StorageService(a.dbPath)
+  const store = new TaskFixtureStore(FIXTURES_ROOT)
+  try {
+    for (const day of a.noiseDays) {
+      const dayStart = dayStartLocal(day)
+      const details = storage.activities.getForDay(dayStart, dayStart + DAY_MS)
+      if (details.length === 0) {
+        console.warn(`  ⚠ ${day}: no activities in the dev DB — skipping.`)
+        continue
+      }
+      const stored = storage.activities.getByIds(details.map((d) => d.id))
+      const noise: TaskFixtureActivity[] = stored.map((s) => toFixtureActivity(s, dayStart))
+
+      for (const placement of a.placements) {
+        const placed = placeTask(task, noise, placement, { interruptions: a.interruptions })
+        const all = [...noise, ...placed].sort((x, y) => x.offsetMin - y.offsetMin)
+        const name = `${day}-jaro-contract${placement === 'multitask' ? '-multitask' : ''}`
+        const goldenMd = renderSightingGoldenMd(name, block, all)
+        const manifest: TaskFixtureManifest = {
+          name,
+          label: name,
+          description: placement,
+          activityCount: all.length,
+          sourceDay: day,
+          schemaVersion: TASK_FIXTURE_SCHEMA_VERSION,
+        }
+        store.write(name, all, goldenMd, manifest)
+        const span = `${placed[0].offsetMin}–${placed[placed.length - 1].offsetMin}min`
+        console.log(
+          `  ✓ ${name}: ${noise.length} noise + ${placed.length} task = ${all.length} activities (task @ ${span})`,
+        )
+      }
+    }
+  } finally {
+    storage.close()
+  }
+
+  console.log(`\nWrote fixtures to ${path.relative(process.cwd(), FIXTURES_ROOT)}/`)
+  console.log('Next: score the miner —  npm run eval-tasks -- --fixture <name>')
+}
+
+main()

--- a/scripts/replay-cell.ts
+++ b/scripts/replay-cell.ts
@@ -55,6 +55,8 @@ export async function replayCell(params: {
     debugDumper: params.dumper,
     // The default UsageTracker reads Electron's app.getPath, absent under enode.
     usageTracker: { recordUsage: () => {} },
+    // Same for the default SummaryModeTracker (writes summary-mode-stats.json).
+    summaryModeTracker: { record: () => {} },
   })
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memorylane-replay-'))
   const transformer = new DefaultActivityTransformer(

--- a/src/main/eval/task-fixture-build.test.ts
+++ b/src/main/eval/task-fixture-build.test.ts
@@ -5,11 +5,16 @@ import { StorageService } from '../storage'
 import { applyMigrations } from '../storage/migrator'
 import { createStoredActivity, deleteDbFiles } from '../storage/test-utils'
 import {
+  applyParaphrasedSummaries,
   buildWindowedActivities,
+  cloneOccurrence,
   largestGapOffset,
+  placeOccurrences,
   placeTask,
   renderSightingGoldenMd,
+  renderTaskFixtureGoldenMd,
   semanticGoldenToTask,
+  type SemanticTaskResult,
 } from './task-fixture-build'
 import { parseTaskGoldenMd } from './task-golden-md'
 import type { GoldenActivity } from './golden-md'
@@ -209,6 +214,13 @@ describe('largestGapOffset', () => {
     expect(largestGapOffset([noiseAt(0, 5)], 10, 583)).toBe(583)
     expect(largestGapOffset([], 10, 583)).toBe(583)
   })
+
+  it('rejects a gap that only equals the span (needs a 1-min buffer so it cannot overlap)', () => {
+    // gap = 20 − (0+5) = 15, exactly the span → must NOT fit (would overlap by 1).
+    expect(largestGapOffset([noiseAt(0, 5), noiseAt(20, 5)], 15, 999)).toBe(999)
+    // one more minute of room and it fits, starting right after the first activity.
+    expect(largestGapOffset([noiseAt(0, 5), noiseAt(21, 5)], 15, 999)).toBe(6)
+  })
 })
 
 describe('placeTask', () => {
@@ -242,5 +254,200 @@ describe('placeTask', () => {
       )
       expect(between.length).toBeGreaterThanOrEqual(1)
     }
+  })
+})
+
+describe('placeTask multitask — sparse noise', () => {
+  const task = semanticGoldenToTask({
+    idPrefix: 't',
+    title: 'T',
+    description: 'd',
+    goldens: [
+      golden({ startOffsetMs: 0, endOffsetMs: 60_000, summary: 'a' }),
+      golden({ startOffsetMs: 60_000, endOffsetMs: 120_000, summary: 'b' }),
+      golden({ startOffsetMs: 120_000, endOffsetMs: 180_000, summary: 'c' }),
+    ],
+  }).activities // 3 steps
+
+  it('reduces interruptions (with a warning) and keeps a gap between every step', () => {
+    const noise = Array.from({ length: 6 }, (_, i) => noiseAt(300 + i * 5, 1))
+    const warnings: string[] = []
+    const placed = placeTask(task, noise, 'multitask', {
+      interruptions: 3,
+      onWarn: (m) => warnings.push(m),
+    })
+    const offsets = placed.map((a) => a.offsetMin)
+    // anchors stay distinct — no two steps collapse onto the same minute
+    expect(offsets.every((o, i) => i === 0 || o > offsets[i - 1])).toBe(true)
+    expect(warnings.some((w) => /reduced interruptions 3/.test(w))).toBe(true)
+    // after the reduction there is still ≥1 noise activity between consecutive steps
+    for (let i = 1; i < offsets.length; i++) {
+      const between = noise.filter(
+        (nn) => nn.offsetMin > offsets[i - 1] && nn.offsetMin < offsets[i],
+      )
+      expect(between.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('warns and does not collapse steps when there is less noise than steps', () => {
+    const noise = [noiseAt(100, 1), noiseAt(105, 1)] // 2 noise, 3 steps
+    const warnings: string[] = []
+    const placed = placeTask(task, noise, 'multitask', {
+      interruptions: 2,
+      onWarn: (m) => warnings.push(m),
+    })
+    const offsets = placed.map((a) => a.offsetMin)
+    expect(new Set(offsets).size).toBe(offsets.length) // all distinct
+    expect(offsets.every((o, i) => i === 0 || o > offsets[i - 1])).toBe(true)
+    expect(warnings.length).toBeGreaterThan(0)
+  })
+})
+
+describe('placeTask contiguous — bounds', () => {
+  const task = semanticGoldenToTask({
+    idPrefix: 't',
+    title: 'T',
+    description: 'd',
+    goldens: [
+      golden({ startOffsetMs: 0, endOffsetMs: 60_000, summary: 'a' }),
+      golden({ startOffsetMs: 60_000, endOffsetMs: 120_000, summary: 'b' }),
+      golden({ startOffsetMs: 120_000, endOffsetMs: 180_000, summary: 'c' }),
+    ],
+  }).activities // span 3
+
+  it('never runs past end-of-day (no stacking on the final minute)', () => {
+    // Only space is just before a late single activity → edge fallback, clamped.
+    const noise = [noiseAt(1435, 5)]
+    const placed = placeTask(task, noise, 'contiguous', {})
+    const offsets = placed.map((a) => a.offsetMin)
+    expect(Math.max(...offsets)).toBeLessThanOrEqual(24 * 60 - 1)
+    expect(new Set(offsets).size).toBe(offsets.length) // distinct, not clamped together
+    // internal back-to-back spacing preserved
+    expect(offsets[1] - offsets[0]).toBe(1)
+    expect(offsets[2] - offsets[1]).toBe(1)
+  })
+})
+
+// --- recurring tasks --------------------------------------------------------
+
+function baseTask(): SemanticTaskResult {
+  return semanticGoldenToTask({
+    idPrefix: 'jaro',
+    title: 'Contract setup',
+    description: 'Did the thing.',
+    goldens: [
+      golden({ startOffsetMs: 0, endOffsetMs: 60_000, appName: 'Drive', summary: 'create folder' }),
+      golden({
+        startOffsetMs: 60_000,
+        endOffsetMs: 120_000,
+        appName: 'Docs',
+        summary: 'copy agreement',
+      }),
+      golden({
+        startOffsetMs: 120_000,
+        endOffsetMs: 180_000,
+        appName: 'Docs',
+        summary: 'fill terms',
+      }),
+    ],
+  })
+}
+
+describe('cloneOccurrence', () => {
+  it('total=1: keeps base ids and title (no suffix, no reorder)', () => {
+    const o = cloneOccurrence(baseTask(), { index: 1, total: 1, reorder: true })
+    expect(o.activities.map((a) => a.id)).toEqual(['jaro-01', 'jaro-02', 'jaro-03'])
+    expect(o.block.title).toBe('Contract setup')
+    expect(o.block.activityIds).toEqual(['jaro-01', 'jaro-02', 'jaro-03'])
+  })
+
+  it('total>1: suffixes ids, tags the title, reorders later occurrences', () => {
+    const o1 = cloneOccurrence(baseTask(), { index: 1, total: 3, reorder: true })
+    const o2 = cloneOccurrence(baseTask(), { index: 2, total: 3, reorder: true })
+
+    expect(o1.activities.map((a) => a.id)).toEqual(['jaro-01-o1', 'jaro-02-o1', 'jaro-03-o1'])
+    expect(o1.block.title).toBe('Contract setup (1/3)')
+    // occurrence 1 keeps order; occurrence 2 swaps the second pair (pos 1<->2).
+    expect(o2.activities.map((a) => a.id)).toEqual(['jaro-01-o2', 'jaro-03-o2', 'jaro-02-o2'])
+    expect(o2.block.title).toBe('Contract setup (2/3)')
+    expect(o2.activities.map((a) => a.offsetMin)).toEqual([0, 1, 2]) // re-laid back-to-back
+
+    // ids are disjoint across occurrences (fixture-unique)
+    const ids1 = new Set(o1.activities.map((a) => a.id))
+    expect(o2.activities.every((a) => !ids1.has(a.id))).toBe(true)
+  })
+})
+
+describe('applyParaphrasedSummaries', () => {
+  it('swaps summaries by index, keeps ids/offsets/block', () => {
+    const o = cloneOccurrence(baseTask(), { index: 1, total: 1 })
+    const out = applyParaphrasedSummaries(o, ['A', '', 'C']) // empty keeps the original
+    expect(out.activities.map((a) => a.summary)).toEqual(['A', 'copy agreement', 'C'])
+    expect(out.activities.map((a) => a.id)).toEqual(o.activities.map((a) => a.id))
+    expect(out.block).toBe(o.block)
+  })
+})
+
+describe('placeOccurrences', () => {
+  it('places each occurrence in its own slice of noise; ids stay unique', () => {
+    const occ = [1, 2, 3].map((k) =>
+      cloneOccurrence(baseTask(), { index: k, total: 3, reorder: true }),
+    )
+    const noise = Array.from({ length: 12 }, (_, i) => noiseAt(60 + i * 60, 5))
+    const { placed, warnings } = placeOccurrences(
+      occ.map((o) => o.activities),
+      noise,
+      'contiguous',
+      {},
+    )
+    expect(placed).toHaveLength(3)
+    const range = (p: TaskFixtureActivity[]): { min: number; max: number } => ({
+      min: Math.min(...p.map((a) => a.offsetMin)),
+      max: Math.max(...p.map((a) => a.offsetMin)),
+    })
+    const r = placed.map(range)
+    expect(r[0].max).toBeLessThan(r[1].min) // temporally separated
+    expect(r[1].max).toBeLessThan(r[2].min)
+    const allIds = placed.flat().map((a) => a.id)
+    expect(new Set(allIds).size).toBe(allIds.length)
+    expect(warnings).toEqual([])
+  })
+
+  it('warns when there is less noise than occurrences', () => {
+    const occ = [1, 2, 3].map((k) => cloneOccurrence(baseTask(), { index: k, total: 3 }))
+    const noise = [noiseAt(60, 5), noiseAt(600, 5)] // 2 noise, 3 occurrences
+    const { placed, warnings } = placeOccurrences(
+      occ.map((o) => o.activities),
+      noise,
+      'contiguous',
+      {},
+    )
+    expect(placed).toHaveLength(3)
+    expect(warnings.some((w) => /won't be separated/.test(w))).toBe(true)
+  })
+})
+
+describe('renderTaskFixtureGoldenMd', () => {
+  it('renders N keep blocks that round-trip to N sightings', () => {
+    const blocks = [
+      {
+        title: 'T (1/2)',
+        apps: ['Drive'],
+        activityIds: ['jaro-01-o1', 'jaro-02-o1'],
+        description: 'd1',
+      },
+      {
+        title: 'T (2/2)',
+        apps: ['Docs'],
+        activityIds: ['jaro-01-o2', 'jaro-02-o2'],
+        description: 'd2',
+      },
+    ]
+    const md = renderTaskFixtureGoldenMd('rec', blocks, [noiseAt(10)])
+    const parsed = parseTaskGoldenMd(md)
+    expect(parsed.sightings).toHaveLength(2)
+    expect(parsed.sightings.map((s) => s.verdict)).toEqual(['keep', 'keep'])
+    expect(parsed.sightings[0].activityIds).toEqual(['jaro-01-o1', 'jaro-02-o1'])
+    expect(parsed.sightings[1].title).toBe('T (2/2)')
   })
 })

--- a/src/main/eval/task-fixture-build.test.ts
+++ b/src/main/eval/task-fixture-build.test.ts
@@ -4,8 +4,16 @@ import * as path from 'path'
 import { StorageService } from '../storage'
 import { applyMigrations } from '../storage/migrator'
 import { createStoredActivity, deleteDbFiles } from '../storage/test-utils'
-import { buildWindowedActivities, renderSightingGoldenMd } from './task-fixture-build'
+import {
+  buildWindowedActivities,
+  largestGapOffset,
+  placeTask,
+  renderSightingGoldenMd,
+  semanticGoldenToTask,
+} from './task-fixture-build'
 import { parseTaskGoldenMd } from './task-golden-md'
+import type { GoldenActivity } from './golden-md'
+import type { TaskFixtureActivity } from './task-types'
 
 const DB_PATH = path.join(os.tmpdir(), 'task-fixture-build-test.db')
 const MIN = 60_000
@@ -90,5 +98,149 @@ describe('renderSightingGoldenMd', () => {
     expect(s.apps).toEqual(['Chrome', 'Preview'])
     expect(s.activityIds).toEqual(['s1', 's2'])
     expect(s.description).toContain('Filled the Concur form')
+  })
+})
+
+// --- pure helpers (no DB) ---------------------------------------------------
+
+function golden(
+  partial: Partial<GoldenActivity> & { startOffsetMs: number; endOffsetMs: number },
+): GoldenActivity {
+  return { index: 1, appName: 'Google Chrome', summary: 's', ...partial }
+}
+
+function noiseAt(offsetMin: number, durationMin = 2): TaskFixtureActivity {
+  return {
+    id: `n-${offsetMin}`,
+    offsetMin,
+    durationMin,
+    app: 'Code',
+    windowTitle: '',
+    tld: null,
+    summary: 'noise',
+    ocrText: '',
+  }
+}
+
+describe('semanticGoldenToTask', () => {
+  it('drops DROPPED blocks, mints ids, lays activities back-to-back', () => {
+    const { activities, block } = semanticGoldenToTask({
+      idPrefix: 'jaro-2026-06-19',
+      title: 'Contract setup',
+      description: 'Did the thing.',
+      goldens: [
+        golden({ startOffsetMs: 0, endOffsetMs: 60_000, tld: 'drive.google.com', summary: 'a' }),
+        golden({ startOffsetMs: 60_000, endOffsetMs: 70_000, dropped: true, summary: 'DROPPED' }),
+        golden({
+          startOffsetMs: 70_000,
+          endOffsetMs: 190_000,
+          appName: 'Google Docs',
+          summary: 'b',
+        }),
+      ],
+    })
+
+    expect(activities.map((a) => a.id)).toEqual(['jaro-2026-06-19-01', 'jaro-2026-06-19-02'])
+    expect(activities.map((a) => a.offsetMin)).toEqual([0, 1]) // back-to-back
+    expect(activities.map((a) => a.durationMin)).toEqual([1, 2])
+    expect(activities.every((a) => a.ocrText === '')).toBe(true)
+    expect(activities[0].tld).toBe('drive.google.com')
+    expect(block.activityIds).toEqual(['jaro-2026-06-19-01', 'jaro-2026-06-19-02'])
+    expect(block.apps).toEqual(['Google Chrome', 'Google Docs'])
+    expect(block.title).toBe('Contract setup')
+  })
+
+  it('keepExclude leaves an id out of the keep block but keeps it as a day activity', () => {
+    const { activities, block } = semanticGoldenToTask({
+      idPrefix: 'jaro',
+      title: 'T',
+      description: 'd',
+      keepExclude: [1], // drop the recorder-start opener
+      goldens: [
+        golden({
+          startOffsetMs: 0,
+          endOffsetMs: 60_000,
+          appName: 'MemoryLane',
+          summary: 'opened settings',
+        }),
+        golden({
+          startOffsetMs: 60_000,
+          endOffsetMs: 120_000,
+          appName: 'Google Chrome',
+          summary: 'a',
+        }),
+        golden({
+          startOffsetMs: 120_000,
+          endOffsetMs: 180_000,
+          appName: 'Google Chrome',
+          summary: 'b',
+        }),
+      ],
+    })
+
+    // all three are day activities…
+    expect(activities.map((a) => a.id)).toEqual(['jaro-01', 'jaro-02', 'jaro-03'])
+    // …but the keep block excludes #1 (and so MemoryLane drops out of apps).
+    expect(block.activityIds).toEqual(['jaro-02', 'jaro-03'])
+    expect(block.apps).toEqual(['Google Chrome'])
+  })
+
+  it('throws when every block is dropped', () => {
+    expect(() =>
+      semanticGoldenToTask({
+        idPrefix: 'x',
+        title: 't',
+        description: 'd',
+        goldens: [
+          golden({ startOffsetMs: 0, endOffsetMs: 1000, dropped: true, summary: 'DROPPED' }),
+        ],
+      }),
+    ).toThrow()
+  })
+})
+
+describe('largestGapOffset', () => {
+  it('returns the start of the largest fitting gap', () => {
+    const noise = [noiseAt(60, 5), noiseAt(120, 5), noiseAt(600, 5)]
+    expect(largestGapOffset(noise, 10, 999)).toBe(126) // 120+5 end, +1
+  })
+
+  it('falls back when no gap fits or there is no noise', () => {
+    expect(largestGapOffset([noiseAt(0, 5)], 10, 583)).toBe(583)
+    expect(largestGapOffset([], 10, 583)).toBe(583)
+  })
+})
+
+describe('placeTask', () => {
+  const task = semanticGoldenToTask({
+    idPrefix: 't',
+    title: 'T',
+    description: 'd',
+    goldens: [
+      golden({ startOffsetMs: 0, endOffsetMs: 60_000, summary: 'a' }),
+      golden({ startOffsetMs: 60_000, endOffsetMs: 120_000, summary: 'b' }),
+      golden({ startOffsetMs: 120_000, endOffsetMs: 180_000, summary: 'c' }),
+    ],
+  }).activities // offsets [0,1,2], durations [1,1,1]
+
+  it('contiguous: packs the task into the largest gap, preserving spacing', () => {
+    const noise = [noiseAt(60, 5), noiseAt(600, 5)] // big gap 65 → 600
+    const placed = placeTask(task, noise, 'contiguous', { fallbackOffsetMin: 999 })
+    expect(placed.map((a) => a.offsetMin)).toEqual([66, 67, 68])
+  })
+
+  it('multitask: weaves the task through noise so unrelated activities sit between steps', () => {
+    const noise = Array.from({ length: 13 }, (_, i) => noiseAt(300 + i * 5, 1))
+    const placed = placeTask(task, noise, 'multitask', { interruptions: 2 })
+    const offsets = placed.map((a) => a.offsetMin)
+    // strictly increasing
+    expect(offsets.every((o, i) => i === 0 || o > offsets[i - 1])).toBe(true)
+    // each consecutive pair of task steps has >=1 noise activity strictly between
+    for (let i = 1; i < offsets.length; i++) {
+      const between = noise.filter(
+        (nn) => nn.offsetMin > offsets[i - 1] && nn.offsetMin < offsets[i],
+      )
+      expect(between.length).toBeGreaterThanOrEqual(1)
+    }
   })
 })

--- a/src/main/eval/task-fixture-build.ts
+++ b/src/main/eval/task-fixture-build.ts
@@ -107,14 +107,15 @@ export interface GoldenBlockSeed {
 }
 
 /**
- * Renders golden.md for a single sighting: a feedback instruction, one editable
- * `keep` block, then a chronological reference of every activity id in the
- * window. Round-trips through `parseTaskGoldenMd` (the `Notes:` line folds into
- * the description — fine for a human-feedback golden).
+ * Renders golden.md for one or more `keep` blocks: a feedback instruction, each
+ * editable `keep` block in turn (separated by `---`), then a chronological
+ * reference of every activity id in the window. Each block ends in a `---`, so
+ * the trailing day-reference comment is ignored when `parseTaskGoldenMd` reads
+ * the file back. A recurring task is N blocks — one per occurrence.
  */
-export function renderSightingGoldenMd(
+export function renderTaskFixtureGoldenMd(
   name: string,
-  block: GoldenBlockSeed,
+  blocks: readonly GoldenBlockSeed[],
   activities: TaskFixtureActivity[],
 ): string {
   const sorted = [...activities].sort((a, b) => a.offsetMin - b.offsetMin)
@@ -122,25 +123,20 @@ export function renderSightingGoldenMd(
   const lines: string[] = []
   lines.push(`# Golden tasks — ${name}`)
   lines.push('')
-  lines.push('<!-- Feedback golden built from a sighting. Edit the block below:')
-  lines.push('     fix the title / Apps / Activities, rewrite the description, set')
-  lines.push('     Verdict (keep = a legit task, reject = the miner shouldn’t surface')
-  lines.push('     this), and add free-text notes after "Notes:" on what the miner')
-  lines.push('     missed or got wrong. The day reference at the bottom lists every')
-  lines.push('     activity id in the window. -->')
-  lines.push('')
 
-  lines.push(`## ${block.title}`)
-  lines.push('Verdict: keep')
-  lines.push(`Apps: ${block.apps.join(', ')}`)
-  lines.push(`Activities: ${block.activityIds.join(', ')}`)
-  lines.push('')
-  if (block.description.trim()) lines.push(block.description.trim())
-  lines.push('')
-  lines.push('Notes:')
-  lines.push('')
-  lines.push('---')
-  lines.push('')
+  for (const block of blocks) {
+    lines.push(`## ${block.title}`)
+    lines.push('Verdict: keep')
+    lines.push(`Apps: ${block.apps.join(', ')}`)
+    lines.push(`Activities: ${block.activityIds.join(', ')}`)
+    lines.push('')
+    if (block.description.trim()) lines.push(block.description.trim())
+    lines.push('')
+    lines.push('Notes:')
+    lines.push('')
+    lines.push('---')
+    lines.push('')
+  }
 
   lines.push('<!-- THE DAY — chronological reference of every activity id in the window.')
   for (const a of sorted) {
@@ -152,6 +148,15 @@ export function renderSightingGoldenMd(
   lines.push('')
 
   return lines.join('\n')
+}
+
+/** Single-block convenience wrapper (one sighting → one keep block). */
+export function renderSightingGoldenMd(
+  name: string,
+  block: GoldenBlockSeed,
+  activities: TaskFixtureActivity[],
+): string {
+  return renderTaskFixtureGoldenMd(name, [block], activities)
 }
 
 // ---------------------------------------------------------------------------
@@ -232,27 +237,72 @@ function taskSpanMin(task: readonly TaskFixtureActivity[]): number {
 }
 
 /**
- * Start offset (min from midnight) of the largest inter-activity gap in the
- * noise day that fits `spanMin`. `fallbackMin` when nothing fits (or no noise).
+ * The largest inter-activity gap in the noise day, and whether it can hold a
+ * `spanMin` task without overlapping its neighbours. `start` is where such a task
+ * would begin (the previous activity's end + 1); -1 when there's no gap to pick.
+ *
+ * `fits` requires `gap >= spanMin + 1`, not `>= spanMin`: the task starts one
+ * minute after the previous activity ends, so it needs room for its own span PLUS
+ * that one-minute lead, otherwise its last minute overlaps the next activity.
+ */
+function bestContiguousGap(
+  noise: readonly TaskFixtureActivity[],
+  spanMin: number,
+): { start: number; fits: boolean } {
+  if (noise.length < 2) return { start: -1, fits: false }
+  const sorted = [...noise].sort((a, b) => a.offsetMin - b.offsetMin)
+  let bestStart = -1
+  let bestGap = -1
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const end = sorted[i].offsetMin + sorted[i].durationMin
+    const gap = sorted[i + 1].offsetMin - end
+    if (gap > bestGap) {
+      bestGap = gap
+      bestStart = end + 1
+    }
+  }
+  return { start: bestStart, fits: bestGap >= spanMin + 1 }
+}
+
+/**
+ * Start offset (min from midnight) of the largest inter-activity gap that fits
+ * `spanMin`. `fallbackMin` when nothing fits (or there's no noise).
  */
 export function largestGapOffset(
   noise: readonly TaskFixtureActivity[],
   spanMin: number,
   fallbackMin: number,
 ): number {
+  const gap = bestContiguousGap(noise, spanMin)
+  return gap.fits ? gap.start : fallbackMin
+}
+
+/**
+ * Last-resort base offset when no inter-activity gap fits the task: prefer the
+ * empty span after the last (or before the first) noise activity — whichever is
+ * larger and fits — so the task at least doesn't overlap real activity. Warns and
+ * returns `fallbackMin` only when even the day's edges can't hold it.
+ */
+function edgeFallbackOffset(
+  noise: readonly TaskFixtureActivity[],
+  spanMin: number,
+  fallbackMin: number,
+  dayEndMin: number,
+  onWarn?: (msg: string) => void,
+): number {
   if (noise.length === 0) return fallbackMin
   const sorted = [...noise].sort((a, b) => a.offsetMin - b.offsetMin)
-  let bestStart = fallbackMin
-  let bestGap = -1
-  for (let i = 0; i < sorted.length - 1; i++) {
-    const end = sorted[i].offsetMin + sorted[i].durationMin
-    const gap = sorted[i + 1].offsetMin - end
-    if (gap >= spanMin && gap > bestGap) {
-      bestGap = gap
-      bestStart = end + 1
-    }
-  }
-  return bestStart
+  const firstStart = sorted[0].offsetMin
+  const lastEnd = sorted[sorted.length - 1].offsetMin + sorted[sorted.length - 1].durationMin
+  const leadRoom = firstStart // [0, firstStart]
+  const trailRoom = dayEndMin - lastEnd // [lastEnd, dayEnd]
+  const leadFits = leadRoom >= spanMin + 1
+  const trailFits = trailRoom >= spanMin + 1
+  if (trailFits && trailRoom >= leadRoom) return lastEnd + 1
+  if (leadFits) return Math.max(0, firstStart - spanMin - 1)
+  if (trailFits) return lastEnd + 1
+  onWarn?.(`task span ${spanMin}min doesn't fit any gap in the noise day — placing it over noise`)
+  return fallbackMin
 }
 
 /** Index into `sortedStarts` of the tightest run of `need` consecutive
@@ -276,10 +326,13 @@ export interface PlaceOptions {
   /** Multitask only: unrelated activities to interleave between consecutive
    *  task steps (default 3). The task is woven into the day's tightest run of
    *  activity so each step is separated by ~this many interruptions —
-   *  density-independent, unlike a wall-clock spread. */
+   *  density-independent, unlike a wall-clock spread. Reduced automatically (with
+   *  a warning) when the noise can't supply that many. */
   interruptions?: number
   /** Offset used when there is no noise to anchor to (default 583 ≈ 09:43). */
   fallbackOffsetMin?: number
+  /** Sink for non-fatal placement warnings (reduced interruptions, no-fit, …). */
+  onWarn?: (msg: string) => void
 }
 
 /**
@@ -287,10 +340,13 @@ export interface PlaceOptions {
  * returning clones (the input task keeps its relative offsets).
  *
  * - `contiguous`: pack the task into the largest free gap, preserving its
- *   back-to-back internal layout — the miner sees one uninterrupted episode.
+ *   back-to-back internal layout — the miner sees one uninterrupted episode. The
+ *   base is clamped so the task never runs past end-of-day (so its tail can't
+ *   stack onto the final minute).
  * - `multitask`: weave the task's steps through the day's tightest run of
  *   activity so `interruptions` unrelated activities sit *between* consecutive
- *   steps — the miner must stitch the task across them and exclude them.
+ *   steps. When the noise can't supply that many, the count is reduced (and a
+ *   warning emitted) rather than silently collapsing steps onto one another.
  */
 export function placeTask(
   task: readonly TaskFixtureActivity[],
@@ -300,29 +356,196 @@ export function placeTask(
 ): TaskFixtureActivity[] {
   const sorted = [...task].sort((a, b) => a.offsetMin - b.offsetMin)
   const fallback = opts.fallbackOffsetMin ?? 583
-  const maxOffset = 24 * 60 - 1
+  const dayEndMin = 24 * 60
+  const maxOffset = dayEndMin - 1
+  const span = taskSpanMin(sorted)
 
   if (mode === 'contiguous') {
-    const base = largestGapOffset(noise, taskSpanMin(sorted), fallback)
-    return sorted.map((a) => ({ ...a, offsetMin: Math.min(base + a.offsetMin, maxOffset) }))
+    const gap = bestContiguousGap(noise, span)
+    const rawBase = gap.fits
+      ? gap.start
+      : edgeFallbackOffset(noise, span, fallback, dayEndMin, opts.onWarn)
+    // Bound the base so the whole task fits in the day; otherwise the trailing
+    // activities would clamp onto the final minute and stack.
+    const base = Math.max(0, Math.min(rawBase, maxOffset - span))
+    return sorted.map((a) => ({ ...a, offsetMin: base + a.offsetMin }))
   }
 
-  // multitask: anchor each step to a noise activity, leaving `gap` unrelated
+  // multitask: anchor each step to a noise activity, leaving `gapCount` unrelated
   // activities between consecutive steps (density-independent interleaving).
   const n = sorted.length
-  const gap = Math.max(0, opts.interruptions ?? 3)
+  const requested = Math.max(0, opts.interruptions ?? 3)
   const starts = noise.map((a) => a.offsetMin).sort((x, y) => x - y)
   if (starts.length === 0) {
-    return sorted.map((a) => ({ ...a, offsetMin: Math.min(fallback + a.offsetMin, maxOffset) }))
+    const base = Math.max(0, Math.min(fallback, maxOffset - span))
+    return sorted.map((a) => ({ ...a, offsetMin: base + a.offsetMin }))
   }
-  const need = (n - 1) * (gap + 1) + 1
+  // Cap interruptions to what the noise can supply: the (n-1)*(gapCount+1)+1
+  // anchors must all fit in `starts`, otherwise later steps would clamp onto the
+  // same (last) noise activity and end up adjacent with nothing between them.
+  const maxGap = n > 1 ? Math.max(0, Math.floor((starts.length - 1) / (n - 1)) - 1) : requested
+  const gapCount = Math.min(requested, maxGap)
+  if (n > 1 && requested >= 1 && gapCount < requested) {
+    opts.onWarn?.(
+      `reduced interruptions ${requested}→${gapCount}: only ${starts.length} noise ` +
+        `activities to weave ${n} steps through` +
+        (gapCount < 1 ? ' — steps may be adjacent' : ''),
+    )
+  }
+  const need = (n - 1) * (gapCount + 1) + 1
   const runStart = densestRunStart(starts, Math.min(need, starts.length))
   let prev = -1
   return sorted.map((a, i) => {
-    const anchorIdx = Math.min(runStart + i * (gap + 1), starts.length - 1)
+    const anchorIdx = Math.min(runStart + i * (gapCount + 1), starts.length - 1)
     let off = starts[anchorIdx]
     if (off <= prev) off = prev + 1
     prev = off
     return { ...a, offsetMin: Math.min(off, maxOffset) }
   })
+}
+
+// ---------------------------------------------------------------------------
+// Recurring tasks: N varied occurrences placed across one noise day
+// ---------------------------------------------------------------------------
+
+/** A small, deterministic adjacent-swap reorder seeded by the occurrence index —
+ *  "the same task, done in a slightly different order". Returns a new array. */
+function slightReorder(
+  acts: readonly TaskFixtureActivity[],
+  occurrenceIndex: number,
+): TaskFixtureActivity[] {
+  const out = [...acts]
+  if (out.length < 2) return out
+  const pos = (occurrenceIndex - 1) % (out.length - 1)
+  ;[out[pos], out[pos + 1]] = [out[pos + 1], out[pos]]
+  return out
+}
+
+export interface OccurrenceOptions {
+  /** 1-based index of this occurrence within the recurring task. */
+  index: number
+  /** Total occurrences; when 1, ids and title keep their base form (no suffix). */
+  total: number
+  /** Slightly reorder the steps (only applied for occurrences after the first). */
+  reorder?: boolean
+}
+
+/**
+ * Clones a base task into one occurrence of a recurring task: mints fresh,
+ * fixture-unique activity ids (`<baseId>-o<index>` when `total > 1`), optionally
+ * reorders the steps a little, re-lays offsets back-to-back, and remaps the keep
+ * block to the new ids with an occurrence-tagged title (`<title> (k/N)`). Summary
+ * text is left intact — LLM paraphrasing, if any, is applied separately via
+ * `applyParaphrasedSummaries`, so this stays pure and deterministic.
+ */
+export function cloneOccurrence(
+  base: SemanticTaskResult,
+  opts: OccurrenceOptions,
+): SemanticTaskResult {
+  const suffix = opts.total > 1 ? `-o${opts.index}` : ''
+  const idMap = new Map<string, string>()
+  let acts = base.activities.map((a) => {
+    const id = `${a.id}${suffix}`
+    idMap.set(a.id, id)
+    return { ...a, id }
+  })
+
+  if (opts.reorder && opts.index > 1) acts = slightReorder(acts, opts.index)
+
+  let cursor = 0
+  acts = acts.map((a) => {
+    const placed = { ...a, offsetMin: cursor }
+    cursor += a.durationMin
+    return placed
+  })
+
+  const inBlock = new Set(base.block.activityIds.map((id) => idMap.get(id) ?? id))
+  const ordered = acts.filter((a) => inBlock.has(a.id))
+  const title =
+    opts.total > 1 ? `${base.block.title} (${opts.index}/${opts.total})` : base.block.title
+
+  return {
+    activities: acts,
+    block: {
+      title,
+      apps: [...new Set(ordered.map((a) => a.app))],
+      activityIds: ordered.map((a) => a.id),
+      description: base.block.description,
+    },
+  }
+}
+
+/**
+ * Returns a copy of an occurrence with each activity's summary replaced by the
+ * paraphrase at the same position (when non-empty); ids, offsets, and the keep
+ * block are untouched. `summaries` must align with `occ.activities` by index.
+ */
+export function applyParaphrasedSummaries(
+  occ: SemanticTaskResult,
+  summaries: readonly (string | null | undefined)[],
+): SemanticTaskResult {
+  const activities = occ.activities.map((a, i) => {
+    const s = summaries[i]
+    return s && s.trim() ? { ...a, summary: s.trim() } : a
+  })
+  return { activities, block: occ.block }
+}
+
+export interface PlaceOccurrencesResult {
+  /** Absolute-offset activities, one array per occurrence (input order). */
+  placed: TaskFixtureActivity[][]
+  /** Non-fatal placement warnings to surface to the user. */
+  warnings: string[]
+}
+
+/**
+ * Places N occurrences of a recurring task into one noise day, each in its own
+ * contiguous slice of the day's noise so occurrences are temporally separated —
+ * the miner should surface each as a distinct sighting and then cluster them.
+ * Each slice is placed with `placeTask`, so the per-occurrence `contiguous` /
+ * `multitask` semantics and the bug-fixed gap/interleave logic apply within it.
+ */
+export function placeOccurrences(
+  occurrences: readonly (readonly TaskFixtureActivity[])[],
+  noise: readonly TaskFixtureActivity[],
+  mode: PlacementMode,
+  opts: PlaceOptions = {},
+): PlaceOccurrencesResult {
+  const warnings: string[] = []
+  const sink = (msg: string): void => {
+    warnings.push(msg)
+    opts.onWarn?.(msg)
+  }
+  const N = occurrences.length
+  if (N <= 1) {
+    return {
+      placed: occurrences.map((o) => placeTask(o, noise, mode, { ...opts, onWarn: sink })),
+      warnings,
+    }
+  }
+
+  const sortedNoise = [...noise].sort((a, b) => a.offsetMin - b.offsetMin)
+  if (sortedNoise.length < N) {
+    sink(
+      `only ${sortedNoise.length} noise activities for ${N} occurrences — some won't be separated by noise`,
+    )
+  }
+
+  const dayEndMin = 24 * 60
+  const placed = occurrences.map((occ, i) => {
+    const lo = Math.floor((i * sortedNoise.length) / N)
+    const hi = Math.floor(((i + 1) * sortedNoise.length) / N)
+    const chunk = sortedNoise.slice(lo, hi)
+    const tag = (msg: string): void => sink(`occurrence ${i + 1}/${N}: ${msg}`)
+    if (chunk.length === 0) {
+      // No noise in this slice — spread the occurrence evenly across the day.
+      const slot = Math.floor(((i + 0.5) * dayEndMin) / N)
+      const base = Math.max(0, Math.min(slot, dayEndMin - 1 - taskSpanMin(occ)))
+      tag('no noise in its time slice — placed without surrounding activity')
+      return occ.map((a) => ({ ...a, offsetMin: base + a.offsetMin }))
+    }
+    return placeTask(occ, chunk, mode, { ...opts, onWarn: tag })
+  })
+
+  return { placed, warnings }
 }

--- a/src/main/eval/task-fixture-build.ts
+++ b/src/main/eval/task-fixture-build.ts
@@ -8,6 +8,7 @@
 
 import type { StorageService } from '../storage'
 import type { StoredActivity } from '../storage/types'
+import type { GoldenActivity } from './golden-md'
 import type { TaskFixtureActivity } from './task-types'
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -151,4 +152,177 @@ export function renderSightingGoldenMd(
   lines.push('')
 
   return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Promoting a semantic-summary golden into a task + placing it in a noise day
+// ---------------------------------------------------------------------------
+
+export type PlacementMode = 'contiguous' | 'multitask'
+
+export interface SemanticTaskResult {
+  /** Task activities with offsets RELATIVE to the task start (laid out
+   *  back-to-back). Absolute offsets are assigned later by `placeTask`. */
+  activities: TaskFixtureActivity[]
+  /** A `keep` block seeded from the whole task (every minted id). */
+  block: GoldenBlockSeed
+}
+
+/**
+ * Promotes a parsed semantic-summary golden (one block per activity) into the
+ * pieces of a task-mining `keep` task: drops the DROPPED blocks, mints stable
+ * ids (`<idPrefix>-NN`), and lays the kept activities out back-to-back (each
+ * starts where the previous ended) so the task reads as one coherent episode.
+ * Semantic goldens carry no OCR, so `ocrText` is left empty — the summaries
+ * drive both the scan and the grounding tools.
+ */
+export function semanticGoldenToTask(params: {
+  goldens: GoldenActivity[]
+  idPrefix: string
+  title: string
+  description: string
+  /**
+   * 1-based indices (over the *kept*, non-dropped blocks) to leave OUT of the
+   * `keep` block — they stay as day activities but aren't part of the golden
+   * task, so the miner is penalised for absorbing them (grounding precision).
+   * E.g. `[1]` drops a recorder-start / unrelated opener that bookends the task.
+   */
+  keepExclude?: number[]
+}): SemanticTaskResult {
+  const kept = params.goldens.filter((g) => !g.dropped)
+  if (kept.length === 0) {
+    throw new Error('Semantic golden has no non-dropped blocks to promote')
+  }
+
+  let cursor = 0
+  const activities: TaskFixtureActivity[] = kept.map((g, i) => {
+    const durationMin = Math.max(1, Math.round((g.endOffsetMs - g.startOffsetMs) / 60_000))
+    const activity: TaskFixtureActivity = {
+      id: `${params.idPrefix}-${String(i + 1).padStart(2, '0')}`,
+      offsetMin: cursor,
+      durationMin,
+      app: g.appName,
+      windowTitle: g.windowTitle ?? '',
+      tld: g.tld ?? null,
+      summary: g.summary,
+      ocrText: '',
+    }
+    cursor += durationMin
+    return activity
+  })
+
+  const exclude = new Set(params.keepExclude ?? [])
+  const inBlock = activities.filter((_, i) => !exclude.has(i + 1))
+  const blockActivities = inBlock.length > 0 ? inBlock : activities
+
+  return {
+    activities,
+    block: {
+      title: params.title,
+      apps: [...new Set(blockActivities.map((a) => a.app))],
+      activityIds: blockActivities.map((a) => a.id),
+      description: params.description,
+    },
+  }
+}
+
+/** Total minutes the task occupies (its last activity's end), 0 when empty. */
+function taskSpanMin(task: readonly TaskFixtureActivity[]): number {
+  return task.reduce((max, a) => Math.max(max, a.offsetMin + a.durationMin), 0)
+}
+
+/**
+ * Start offset (min from midnight) of the largest inter-activity gap in the
+ * noise day that fits `spanMin`. `fallbackMin` when nothing fits (or no noise).
+ */
+export function largestGapOffset(
+  noise: readonly TaskFixtureActivity[],
+  spanMin: number,
+  fallbackMin: number,
+): number {
+  if (noise.length === 0) return fallbackMin
+  const sorted = [...noise].sort((a, b) => a.offsetMin - b.offsetMin)
+  let bestStart = fallbackMin
+  let bestGap = -1
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const end = sorted[i].offsetMin + sorted[i].durationMin
+    const gap = sorted[i + 1].offsetMin - end
+    if (gap >= spanMin && gap > bestGap) {
+      bestGap = gap
+      bestStart = end + 1
+    }
+  }
+  return bestStart
+}
+
+/** Index into `sortedStarts` of the tightest run of `need` consecutive
+ *  activities (smallest wall-clock span) — the busiest stretch to weave the
+ *  task through, so its interruptions are genuinely back-to-back rather than
+ *  separated by idle gaps. */
+function densestRunStart(sortedStarts: number[], need: number): number {
+  let bestStart = 0
+  let bestSpan = Infinity
+  for (let s = 0; s + need <= sortedStarts.length; s++) {
+    const span = sortedStarts[s + need - 1] - sortedStarts[s]
+    if (span < bestSpan) {
+      bestSpan = span
+      bestStart = s
+    }
+  }
+  return bestStart
+}
+
+export interface PlaceOptions {
+  /** Multitask only: unrelated activities to interleave between consecutive
+   *  task steps (default 3). The task is woven into the day's tightest run of
+   *  activity so each step is separated by ~this many interruptions —
+   *  density-independent, unlike a wall-clock spread. */
+  interruptions?: number
+  /** Offset used when there is no noise to anchor to (default 583 ≈ 09:43). */
+  fallbackOffsetMin?: number
+}
+
+/**
+ * Assigns absolute `offsetMin` to a task's activities relative to a noise day,
+ * returning clones (the input task keeps its relative offsets).
+ *
+ * - `contiguous`: pack the task into the largest free gap, preserving its
+ *   back-to-back internal layout — the miner sees one uninterrupted episode.
+ * - `multitask`: weave the task's steps through the day's tightest run of
+ *   activity so `interruptions` unrelated activities sit *between* consecutive
+ *   steps — the miner must stitch the task across them and exclude them.
+ */
+export function placeTask(
+  task: readonly TaskFixtureActivity[],
+  noise: readonly TaskFixtureActivity[],
+  mode: PlacementMode,
+  opts: PlaceOptions = {},
+): TaskFixtureActivity[] {
+  const sorted = [...task].sort((a, b) => a.offsetMin - b.offsetMin)
+  const fallback = opts.fallbackOffsetMin ?? 583
+  const maxOffset = 24 * 60 - 1
+
+  if (mode === 'contiguous') {
+    const base = largestGapOffset(noise, taskSpanMin(sorted), fallback)
+    return sorted.map((a) => ({ ...a, offsetMin: Math.min(base + a.offsetMin, maxOffset) }))
+  }
+
+  // multitask: anchor each step to a noise activity, leaving `gap` unrelated
+  // activities between consecutive steps (density-independent interleaving).
+  const n = sorted.length
+  const gap = Math.max(0, opts.interruptions ?? 3)
+  const starts = noise.map((a) => a.offsetMin).sort((x, y) => x - y)
+  if (starts.length === 0) {
+    return sorted.map((a) => ({ ...a, offsetMin: Math.min(fallback + a.offsetMin, maxOffset) }))
+  }
+  const need = (n - 1) * (gap + 1) + 1
+  const runStart = densestRunStart(starts, Math.min(need, starts.length))
+  let prev = -1
+  return sorted.map((a, i) => {
+    const anchorIdx = Math.min(runStart + i * (gap + 1), starts.length - 1)
+    let off = starts[anchorIdx]
+    if (off <= prev) off = prev + 1
+    prev = off
+    return { ...a, offsetMin: Math.min(off, maxOffset) }
+  })
 }

--- a/src/main/semantic/constants.ts
+++ b/src/main/semantic/constants.ts
@@ -20,4 +20,20 @@ export const MODEL_PRICING_USD_PER_MILLION: Record<
     input_tokens_per_million: 0.1,
     completion_tokens_per_million: 0.4,
   },
+  'google/gemini-3-flash-preview': {
+    input_tokens_per_million: 0.5,
+    completion_tokens_per_million: 3,
+  },
+  'minimax/minimax-m3': {
+    input_tokens_per_million: 0.3,
+    completion_tokens_per_million: 1.2,
+  },
+  'google/gemini-3.1-flash-lite': {
+    input_tokens_per_million: 0.25,
+    completion_tokens_per_million: 1.5,
+  },
+  'google/gemini-3.1-flash-lite-preview': {
+    input_tokens_per_million: 0.25,
+    completion_tokens_per_million: 1.5,
+  },
 }


### PR DESCRIPTION
## What

Adds `npm run build-task-fixture`: promotes a semantic-summary golden (e.g. `jaro-2026-06-19-09-43`) into a ground-truth task-mining **`keep`** task and pads it with a real dev-DB day as noise, so the new sightings miner (`src/main/services/task-miner/`) can be scored on **recall + grounding** via `eval-tasks`.

Complements the existing `export-day` (noise-only; its golden is built by labeling the miner's own output, which can't measure recall of tasks the miner never surfaces).

## How

- `semanticGoldenToTask` / `placeTask` / `largestGapOffset` in `src/main/eval/task-fixture-build.ts`
- Placement modes:
  - **contiguous** — task packed into the largest free gap (uninterrupted) → tests recall
  - **multitask** — task steps woven through the day's busiest stretch with `--interruptions N` unrelated activities between each step (density-independent) → tests grounding precision under interruption
- `--keep-exclude` drops opener activities (e.g. the recorder-start) from the keep block while keeping them as day activities → grounding-**precision** probe
- 6 new unit tests

## Verification

Ran the real miner over generated fixtures (`google/gemini-2.5-flash`):

| fixture | found | grounding IoU |
|---|--:|--:|
| `2026-06-10-jaro-contract` (contiguous) | 1/1 | 100% (8 ids) |
| `2026-06-10-jaro-contract-multitask` | 1/1 | 100% (8 ids) |

The miner stitched the task across ~30 interleaved interruptions and excluded both them and the recorder-start activity. `npm test -- task-fixture-build` → 10 passing.

## Notes

- The generated fixtures live in the separate gitignored `memorylane-evals` repo (not in this PR).
- Usage: `npm run build-task-fixture -- --noise-day 2026-06-10,2026-06-05 --placement contiguous,multitask --keep-exclude 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
