### PR TITLE
fix(windows): co-locate VC++ runtime with onnxruntime addon so it resolves

### DIFF
--- a/build/bundle-win-runtime.js
+++ b/build/bundle-win-runtime.js
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs')
+const path = require('path')
+
+// Copies the staged x64 VC++ runtime DLLs (produced by
+// scripts/copy-vc-runtime-win.js in build/win-runtime) into the packaged
+// onnxruntime-node native dir, directly next to onnxruntime_binding.node.
+//
+// They must sit *beside* the addon. Native modules load via
+// LOAD_WITH_ALTERED_SEARCH_PATH, which resolves a module's dependencies from the
+// module's own directory (and System32) but does not reliably consult PATH — so
+// shipping the runtime to a separate resources dir and adding it to PATH does not
+// work. Co-locating is the same guarantee that lets the sibling onnxruntime.dll
+// resolve, and mirrors what installing the VC++ redistributable (into System32)
+// achieves.
+exports.default = async function bundleWinRuntime(context) {
+  const { electronPlatformName, appOutDir } = context
+  if (electronPlatformName !== 'win32') return
+
+  const stagedDir = path.join(__dirname, '..', 'build', 'win-runtime')
+  const dlls = fs.existsSync(stagedDir)
+    ? fs.readdirSync(stagedDir).filter((f) => f.toLowerCase().endsWith('.dll'))
+    : []
+  if (dlls.length === 0) {
+    throw new Error(
+      '[vc-runtime] build/win-runtime has no DLLs; run scripts/copy-vc-runtime-win.js before packaging.',
+    )
+  }
+
+  const binRoot = path.join(
+    appOutDir,
+    'resources',
+    'app.asar.unpacked',
+    'node_modules',
+    'onnxruntime-node',
+    'bin',
+  )
+  const targets = []
+  for (const napi of fs.existsSync(binRoot) ? fs.readdirSync(binRoot) : []) {
+    const dir = path.join(binRoot, napi, 'win32', 'x64')
+    if (fs.existsSync(path.join(dir, 'onnxruntime_binding.node'))) targets.push(dir)
+  }
+  if (targets.length === 0) {
+    throw new Error('[vc-runtime] onnxruntime-node win32/x64 dir not found in packaged app.')
+  }
+
+  for (const dir of targets) {
+    for (const dll of dlls) {
+      fs.copyFileSync(path.join(stagedDir, dll), path.join(dir, dll))
+      console.log(`[vc-runtime] afterPack: ${dll} -> ${dir}`)
+    }
+  }
+}

