### PR TITLE
feat(models): GA video model defaults + versioned override of local picks

### DIFF
--- a/src/main/settings/capture-settings-manager.test.ts
+++ b/src/main/settings/capture-settings-manager.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import * as os from 'os'
 import type { InstalledApp } from '../../shared/types'
 import { CaptureSettingsManager } from './capture-settings-manager'
+import { MODEL_DEFAULTS_VERSION, getVendorDefaults } from '../../shared/vendor-defaults'
 import {
   VISUAL_DETECTOR_CONFIG,
   INTERACTION_MONITOR_CONFIG,
@@ -339,6 +340,55 @@ describe('CaptureSettingsManager', () => {
       expect(map.openrouter).toBeDefined()
       expect(map.openrouter?.semanticSnapshotModel).toBe('mistralai/mistral-small-3.2-24b-instruct')
       expect(map.openrouter?.semanticPipelineMode).toBe('image')
+    })
+
+    it('overrides stale model picks when stored defaults version is older', () => {
+      // A seat pinned to a since-retired preview id, from before the version bump.
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          activeVendor: 'openrouter',
+          semanticVideoModel: 'google/gemini-3.1-flash-lite-preview',
+          modelDefaultsVersion: MODEL_DEFAULTS_VERSION - 1,
+        }),
+      )
+      const manager = new CaptureSettingsManager(configPath)
+      const settings = manager.get()
+      const expected = getVendorDefaults('openrouter').semanticVideoModel
+      expect(settings.semanticVideoModel).toBe(expected)
+      expect(settings.modelsByVendor.openrouter?.semanticVideoModel).toBe(expected)
+      expect(settings.modelDefaultsVersion).toBe(MODEL_DEFAULTS_VERSION)
+    })
+
+    it('keeps custom picks when stored defaults version is current', () => {
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          activeVendor: 'openrouter',
+          semanticVideoModel: 'google/gemini-2.5-flash',
+          modelDefaultsVersion: MODEL_DEFAULTS_VERSION,
+        }),
+      )
+      const manager = new CaptureSettingsManager(configPath)
+      expect(manager.get().semanticVideoModel).toBe('google/gemini-2.5-flash')
+    })
+
+    it('does not override local model picks for vendors without presets', () => {
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          activeVendor: 'openai-compatible',
+          semanticSnapshotModel: 'my-local-model',
+          patternDetectionModel: 'my-local-model',
+          semanticPipelineMode: 'image',
+          // No modelDefaultsVersion → triggers the override pass.
+        }),
+      )
+      const manager = new CaptureSettingsManager(configPath)
+      const settings = manager.get()
+      expect(settings.semanticSnapshotModel).toBe('my-local-model')
+      expect(settings.patternDetectionModel).toBe('my-local-model')
+      expect(settings.modelDefaultsVersion).toBe(MODEL_DEFAULTS_VERSION)
     })
 
     it('switching vendors does not lose other vendor selections', () => {

--- a/src/main/settings/capture-settings-manager.test.ts
+++ b/src/main/settings/capture-settings-manager.test.ts
@@ -391,6 +391,38 @@ describe('CaptureSettingsManager', () => {
       expect(settings.modelDefaultsVersion).toBe(MODEL_DEFAULTS_VERSION)
     })
 
+    it('resets all curated slots on a version bump, not just the changed one', () => {
+      // The override is authoritative across every slot: a still-valid but
+      // non-default task-miner pick is reset to the vendor default too.
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          activeVendor: 'openrouter',
+          patternDetectionModel: 'xiaomi/mimo-v2.5',
+          modelDefaultsVersion: MODEL_DEFAULTS_VERSION - 1,
+        }),
+      )
+      const manager = new CaptureSettingsManager(configPath)
+      const expected = getVendorDefaults('openrouter').patternDetectionModel
+      expect(manager.get().patternDetectionModel).toBe(expected)
+    })
+
+    it('persists the version bump so the override runs only once', () => {
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          activeVendor: 'openrouter',
+          semanticVideoModel: 'google/gemini-3.1-flash-lite-preview',
+          modelDefaultsVersion: MODEL_DEFAULTS_VERSION - 1,
+        }),
+      )
+      new CaptureSettingsManager(configPath)
+      // The stamp is written back to disk, so a second load sees the current
+      // version and skips the override — no repeated clobber on every launch.
+      const stored = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+      expect(stored.modelDefaultsVersion).toBe(MODEL_DEFAULTS_VERSION)
+    })
+
     it('switching vendors does not lose other vendor selections', () => {
       const manager = new CaptureSettingsManager(configPath)
       // Customize OpenRouter.

--- a/src/main/settings/capture-settings-manager.ts
+++ b/src/main/settings/capture-settings-manager.ts
@@ -11,7 +11,7 @@ import type {
 } from '../../shared/types'
 import { VENDORS } from '../../shared/types'
 import type { AppEdition } from '../../shared/edition'
-import { getVendorDefaults } from '../../shared/vendor-defaults'
+import { MODEL_DEFAULTS_VERSION, getVendorDefaults } from '../../shared/vendor-defaults'
 import {
   isBundleIdToken,
   migrateExcludedAppTokens,
@@ -155,6 +155,7 @@ const DEFAULTS: CaptureSettings = {
   excludedUrlPatterns: [],
   urlMatchSchemaVersion: URL_MATCH_SCHEMA_VERSION,
   appMatchSchemaVersion: APP_MATCH_SCHEMA_VERSION,
+  modelDefaultsVersion: MODEL_DEFAULTS_VERSION,
   activeVendor: 'openrouter',
   semanticVideoModel: OPENROUTER_DEFAULTS.semanticVideoModel,
   semanticSnapshotModel: OPENROUTER_DEFAULTS.semanticSnapshotModel,
@@ -201,6 +202,25 @@ function normalizeVendorSelection(value: unknown): VendorModelSelection | undefi
     patternDetectionModel:
       typeof v.patternDetectionModel === 'string' ? v.patternDetectionModel : '',
     semanticPipelineMode: mode,
+  }
+}
+
+/**
+ * Reset a vendor's remembered model slots to the current vendor defaults. Slots
+ * whose vendor has no curated default (empty preset list, e.g. openai-compatible
+ * local models) are left untouched — there is nothing authoritative to override
+ * them with, so the user's local pick stands. Pipeline mode is preserved.
+ */
+function overrideWithVendorDefaults(
+  selection: VendorModelSelection,
+  vendor: Vendor,
+): VendorModelSelection {
+  const d = getVendorDefaults(vendor)
+  return {
+    semanticVideoModel: d.semanticVideoModel || selection.semanticVideoModel,
+    semanticSnapshotModel: d.semanticSnapshotModel || selection.semanticSnapshotModel,
+    patternDetectionModel: d.patternDetectionModel || selection.patternDetectionModel,
+    semanticPipelineMode: selection.semanticPipelineMode,
   }
 }
 
@@ -282,6 +302,31 @@ export class CaptureSettingsManager {
             semanticPipelineMode,
           }
         }
+        // Curated model defaults changed (version bump): overwrite the stored
+        // model picks with the current vendor defaults for every remembered
+        // vendor, and re-derive the active vendor's flat fields from them. This
+        // is authoritative — it evicts stale/retired ids the user may be pinned
+        // to. Vendors without presets keep their local pick (see helper).
+        let finalVideoModel = semanticVideoModel
+        let finalSnapshotModel = semanticSnapshotModel
+        let finalPatternModel = patternDetectionModel
+        let finalModelsByVendor = modelsByVendor
+        if ((data.modelDefaultsVersion ?? 0) < MODEL_DEFAULTS_VERSION) {
+          finalModelsByVendor = { ...modelsByVendor }
+          for (const vendor of VENDORS) {
+            const entry = finalModelsByVendor[vendor]
+            if (entry) finalModelsByVendor[vendor] = overrideWithVendorDefaults(entry, vendor)
+          }
+          const active = finalModelsByVendor[activeVendor]
+          if (active) {
+            finalVideoModel = active.semanticVideoModel
+            finalSnapshotModel = active.semanticSnapshotModel
+            finalPatternModel = active.patternDetectionModel
+          }
+          log.info(
+            `[CaptureSettings] Model defaults v${data.modelDefaultsVersion ?? 0} → v${MODEL_DEFAULTS_VERSION}: overriding stored model picks with vendor defaults`,
+          )
+        }
         // Migrate pre-v1 URL patterns (substring era): wrap patterns without a
         // `*` in `*…*` so they keep contains behavior as a wildcard. Only `*` is a
         // wildcard now, so a pre-v1 `?` (the old single-char wildcard) must also be
@@ -310,12 +355,13 @@ export class CaptureSettingsManager {
             data.captureHotkeyAccelerator ?? data.pauseHotkeyAccelerator,
           ),
           databaseExportDirectory: normalizeDatabaseExportDirectory(data.databaseExportDirectory),
+          modelDefaultsVersion: MODEL_DEFAULTS_VERSION,
           activeVendor,
-          semanticVideoModel,
-          semanticSnapshotModel,
-          patternDetectionModel,
+          semanticVideoModel: finalVideoModel,
+          semanticSnapshotModel: finalSnapshotModel,
+          patternDetectionModel: finalPatternModel,
           semanticPipelineMode,
-          modelsByVendor,
+          modelsByVendor: finalModelsByVendor,
         }
       }
     } catch (error) {

--- a/src/main/settings/capture-settings-manager.ts
+++ b/src/main/settings/capture-settings-manager.ts
@@ -208,8 +208,7 @@ function normalizeVendorSelection(value: unknown): VendorModelSelection | undefi
 /**
  * Reset a vendor's remembered model slots to the current vendor defaults. Slots
  * whose vendor has no curated default (empty preset list, e.g. openai-compatible
- * local models) are left untouched — there is nothing authoritative to override
- * them with, so the user's local pick stands. Pipeline mode is preserved.
+ * local models) keep the user's local pick. Pipeline mode is preserved.
  */
 function overrideWithVendorDefaults(
   selection: VendorModelSelection,
@@ -244,6 +243,7 @@ export class CaptureSettingsManager {
   private configPath: string
   private settings: CaptureSettings
   private defaults: CaptureSettings
+  private modelDefaultsUpgraded = false
 
   constructor(options: CaptureSettingsManagerOptions | string = {}) {
     const opts: CaptureSettingsManagerOptions =
@@ -260,6 +260,11 @@ export class CaptureSettingsManager {
       uploadDetailLevel: defaultUploadDetailLevel(opts.edition ?? 'customer'),
     }
     this.settings = this.load()
+    // Persist the version stamp once so the override runs a single time, not on
+    // every launch (mirrors migrateAppTokens stamping its schema version).
+    if (this.modelDefaultsUpgraded) {
+      this.save({})
+    }
   }
 
   private load(): CaptureSettings {
@@ -302,11 +307,9 @@ export class CaptureSettingsManager {
             semanticPipelineMode,
           }
         }
-        // Curated model defaults changed (version bump): overwrite the stored
-        // model picks with the current vendor defaults for every remembered
-        // vendor, and re-derive the active vendor's flat fields from them. This
-        // is authoritative — it evicts stale/retired ids the user may be pinned
-        // to. Vendors without presets keep their local pick (see helper).
+        // Version bump: overwrite every remembered vendor's picks with the
+        // current defaults and re-derive the active vendor's flat fields. See
+        // MODEL_DEFAULTS_VERSION for why this is authoritative.
         let finalVideoModel = semanticVideoModel
         let finalSnapshotModel = semanticSnapshotModel
         let finalPatternModel = patternDetectionModel
@@ -323,6 +326,7 @@ export class CaptureSettingsManager {
             finalSnapshotModel = active.semanticSnapshotModel
             finalPatternModel = active.patternDetectionModel
           }
+          this.modelDefaultsUpgraded = true
           log.info(
             `[CaptureSettings] Model defaults v${data.modelDefaultsVersion ?? 0} → v${MODEL_DEFAULTS_VERSION}: overriding stored model picks with vendor defaults`,
           )

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -234,6 +234,7 @@ export interface CaptureSettings {
   excludedUrlPatterns: string[]
   urlMatchSchemaVersion?: number
   appMatchSchemaVersion?: number
+  modelDefaultsVersion?: number
   activeVendor: Vendor
   semanticVideoModel: string
   semanticSnapshotModel: string

--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -5,6 +5,16 @@ export interface ModelPreset {
   label: string
 }
 
+/**
+ * Bump whenever the preset lists below change in a way that should be pushed to
+ * existing installs. On load, a stored `modelDefaultsVersion` older than this
+ * causes the manager to overwrite the user's remembered model picks with the
+ * current vendor defaults (see CaptureSettingsManager.load). Curated defaults
+ * are treated as authoritative — an upgrade replaces stale/retired ids (e.g.
+ * `-preview` snapshots that later 404) rather than stranding a seat on them.
+ */
+export const MODEL_DEFAULTS_VERSION = 2
+
 interface VendorPresets {
   /** Presets for each model slot. The first entry is the vendor's default. */
   semanticVideo: ModelPreset[]
@@ -29,10 +39,15 @@ interface VendorModelDefaults {
  */
 export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
   openrouter: {
+    // GA ids only — preview ids resolve on Google AI Studio but 404 on
+    // Vertex-pinned (ZDR) keys, and are the class that gets retired. All four
+    // verified available under the ZDR OpenRouter key (2026-07-10), ordered by
+    // cost-efficiency: gemini-3.1-flash-lite (~60 tok/frame, $0.25/M) heads it;
+    // gemini-2.5-flash is the quality-max floor.
     semanticVideo: [
-      { id: 'google/gemini-3.1-flash-lite-preview', label: 'Gemini 3.1 Flash Lite' },
+      { id: 'google/gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
       { id: 'google/gemini-3-flash-preview', label: 'Gemini 3 Flash' },
-      { id: 'google/gemini-2.5-flash-lite-preview-09-2025', label: 'Gemini 2.5 Flash Lite' },
+      { id: 'google/gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
       { id: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
     ],
     semanticSnapshot: [

--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -10,8 +10,8 @@ export interface ModelPreset {
  * existing installs. On load, a stored `modelDefaultsVersion` older than this
  * causes the manager to overwrite the user's remembered model picks with the
  * current vendor defaults (see CaptureSettingsManager.load). Curated defaults
- * are treated as authoritative — an upgrade replaces stale/retired ids (e.g.
- * `-preview` snapshots that later 404) rather than stranding a seat on them.
+ * are authoritative — an upgrade replaces stale/retired ids rather than
+ * stranding a seat on them.
  */
 export const MODEL_DEFAULTS_VERSION = 2
 


### PR DESCRIPTION
## What

Two related changes to how semantic-video model defaults are chosen and rolled out.

**1. GA video defaults (openrouter `semanticVideo`).** Swap the two `-preview` ids for their GA equivalents. New chain:

```
google/gemini-3.1-flash-lite → google/gemini-3-flash-preview
→ google/gemini-2.5-flash-lite → google/gemini-2.5-flash
```

Preview ids resolve on Google AI Studio but **404 on Vertex-pinned (ZDR) keys**, and are the class Google retires (`gemini-2.5-flash-lite-preview-09-2025` is already gone). With the old defaults, a Vertex-routed seat's primary model 404'd and fell through the entire chain — three failed round-trips per activity — before landing on `gemini-2.5-flash`, the *most expensive* option. All four new ids were verified available under the ZDR OpenRouter key (2026-07-10), ordered by cost-efficiency.

**2. Versioned defaults with local override.** New `MODEL_DEFAULTS_VERSION` (co-located with the presets). On load, if a seat's stored `modelDefaultsVersion` is older than current, `CaptureSettingsManager` overwrites the remembered model picks (flat fields + `modelsByVendor` map) with the current vendor defaults, then stamps the new version. Bumping the constant when curating the list now propagates to existing installs on next launch, so stale/retired ids can't strand a seat.

**Guard:** vendors with no curated presets (`openai-compatible` — local Ollama/LM Studio ids) are **not** overridden; there's no authoritative default to replace a user's working local pick with.

## Measurements (this video, 1920×1248, 1 fps)

| Model | Tok/frame | $/1M in | $/video |
|---|---|---|---|
| gemini-3.1-flash-lite | ~60 | $0.25 | $0.00032 |
| gemini-2.5-flash-lite | ~258 | $0.10 | $0.00054 |
| gemini-3-flash-preview | ~60 | $0.50 | $0.00063 |
| gemini-2.5-flash | ~258 | $0.30 | $0.00163 |

Quality (2026-06-23 semantic-summary evals): `gemini-2.5-flash` leads (0.83 equivalence) but the 3.1/3.0 flash-lite tier is within ~0.03 at a fraction of the cost.

## Tests

Added three `CaptureSettingsManager` cases: stale version overrides to the new default, current version preserves custom picks, local-vendor picks survive the override. Full suite green (51 tests).

## Not included
- `google`/Vertex presets still pin to `gemini-2.5-flash` only; adding `gemini-3.1-flash-lite` there would cut managed-enterprise video cost ~5× (confirmed available on Vertex) — left out to keep this PR scoped to the openrouter chain.