### PR TITLE
fix(upload): DB sync runs exactly once per active calendar day

### DIFF
--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -513,4 +513,107 @@ describe('DatabaseUploadSync', () => {
     // The first upload still completed (fetch fired exactly once).
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
+
+  it('uploads exactly once per local calendar day across hourly ticks', async () => {
+    vi.useFakeTimers()
+    // Start late on day 1 so the next hourly tick crosses local midnight.
+    vi.setSystemTime(new Date(2026, 5, 24, 23, 0, 0))
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_1',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const backupToFile = vi.fn(async (dest: string) => {
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+    // Backing store that the gate actually reads/writes, like production.
+    let lastUploadAt: number | null = null
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => true,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => lastUploadAt,
+      recordUploadAt: (ts) => {
+        lastUploadAt = ts
+      },
+      intervalMs: 60 * 60 * 1000,
+    })
+
+    sync.start()
+    await vi.advanceTimersByTimeAsync(0)
+    // Day 1 upload.
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+
+    // Tick across midnight into day 2 — uploads again (new calendar day).
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+    expect(backupToFile).toHaveBeenCalledTimes(2)
+
+    // Another hour, still day 2 — gated out, no second upload that day.
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+    expect(backupToFile).toHaveBeenCalledTimes(2)
+
+    await sync.stop()
+  })
+
+  it('does not double-upload when a second trigger races before the first records', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchResponse(201, {
+      ok: true,
+      upload_id: 'up_1',
+      checksum_sha256: 'abc',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    let resolveBackup!: () => void
+    const backupGate = new Promise<void>((resolve) => {
+      resolveBackup = resolve
+    })
+    let firstCall = true
+    const backupToFile = vi.fn(async (dest: string) => {
+      if (firstCall) {
+        firstCall = false
+        await backupGate
+      }
+      fs.writeFileSync(dest, 'dbcontent')
+    })
+    let lastUploadAt: number | null = null
+
+    const sync = new DatabaseUploadSync({
+      storage: { backupToFile },
+      getDeviceId: () => 'device-hex-id',
+      isActivated: () => true,
+      isSyncEnabled: () => true,
+      getStripOptions: () => ({ detailLevel: 'summary' as const }),
+      getBackendUrl: () => 'http://localhost:8000/',
+      getLastUploadAt: () => lastUploadAt,
+      recordUploadAt: (ts) => {
+        lastUploadAt = ts
+      },
+      intervalMs: 1_000_000,
+    })
+
+    // Startup upload enters uploadOnce (gate passes, store still empty) and
+    // blocks on the backup gate.
+    sync.start()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+
+    // A second trigger (e.g. power resume) arrives mid-flight, before the first
+    // upload has recorded its timestamp — schedules a coalesced rerun.
+    sync.scheduleUploadIfStale('resume')
+
+    // Release the first upload: it records today's timestamp, then the rerun
+    // re-checks the daily gate and skips — exactly one upload, not two.
+    resolveBackup()
+    await sync.stop()
+
+    expect(backupToFile).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/main/services/database-upload-sync.ts
+++ b/src/main/services/database-upload-sync.ts
@@ -5,7 +5,12 @@ import log from '../logger'
 import { isSameDay } from './pattern-detector/helpers'
 import { type StripOptions } from './strip-database-for-upload'
 
-const DEFAULT_UPLOAD_INTERVAL_MS = 24 * 60 * 60 * 1000
+// Poll cadence, NOT the upload frequency. We check hourly whether today's
+// upload has happened yet; the isSameDay gate deduplicates to exactly one
+// successful upload per local calendar day. A frequent idempotent poll (vs a
+// 24h interval pinned to launch time) is what guarantees every active day gets
+// its upload promptly after midnight and survives sleep/DST/clock drift.
+const DEFAULT_CHECK_INTERVAL_MS = 60 * 60 * 1000
 
 /** Strip + VACUUM + gzip a backup DB into the bytes to upload. */
 export type PrepareUpload = (tempPath: string, stripOptions: StripOptions) => Promise<Buffer>
@@ -65,7 +70,7 @@ export class DatabaseUploadSync {
     this.getBackendUrl = params.getBackendUrl
     this.getLastUploadAt = params.getLastUploadAt
     this.recordUploadAt = params.recordUploadAt
-    this.intervalMs = params.intervalMs ?? DEFAULT_UPLOAD_INTERVAL_MS
+    this.intervalMs = params.intervalMs ?? DEFAULT_CHECK_INTERVAL_MS
     this.prepareUpload = params.prepareUpload ?? defaultPrepareUpload
   }
 
@@ -83,10 +88,10 @@ export class DatabaseUploadSync {
   }
 
   /**
-   * Upload if we haven't already uploaded today, otherwise skip. Call this on
-   * startup and on power resume so uploads catch up regardless of how the
-   * sleep-fragile 24h interval drifts. Unlike `triggerUpload`, this is gated —
-   * it never forces a duplicate same-day upload.
+   * Upload if we haven't already uploaded today, otherwise skip. Driven by the
+   * hourly poll and also called on startup and power resume so uploads catch up
+   * regardless of when the app became active. Unlike `triggerUpload`, this is
+   * gated — it never forces a duplicate same-day upload.
    */
   public scheduleUploadIfStale(reason: string): void {
     const lastUploadAt = this.getLastUploadAt()
@@ -94,7 +99,7 @@ export class DatabaseUploadSync {
       log.debug(`[DatabaseUploadSync] Skipping upload (${reason}) — already uploaded today`)
       return
     }
-    void this.queueUpload(reason)
+    void this.queueUpload(reason, false)
   }
 
   public async triggerUpload(): Promise<{ success: boolean; error?: string }> {
@@ -102,7 +107,7 @@ export class DatabaseUploadSync {
       return { success: false, error: 'Sharing disabled' }
     }
     try {
-      await this.queueUpload('manual')
+      await this.queueUpload('manual', true)
       return { success: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Upload failed'
@@ -119,7 +124,7 @@ export class DatabaseUploadSync {
     await this.inFlight.catch(() => undefined)
   }
 
-  private async queueUpload(reason: string): Promise<void> {
+  private async queueUpload(reason: string, force: boolean): Promise<void> {
     if (this.uploadRunning) {
       this.rerunRequested = true
       return this.inFlight
@@ -127,11 +132,15 @@ export class DatabaseUploadSync {
 
     this.uploadRunning = true
     let nextReason = reason
+    // The coalesced rerun re-evaluates the daily gate (force = false) so a
+    // trigger that lands mid-flight can't produce a second same-day upload.
+    let nextForce = force
     this.inFlight = (async () => {
       do {
         this.rerunRequested = false
-        await this.uploadOnce(nextReason)
+        await this.uploadOnce(nextReason, nextForce)
         nextReason = 'coalesced'
+        nextForce = false
       } while (this.rerunRequested)
     })()
       .catch((error) => {
@@ -144,10 +153,22 @@ export class DatabaseUploadSync {
     return this.inFlight
   }
 
-  private async uploadOnce(reason: string): Promise<void> {
+  private async uploadOnce(reason: string, force: boolean): Promise<void> {
     if (!this.isSyncEnabled()) {
       log.debug('[DatabaseUploadSync] Skipping upload — sharing disabled')
       return
+    }
+
+    // Re-check the daily gate at upload time (manual force bypasses). This is
+    // the authoritative once-per-day guard: it closes the race where two
+    // triggers both pass scheduleUploadIfStale before the first records, and
+    // re-gates the coalesced rerun.
+    if (!force) {
+      const lastUploadAt = this.getLastUploadAt()
+      if (lastUploadAt !== null && isSameDay(lastUploadAt, Date.now())) {
+        log.debug(`[DatabaseUploadSync] Skipping upload (${reason}) — already uploaded today`)
+        return
+      }
     }
 
     if (!this.isActivated()) {


### PR DESCRIPTION
## Context

The enterprise DB upload sync was **"at most once a day"**, not a guaranteed once-per-active-day:

- The only periodic trigger was a **24h `setInterval`** pinned to app launch time. It's `unref`'d (doesn't fire reliably across sleep), can drift across DST/clock changes, and only re-checks for a "new day" every 24h.
- A rare **coalescing race** could produce two same-day uploads: the rerun loop called `uploadOnce` without re-checking the `isSameDay` gate, so two triggers (e.g. startup + power-resume) that both passed the gate before the first recorded would upload twice.

Goal: while the app is active, upload **exactly once per local calendar day**.

## Changes

`src/main/services/database-upload-sync.ts`
- **Hourly idempotent poll** — `DEFAULT_CHECK_INTERVAL_MS` is now 1h (was 24h). The tick still calls the `isSameDay`-gated `scheduleUploadIfStale`, so it does at most one upload per day but re-checks every hour — catching each new day promptly after midnight and surviving sleep/DST/clock drift. `start()`, the power-resume hook, and `index.ts` are unchanged (they rely on the default).
- **Closed the double-upload race** — threaded a `force` flag through `queueUpload`/`uploadOnce`; `uploadOnce` re-checks the daily gate at upload time (unless forced), so racing triggers and the coalesced rerun can't double-upload. The manual button (`triggerUpload`) passes `force: true` and still bypasses the gate.

`src/main/services/database-upload-sync.test.ts`
- All existing tests stay green; added two: *uploads exactly once per local calendar day across hourly ticks* (crosses midnight via `vi.setSystemTime`) and *does not double-upload when a second trigger races before the first records*.

## Behavior note

The daily upload now lands within ~1h of local **midnight** (first active tick of the day) rather than near app-launch time. If the machine is asleep at midnight, that day's upload happens at the first tick after wake — still "once per day *if the app is active*."

## Verification

- `npm test -- database-upload-sync` — 17 passed
- `npm run lint` — 0 errors
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)