### PR TITLE
feat(access): send app_version in enterprise activate payload

### DIFF
--- a/src/main/access/create-access-provider.ts
+++ b/src/main/access/create-access-provider.ts
@@ -7,8 +7,9 @@ import type { AccessProvider } from './types'
 export function createAccessProvider(
   edition: AppEdition,
   deviceIdentity: DeviceIdentity,
+  appVersion: string,
 ): AccessProvider {
   return edition === 'enterprise'
-    ? new EnterpriseAccessProvider(deviceIdentity)
+    ? new EnterpriseAccessProvider(deviceIdentity, appVersion)
     : new CustomerAccessProvider(deviceIdentity)
 }

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -14,6 +14,7 @@ import { EnterpriseAccessProvider } from './enterprise-access-provider'
 import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import { DeviceIdentityUnavailableError, type DeviceIdentity } from '../settings/device-identity'
 
+const TEST_APP_VERSION = '9.9.9'
 const TENANT_TOKEN = 'tt_GigKRAyNbQ1U8jBSEKTq7uiiufT392Si'
 const EMAIL = 'alice@corp.com'
 
@@ -78,7 +79,7 @@ describe('EnterpriseAccessProvider', () => {
     const responses = [descriptorResponse(), pdfResponse()]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus })
@@ -96,7 +97,7 @@ describe('EnterpriseAccessProvider', () => {
     const fetchMock = vi.fn() as unknown as typeof fetch
     globalThis.fetch = fetchMock
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null; error: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus, error: state.error })
@@ -114,7 +115,7 @@ describe('EnterpriseAccessProvider', () => {
       descriptorResponse({ contentType: 'text/html' }),
     ) as unknown as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus })
@@ -129,7 +130,7 @@ describe('EnterpriseAccessProvider', () => {
     const fetchMock = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
     globalThis.fetch = fetchMock
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null; error: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus, error: state.error })
@@ -152,7 +153,7 @@ describe('EnterpriseAccessProvider', () => {
     ]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus })
@@ -193,7 +194,7 @@ describe('EnterpriseAccessProvider', () => {
       return responses.shift() as Response
     }) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null; payload?: unknown }> = []
     provider.setUpdateCallback((state, payload) => {
       updates.push({ status: state.enterpriseActivationStatus, payload })
@@ -213,6 +214,7 @@ describe('EnterpriseAccessProvider', () => {
       device_id: 'device-123',
       email: EMAIL,
       outcome: 'accepted',
+      app_version: TEST_APP_VERSION,
     })
     expect(activateBody).not.toHaveProperty('document_version')
 
@@ -250,7 +252,7 @@ describe('EnterpriseAccessProvider', () => {
     ]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus })
@@ -269,7 +271,7 @@ describe('EnterpriseAccessProvider', () => {
       json: async () => ({ state: 'pending_review' }),
     })) as unknown as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null; error: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus, error: state.error })
