### PR TITLE
fix(privacy): poll managed blacklist every 5 min, not 30s

### DIFF
--- a/src/main/services/remote-blacklist-service.ts
+++ b/src/main/services/remote-blacklist-service.ts
@@ -1,12 +1,14 @@
 import log from '../logger'
 import type { ManagedExclusions } from '../../shared/types'
+import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import { coerceManagedExclusions } from './remote-blacklist-store'
 
 const EMPTY: ManagedExclusions = { apps: [], urlPatterns: [] }
 
 // Poll cadence for the tenant blacklist. Cheap, since a sync only notifies on a
-// real change. Matches the enterprise status-refresh interval.
-const DEFAULT_SYNC_INTERVAL_MS = 0.5 * 60 * 1000
+// real change. Shares the enterprise status-refresh interval (5 min) — IT edits
+// the policy rarely, so there's no need to poll more often.
+const DEFAULT_SYNC_INTERVAL_MS = ENTERPRISE_BACKEND_CONFIG.STATUS_REFRESH_INTERVAL_MS
 
 function serialize(blacklist: ManagedExclusions): string {
   return JSON.stringify([blacklist.apps, blacklist.urlPatterns])


### PR DESCRIPTION
## What

The enterprise managed-blacklist sync (added in #193) polled every **30 seconds**. This reuses the existing `ENTERPRISE_BACKEND_CONFIG.STATUS_REFRESH_INTERVAL_MS` (**5 min**) instead.

## Why

- The cached blacklist is enforced immediately on startup, and a sync only fires `onChange` on a real diff — so the 30s cadence only added network chatter, no faster enforcement.
- The existing comment already *claimed* to "match the enterprise status-refresh interval" (5 min) while hardcoding 30s. This makes the code match the comment and drops the duplicated literal.

## Risk

None to persisted data — interval-only change. IT policy edits now take up to ~5 min to propagate to a running device (was ~30s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)