--- a/build/bundle-win-runtime.js
+++ b/build/bundle-win-runtime.js
@@ -21,10 +21,16 @@ exports.default = async function bundleWinRuntime(context) {
   const dlls = fs.existsSync(stagedDir)
     ? fs.readdirSync(stagedDir).filter((f) => f.toLowerCase().endsWith('.dll'))
     : []
+  // Only make:win stages the runtime (via scripts/copy-vc-runtime-win.js, which
+  // fails loud if the DLLs can't be sourced). A win pack without staging — e.g. a
+  // dev `npm run package --dir` on a machine that already has the redistributable
+  // — should still succeed; skip rather than fail the build.
   if (dlls.length === 0) {
-    throw new Error(
-      '[vc-runtime] build/win-runtime has no DLLs; run scripts/copy-vc-runtime-win.js before packaging.',
+    console.warn(
+      '[vc-runtime] afterPack: build/win-runtime has no DLLs; skipping runtime co-location. ' +
+        'Run scripts/copy-vc-runtime-win.js (make:win does) to ship the VC++ runtime for clean machines.',
     )
+    return
   }
 
   const binRoot = path.join(

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -97,6 +97,7 @@ module.exports = {
     'node_modules/onnxruntime-node/**/*',
     '**/*.node',
   ],
+  afterPack: 'build/bundle-win-runtime.js',
   afterSign: 'build/notarize.js',
   afterAllArtifactBuild: 'build/notarize-pkg.js',
   mac: macConfig,
@@ -106,11 +107,6 @@ module.exports = {
         from: 'build/rust',
         to: 'rust',
         filter: ['app-watcher-windows.exe', 'screenshot-capturer-windows.exe'],
-      },
-      {
-        from: 'build/win-runtime',
-        to: 'vcruntime',
-        filter: ['*.dll'],
       },
     ],
     azureSignOptions: {

--- a/scripts/copy-vc-runtime-win.js
+++ b/scripts/copy-vc-runtime-win.js
@@ -4,10 +4,10 @@
 // clean Windows machine without the VC++ redistributable the loader fails with
 // "The specified module could not be found" (error 126) at startup.
 //
-// The DLLs are copied into build/win-runtime/, shipped to resources/vcruntime
-// via electron-builder (win.extraResources), and that dir is prepended to PATH
-// at runtime in src/main/system/onnxruntime-path-fix.ts so they resolve when the
-// native module is dlopen'd under LOAD_WITH_ALTERED_SEARCH_PATH.
+// The DLLs are copied into build/win-runtime/, then placed next to
+// onnxruntime_binding.node at package time by build/bundle-win-runtime.js so they
+// resolve when the native module is dlopen'd under LOAD_WITH_ALTERED_SEARCH_PATH,
+// which searches the addon's own directory but not reliably PATH.
 const fs = require('fs')
 const path = require('path')
 const { spawnSync } = require('child_process')

--- a/src/main/system/onnxruntime-path-fix.ts
+++ b/src/main/system/onnxruntime-path-fix.ts
@@ -1,15 +1,13 @@
 /**
  * Must be imported BEFORE any module that transitively loads onnxruntime-node.
  *
- * On Windows, onnxruntime_binding.node depends on onnxruntime.dll and
- * DirectML.dll in the same directory, and both statically import the x64 VC++
- * runtime (vcruntime140*.dll / msvcp140*.dll). The Windows DLL loader doesn't
- * always find sibling DLLs inside the deeply nested asar.unpacked path, and
- * clean machines may lack the VC++ redistributable entirely — either failing
- * with "The specified module could not be found" at load time. We ship the VC++
- * runtime in resources/vcruntime (see scripts/copy-vc-runtime-win.js) and add
- * both directories to PATH at module-evaluation time — before any subsequent
- * static import can trigger a require('onnxruntime-node').
+ * On Windows, onnxruntime_binding.node depends on onnxruntime.dll, DirectML.dll,
+ * and the x64 VC++ runtime (vcruntime140*.dll / msvcp140*.dll). All of these live
+ * in the addon's own directory — onnxruntime.dll/DirectML.dll ship there, and the
+ * VC++ runtime is copied in at package time (see build/bundle-win-runtime.js) so
+ * clean machines without the VC++ redistributable can still load it. We also add
+ * that directory to PATH at module-evaluation time — before any subsequent static
+ * import can trigger a require('onnxruntime-node').
  */
 import path from 'node:path'
 import { app } from 'electron'
@@ -25,6 +23,5 @@ if (process.platform === 'win32' && app.isPackaged) {
     'win32',
     process.arch,
   )
-  const vcRuntimeDir = path.join(process.resourcesPath, 'vcruntime')
-  process.env.PATH = `${vcRuntimeDir};${onnxBinDir};${process.env.PATH ?? ''}`
+  process.env.PATH = `${onnxBinDir};${process.env.PATH ?? ''}`
 }


### PR DESCRIPTION
## Follow-up to #211 — that fix shipped but didn't resolve

#211 bundled the x64 VC++ runtime into `resources/vcruntime` and added that dir to `PATH`. The app **still crashed** on clean Windows machines with the same error 126 (`The specified module could not be found`) at `onnxruntime_binding.node`.

I downloaded the published `v1.4.0-alpha.2` Enterprise MSI and confirmed the four DLLs (`vcruntime140.dll`, `vcruntime140_1.dll`, `msvcp140.dll`, `msvcp140_1.dll`) **were packaged correctly** into `resources\vcruntime\`. The build was fine — the **placement** was wrong.

## Why PATH didn't work

Native addons load via `LOAD_WITH_ALTERED_SEARCH_PATH`. That resolves a module's dependencies from **the module's own directory** and **System32**, but does **not** reliably consult `PATH`. So:

- The sibling `onnxruntime.dll` resolves because it's co-located with the addon.
- The VC++ runtime in a separate `resources/vcruntime` (reachable only via `PATH`) was never found.
- `vc_redist` works precisely because it installs into **System32**, which is always searched.

## Fix

Put the runtime **next to `onnxruntime_binding.node`** — the one location guaranteed to be searched:

- `build/bundle-win-runtime.js` — new `afterPack` hook; copies the staged DLLs (still sourced into `build/win-runtime` by `scripts/copy-vc-runtime-win.js`) into the packaged onnxruntime-node native dir.
- `electron-builder.config.js` — wire `afterPack`; drop the ineffective `resources/vcruntime` `extraResources` entry.
- `onnxruntime-path-fix.ts` — drop the `resources/vcruntime` PATH line (no longer used).

## Testing

- [x] Confirmed via the shipped MSI that #211's DLLs landed in `resources/vcruntime` (packaging works; placement was the bug).
- [x] Manual proof of the mechanism: copying those DLLs next to `onnxruntime_binding.node` in an installed build makes it launch on a clean machine.
- [x] Config loads, `afterPack` wired, prettier/eslint pass; no-op on macOS.
- [ ] **Windows build to confirm end-to-end:** `npm run make:enterprise:win` should log `[vc-runtime] afterPack: … -> …\onnxruntime-node\bin\napi-v3\win32\x64`; the MSI should launch in a clean Windows Sandbox with no manual redist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)