@@ -301,7 +303,7 @@ describe('EnterpriseAccessProvider', () => {
     ]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null; payload?: unknown }> = []
     provider.setUpdateCallback((state, payload) => {
       updates.push({ status: state.enterpriseActivationStatus, payload })
@@ -329,7 +331,7 @@ describe('EnterpriseAccessProvider', () => {
       },
     } as unknown as DeviceIdentity
 
-    const provider = new EnterpriseAccessProvider(throwingIdentity)
+    const provider = new EnterpriseAccessProvider(throwingIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus })
@@ -385,7 +387,7 @@ describe('EnterpriseAccessProvider', () => {
     ]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null; payload?: unknown }> = []
     provider.setUpdateCallback((state, payload) => {
       updates.push({ status: state.enterpriseActivationStatus, payload })
@@ -435,7 +437,7 @@ describe('EnterpriseAccessProvider', () => {
     const fetchMock = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
     globalThis.fetch = fetchMock
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     await provider.activateEnterpriseLicense(ACTIVATION_CODE)
     await provider.submitConsentDecision('accepted')
 
@@ -451,6 +453,7 @@ describe('EnterpriseAccessProvider', () => {
       email: EMAIL,
       document_version: 7,
       outcome: 'accepted',
+      app_version: TEST_APP_VERSION,
     })
   })
 
@@ -474,7 +477,7 @@ describe('EnterpriseAccessProvider', () => {
     const fetchMock = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
     globalThis.fetch = fetchMock
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     await provider.activateEnterpriseLicense(ACTIVATION_CODE)
     await provider.submitConsentDecision('accepted')
     await vi.advanceTimersByTimeAsync(ENTERPRISE_BACKEND_CONFIG.POLL_INTERVAL_MS)
@@ -510,7 +513,7 @@ describe('EnterpriseAccessProvider', () => {
     ]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus })
@@ -547,7 +550,7 @@ describe('EnterpriseAccessProvider', () => {
     ]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus })
@@ -572,7 +575,7 @@ describe('EnterpriseAccessProvider', () => {
     ]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus })
@@ -590,7 +593,7 @@ describe('EnterpriseAccessProvider', () => {
     ) as unknown as typeof fetch
     globalThis.fetch = fetchMock
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     await provider.activateEnterpriseLicense(ACTIVATION_CODE)
 
     const before = (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls.length
@@ -603,7 +606,7 @@ describe('EnterpriseAccessProvider', () => {
     const responses = [descriptorResponse(), pdfResponse()]
     globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null; error: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({
@@ -628,7 +631,7 @@ describe('EnterpriseAccessProvider', () => {
       json: async () => ({ error: 'unauthorized' }),
     })) as unknown as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null; error: string | null }> = []
     provider.setUpdateCallback((state) => {
       updates.push({ status: state.enterpriseActivationStatus, error: state.error })
@@ -646,7 +649,7 @@ describe('EnterpriseAccessProvider', () => {
       json: async () => ({ activated: false }),
     })) as unknown as typeof fetch
 
-    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const provider = new EnterpriseAccessProvider(deviceIdentity, TEST_APP_VERSION)
     const updates: Array<{ status: string | null; payload?: unknown }> = []
     provider.setUpdateCallback((state, payload) => {
       updates.push({ status: state.enterpriseActivationStatus, payload })

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -105,7 +105,10 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   private tokenRefreshTimer: ReturnType<typeof setTimeout> | null = null
   private pendingConsent: PendingConsentState | null = null
 
-  constructor(deviceIdentity: DeviceIdentity) {
+  constructor(
+    deviceIdentity: DeviceIdentity,
+    private readonly appVersion: string,
+  ) {
     super(createInitialAccessState('enterprise'), deviceIdentity)
   }
 
@@ -392,7 +395,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
         'Content-Type': 'application/json',
         ...bearer(tenantToken),
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify({ ...body, app_version: this.appVersion }),
     })
 
     if (response.status === 502) {

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -224,7 +224,7 @@ export async function createMainRuntime(params: {
   interactionMonitor.onInteraction(interactionHandler)
 
   const deviceIdentity = params.deviceIdentity ?? new DeviceIdentity()
-  const accessProvider = createAccessProvider(params.edition, deviceIdentity)
+  const accessProvider = createAccessProvider(params.edition, deviceIdentity, app.getVersion())
 
   // In-app eval recorder (Developer mode). Inert until start() is called; ships
   // in every build but does nothing unless the hidden UI invokes it.


### PR DESCRIPTION
## What

The enterprise `POST /api/license/activate` request now includes the running app version (`app.getVersion()`) as an `app_version` field, so the backend can persist which client version a device activated with.

Previously the app version was never sent to the enterprise backend — it was only used for a startup log line and tray labels.

## How

- **`runtime.ts`** — resolves `app.getVersion()` at the main-process wiring point (where electron's `app` is available) and passes it into the factory.
- **`create-access-provider.ts`** — factory takes `appVersion` and forwards it to the enterprise provider only.
- **`enterprise-access-provider.ts`** — constructor stores `appVersion`; `postActivate` merges `app_version` into the body, so **both** activate paths (consent + external-consent) carry it via one edit. Field name matches the existing snake_case convention.

`app.getVersion()` is injected rather than called inside the provider because it returns `undefined` under `ELECTRON_RUN_AS_NODE=1` (how the test suite runs).

## Follow-up (separate repo)

Persisting `app_version` requires a corresponding change in the enterprise backend (`enterprise.trymemorylane.com`) to accept and store the field. **The field is inert until the backend reads it.**

## Testing

- `npm run test -- enterprise-access-provider` — 20/20 pass; both activate-body assertions now require `app_version`.
- `npm run lint` — clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)