### PR TITLE
fix(recorder): handle daemon stdin write errors instead of crashing the app

### DIFF
--- a/src/main/recorder/native-screenshot.test.ts
+++ b/src/main/recorder/native-screenshot.test.ts
@@ -98,4 +98,38 @@ describe('ScreenshotDaemon', () => {
 
     await daemon.stop()
   })
+
+  it('survives a stdin write that fails after the daemon dies', async () => {
+    const childProcess = await import('child_process')
+    const { ScreenshotDaemon } = await import('./native-screenshot')
+
+    const child = createMockChildProcess(303)
+    vi.mocked(childProcess.spawn).mockReturnValue(
+      child as unknown as ReturnType<typeof childProcess.spawn>,
+    )
+
+    const daemon = new ScreenshotDaemon({
+      getExecutable: () => ({ command: '/tmp/screenshot', args: [] }),
+      buildSpawnArgs: () => [],
+      buildCommandPayload: (command) => command,
+    })
+
+    await daemon.start({
+      outputDir: '/tmp/memorylane-test',
+      onFrame: vi.fn(),
+    })
+
+    // A display change queues a write while the daemon is still alive...
+    daemon.send({ displayId: 2 })
+
+    // ...the daemon is then killed, and the queued write flushes into a dead pipe.
+    // An unhandled 'error' here is what took down the main process.
+    expect(() => child.stdin.emit('error', new Error('write EPIPE'))).not.toThrow()
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      '[ScreenshotDaemon] stdin write failed: write EPIPE',
+    )
+
+    await daemon.stop()
+  })
 })

--- a/src/main/recorder/native-screenshot.ts
+++ b/src/main/recorder/native-screenshot.ts
@@ -141,11 +141,11 @@ export class ScreenshotDaemon implements ScreenCaptureBackend {
       this.handleLine(line)
     })
 
-    /*     // Writes queue in the stdin buffer, so a command sent while the daemon was alive
+    // Writes queue in the stdin buffer, so a command sent while the daemon was alive
     // can still flush after the pipe dies. Unhandled, that EPIPE kills the main process.
     proc.stdin?.on('error', (err: Error) => {
       log.warn(`[ScreenshotDaemon] stdin write failed: ${err.message}`)
-    }) */
+    })
 
     proc.stderr?.on('data', (chunk) => {
       const msg = chunk.toString().trim()

--- a/src/main/recorder/native-screenshot.ts
+++ b/src/main/recorder/native-screenshot.ts
@@ -141,6 +141,12 @@ export class ScreenshotDaemon implements ScreenCaptureBackend {
       this.handleLine(line)
     })
 
+    /*     // Writes queue in the stdin buffer, so a command sent while the daemon was alive
+    // can still flush after the pipe dies. Unhandled, that EPIPE kills the main process.
+    proc.stdin?.on('error', (err: Error) => {
+      log.warn(`[ScreenshotDaemon] stdin write failed: ${err.message}`)
+    }) */
+
     proc.stderr?.on('data', (chunk) => {
       const msg = chunk.toString().trim()
       if (!msg) return


### PR DESCRIPTION
## The bug

An unhandled `EPIPE` on the screenshot daemon's stdin **killed the entire main process**.

A single `app_change` event drives two paths in the same tick:

1. `pipeline-harness.ts:173` → `setDisplayId()` → `send()` → `stdin.write()` — the payload **queues in the writable buffer** and returns. The guard in `send()` passes legitimately; the daemon is alive.
2. The same event reaches the blacklist coordinator → `Entering blocked mode` → `setFrameCaptureSuppressed(true)` → `screenCapturer.stop()` → `killProcess()` → **the pipe dies**.

The buffered payload then flushes into a dead pipe. With no `'error'` listener on stdin, Node promotes the EPIPE to an uncaught exception and the app dies.

The stack confirms the buffering — `clearBuffer (node:internal/streams/writable:781)` is the flush-pending-writes path:

```
[12:12:54] [Blacklist] Entering blocked mode (app_change: excluded_app=slack)
[12:12:54] [Crash] Uncaught exception in main process: Error: write EPIPE
    at clearBuffer (node:internal/streams/writable:781:7)
    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:105:10)
[12:12:54] [ScreenshotDaemon] Process exited with code null   ← 'close' arrives AFTER the crash
```

Real impact: an enterprise device died at `12:12:54` on 2026-07-08 and stayed down until the next launch at `19:08:42` — **~7 hours of silently lost capture**.

## Why the guard can't fix it

The check on `native-screenshot.ts:113` passed correctly — the daemon was alive at both check time and write-call time. It died while the bytes were still queued. No synchronous check can close that window; only an `'error'` listener can.

## Why this only hit 2 devices in the fleet

`setDisplayId` early-returns when the display is unchanged (`screen-capturer.ts:46`), so on a single-monitor machine `send()` is **never called** and the bug is structurally unreachable.

`Cannot send command: daemon not running` is only reachable from inside `send()`, and `setIntervalMs` has zero callers — so every one of those log lines is a confirmed display change. The two affected devices: **218** and **60**. Everyone else: zero.

Required conjunction: multi-monitor + a blacklisted app + switching to it on a different display.

## The fix

An `'error'` listener on stdin, alongside the existing `stderr`/`close`/`error` handlers. The existing `'close'` → `handleProcessExit` → backoff-restart machinery already recovers correctly — it just never got the chance, because the process died first.

## Test

`survives a stdin write that fails after the daemon dies` reproduces the exact sequence. Verified it fails against pre-fix code with the production symptom:

```
× survives a stdin write that fails after the daemon dies
  AssertionError: expected [Function] to not throw an error but 'Error: write EPIPE' was thrown
```

- 113 tests pass across `src/main/recorder` + `src/main/capture`
- ESLint clean; `tsc` clean on both changed files

## Follow-up (not in this PR)

This stops the crash, not the cause. `setDisplayId` and the blacklist teardown still race on every `app_change`, and the daemon still receives a display command it can't use. That connects to the known display-id flapping issue (dual native emissions on the Windows app-watcher, no `setDisplayId` debounce). Debouncing there would cut write volume and address both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)