### PR TITLE
feat(semantic): default openrouter video model to Gemini 3.1 Flash Lite

### DIFF
--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -30,6 +30,8 @@ interface VendorModelDefaults {
 export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
   openrouter: {
     semanticVideo: [
+      { id: 'google/gemini-3.1-flash-lite-preview', label: 'Gemini 3.1 Flash Lite' },
+      { id: 'google/gemini-3-flash-preview', label: 'Gemini 3 Flash' },
       { id: 'google/gemini-2.5-flash-lite-preview-09-2025', label: 'Gemini 2.5 Flash Lite' },
       { id: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
     ],


### PR DESCRIPTION
Promote gemini-3.1-flash-lite-preview to the openrouter semanticVideo default with gemini-3-flash-preview as backup, per the 2026-06-23 eval: higher deterministic pass rate, fewer hard-fails, and lower cost than the prior 2.5 Flash Lite default. Keeps both 2.5 variants in the fallback tail.