### PR TITLE
build(win): switch customer NSIS installer to one-click per-user

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -119,10 +119,8 @@ module.exports = {
   },
   nsis: {
     artifactName: '${productName}-Setup.${ext}',
-    oneClick: false,
-    perMachine: true,
-    allowElevation: true,
-    allowToChangeInstallationDirectory: true,
+    oneClick: true,
+    perMachine: false,
   },
   msi: {
     perMachine: true,


### PR DESCRIPTION
## Why

A customer (PSG) reported the app "needs admin rights". Root cause: the customer-edition NSIS installer used `perMachine: true`, installing to `C:\Program Files`, so every auto-update had to elevate. Non-admin employees can't approve the UAC prompt, leaving them stuck on old versions in an update loop — and pushing setup into elevated sessions, which then strands activation/settings in the admin account's profile.

## What

- `perMachine: false` — install to `%LOCALAPPDATA%\Programs\MemoryLane`; install and all auto-updates run without elevation.
- `oneClick: true` — no wizard, no directory picker (prevents users from reintroducing the Program Files problem).
- Dropped `allowElevation` / `allowToChangeInstallationDirectory` — meaningless for a one-click per-user installer.

Enterprise MSI stays `perMachine: true` intentionally: it has no auto-updater (IT pushes MSIs) and per-machine is what Intune/SCCM deployment expects.

## Migration for existing installs

Existing per-machine installs won't self-migrate — the old copy in Program Files needs one elevated uninstall (`"C:\Program Files\MemoryLane\Uninstall MemoryLane.exe" /S`), then the new setup installed in the end user's own session. User data in `AppData\Roaming\MemoryLane` is untouched.

Before releasing: VM-test the auto-update path from a per-machine 1.3.x install under a non-admin account to see whether the new installer elevates for the old uninstall or installs alongside — release notes depend on the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)