### PR TITLE
fix(activity): retry frame/video delete on transient Windows locks

### DIFF
--- a/src/main/activity/activity-cleanup.ts
+++ b/src/main/activity/activity-cleanup.ts
@@ -6,10 +6,10 @@ import type { Activity } from './activity-types'
 
 function deleteFileIfPresent(filepath: string, label: 'frame' | 'video'): boolean {
   try {
-    fs.rmSync(filepath, { force: true })
+    fs.rmSync(filepath, { force: true, maxRetries: 5, retryDelay: 100 })
     return fs.existsSync(filepath) === false
   } catch {
-    log.warn(`[ActivityCleanup] Failed to delete ${label}: ${filepath}`)
+    log.debug(`[ActivityCleanup] Failed to delete ${label}: ${filepath}`)
     return false
   }
 }


### PR DESCRIPTION
## DEU-196

Windows-only log spam: `[ActivityCleanup] Failed to delete frame: ...` repeated for one or two frames per activity.

### Root cause
On Windows, deleting a file that any process has open throws `EBUSY`/`EPERM`, and Windows Defender / AV real-time protection opens every freshly-written file to scan it. Our recorder writes a frame `.jpg`, and moments later `cleanupActivityFiles()` tries to delete it while Defender still holds a handle. `fs.rmSync(filepath, { force: true })` had no retry, so a momentary lock failed permanently and logged at `warn`.

macOS/Linux are unaffected — `unlink` on an open file succeeds there (confirmed: 2,513 successful deletes and 0 failures in prod macOS logs).

Not a leak — `sweepStaleFiles` already reclaims any file older than 1h.

### Fix
- Add Node's native `maxRetries: 5, retryDelay: 100` to the `fs.rmSync` call — retries exactly on `EBUSY`/`EPERM`/etc. with linear backoff (~1.5s), so transient AV locks resolve silently.
- Drop the residual failure log from `warn` → `debug`: a file still stuck after all retries is the rare genuinely-locked case that the 1h sweep reclaims anyway — a self-healing condition, not warn-worthy.

Two-line change in `deleteFileIfPresent`; no signature/callsite changes.

### Verification
- `npm run test -- activity-cleanup` — 3/3 pass; `npm run lint` clean.
- Real confirmation is Windows-side: `Failed to delete frame` should drop to ~zero under normal AV operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)