### PR TITLE
feat(eval): tag --vary llm task fixtures with -llm to avoid name collisions

### DIFF
--- a/scripts/build-task-fixture.ts
+++ b/scripts/build-task-fixture.ts
@@ -47,6 +47,7 @@ import { loadGoldenMd } from '../src/main/eval/golden-md'
 import {
   applyParaphrasedSummaries,
   cloneOccurrence,
+  fixtureName,
   placeOccurrences,
   renderTaskFixtureGoldenMd,
   semanticGoldenToTask,
@@ -336,8 +337,7 @@ async function main(): Promise<void> {
         })
         const taskActivities = placed.flat()
         const all = [...noise, ...taskActivities].sort((x, y) => x.offsetMin - y.offsetMin)
-        const suffix = `${placement === 'multitask' ? '-multitask' : ''}${a.occurrences > 1 ? `-x${a.occurrences}` : ''}`
-        const name = `${day}-jaro-contract${suffix}`
+        const name = fixtureName(day, 'jaro-contract', placement, a.occurrences, vary)
         const goldenMd = renderTaskFixtureGoldenMd(name, blocks, all)
         const manifest: TaskFixtureManifest = {
           name,

--- a/src/main/eval/task-fixture-build.test.ts
+++ b/src/main/eval/task-fixture-build.test.ts
@@ -8,6 +8,7 @@ import {
   applyParaphrasedSummaries,
   buildWindowedActivities,
   cloneOccurrence,
+  fixtureName,
   largestGapOffset,
   placeOccurrences,
   placeTask,
@@ -449,5 +450,35 @@ describe('renderTaskFixtureGoldenMd', () => {
     expect(parsed.sightings.map((s) => s.verdict)).toEqual(['keep', 'keep'])
     expect(parsed.sightings[0].activityIds).toEqual(['jaro-01-o1', 'jaro-02-o1'])
     expect(parsed.sightings[1].title).toBe('T (2/2)')
+  })
+})
+
+describe('fixtureName', () => {
+  it('keeps existing names for deterministic variants', () => {
+    expect(fixtureName('2026-06-10', 'jaro-contract', 'contiguous', 1, 'none')).toBe(
+      '2026-06-10-jaro-contract',
+    )
+    expect(fixtureName('2026-06-10', 'jaro-contract', 'multitask', 1, 'none')).toBe(
+      '2026-06-10-jaro-contract-multitask',
+    )
+    // reorder stays unmarked so the existing x3 fixtures don't get renamed
+    expect(fixtureName('2026-06-10', 'jaro-contract', 'multitask', 3, 'reorder')).toBe(
+      '2026-06-10-jaro-contract-multitask-x3',
+    )
+  })
+
+  it('tags llm variants so they do not collide with reorder', () => {
+    expect(fixtureName('2026-06-10', 'jaro-contract', 'contiguous', 3, 'llm')).toBe(
+      '2026-06-10-jaro-contract-x3-llm',
+    )
+    expect(fixtureName('2026-06-10', 'jaro-contract', 'multitask', 3, 'llm')).toBe(
+      '2026-06-10-jaro-contract-multitask-x3-llm',
+    )
+  })
+
+  it('respects the slug', () => {
+    expect(fixtureName('2026-06-10', 'petr-admin', 'contiguous', 1, 'none')).toBe(
+      '2026-06-10-petr-admin',
+    )
   })
 })

--- a/src/main/eval/task-fixture-build.ts
+++ b/src/main/eval/task-fixture-build.ts
@@ -165,6 +165,24 @@ export function renderSightingGoldenMd(
 
 export type PlacementMode = 'contiguous' | 'multitask'
 
+/**
+ * Names a fixture dir so it's self-describing and collision-free across the
+ * variation axes: `<day>-<slug>[-multitask][-xN][-llm]`. `reorder`/`none` stay
+ * unmarked so deterministic variants keep their existing names.
+ */
+export function fixtureName(
+  day: string,
+  slug: string,
+  placement: PlacementMode,
+  occurrences: number,
+  vary: string, // 'none' | 'reorder' | 'llm'
+): string {
+  const multitask = placement === 'multitask' ? '-multitask' : ''
+  const repeat = occurrences > 1 ? `-x${occurrences}` : ''
+  const varyTag = vary === 'llm' ? '-llm' : ''
+  return `${day}-${slug}${multitask}${repeat}${varyTag}`
+}
+
 export interface SemanticTaskResult {
   /** Task activities with offsets RELATIVE to the task start (laid out
    *  back-to-back). Absolute offsets are assigned later by `placeTask`. */


### PR DESCRIPTION
## What

Extracts a pure `fixtureName(day, slug, placement, occurrences, vary)` helper from `build-task-fixture` and uses it for fixture directory names.

`--vary llm` recurring variants now get a `-llm` suffix (e.g. `2026-06-10-jaro-contract-x3-llm`) so they no longer **overwrite** the `reorder` variant of the same shape. `reorder`/`none` stay unmarked, so existing fixture names are unchanged.

## Why

Before this, the fixture name only encoded placement + occurrence count (`<day>-jaro-contract[-multitask][-xN]`). A `reorder` and an `llm` variant of the same shape produced the *same* directory name and clobbered each other — making it impossible to keep both in the suite.

## Changes

- `src/main/eval/task-fixture-build.ts` — new exported `fixtureName()`.
- `scripts/build-task-fixture.ts` — call `fixtureName(...)` instead of the inline `jaro-contract` template.
- `src/main/eval/task-fixture-build.test.ts` — cases for back-compat names + the new `-llm` tag.

## Test

`npm test -- task-fixture-build` → 23/23 pass. Generated the full jaro variation suite (16 fixtures incl. `-x3-llm`/`-x5`) and verified one end-to-end via `eval-tasks` (real miner, 100% recall). Fixtures themselves live in the separate `memorylane-evals` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)