### PR TITLE
fix(access): actionable messages for network failures during activation

### DIFF
--- a/src/main/access/customer-access-provider.test.ts
+++ b/src/main/access/customer-access-provider.test.ts
@@ -157,6 +157,20 @@ describe('CustomerAccessProvider', () => {
     expect(openedUrl).not.toContain('device_id=')
   })
 
+  it('maps transport failures from the portal link to a friendly message', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError('fetch failed', {
+        cause: Object.assign(new Error('getaddrinfo ENOTFOUND backend.example'), {
+          code: 'ENOTFOUND',
+        }),
+      })
+    }) as typeof fetch
+
+    const provider = new CustomerAccessProvider(deviceIdentity)
+    await expect(provider.openSubscriptionPortal()).rejects.toThrow(/can't reach the server/i)
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
   it('rejects checkout URLs outside the backend registrable domain', async () => {
     globalThis.fetch = makeFetchMock([
       jsonResponse({ url: 'https://attacker.example/phishing?token=x' }),

--- a/src/main/access/customer-access-provider.ts
+++ b/src/main/access/customer-access-provider.ts
@@ -3,7 +3,7 @@ import { MANAGED_KEY_CONFIG } from '../../shared/constants'
 import type { ConsentOutcome, PendingConsent, SubscriptionPlan } from '../../shared/types'
 import { isSameRegistrableDomain } from '../../shared/url-utils'
 import log from '@main/utils/logger'
-import { describeNetworkError } from '@main/utils/network-error'
+import { toUserFacingError } from '@main/utils/network-error'
 import type { DeviceIdentity } from '../settings/device-identity'
 import { BaseAccessProvider } from './base-access-provider'
 import {
@@ -89,8 +89,7 @@ export class CustomerAccessProvider extends BaseAccessProvider {
       signedUrl = await this.fetchSignedLink('/v2/subscription/portal-link', deviceId)
     } catch (error) {
       log.warn('[CustomerAccess] Failed to mint portal link:', error)
-      const friendly = describeNetworkError(error)
-      throw friendly !== null ? new Error(friendly) : error
+      throw toUserFacingError(error)
     }
     await shell.openExternal(signedUrl)
     log.info('[CustomerAccess] Opened subscription portal in system browser')

--- a/src/main/access/customer-access-provider.ts
+++ b/src/main/access/customer-access-provider.ts
@@ -3,6 +3,7 @@ import { MANAGED_KEY_CONFIG } from '../../shared/constants'
 import type { ConsentOutcome, PendingConsent, SubscriptionPlan } from '../../shared/types'
 import { isSameRegistrableDomain } from '../../shared/url-utils'
 import log from '@main/utils/logger'
+import { describeNetworkError } from '@main/utils/network-error'
 import type { DeviceIdentity } from '../settings/device-identity'
 import { BaseAccessProvider } from './base-access-provider'
 import {
@@ -83,7 +84,14 @@ export class CustomerAccessProvider extends BaseAccessProvider {
 
   public async openSubscriptionPortal(): Promise<void> {
     const deviceId = this.resolveDeviceIdInteractive()
-    const signedUrl = await this.fetchSignedLink('/v2/subscription/portal-link', deviceId)
+    let signedUrl: string
+    try {
+      signedUrl = await this.fetchSignedLink('/v2/subscription/portal-link', deviceId)
+    } catch (error) {
+      log.warn('[CustomerAccess] Failed to mint portal link:', error)
+      const friendly = describeNetworkError(error)
+      throw friendly !== null ? new Error(friendly) : error
+    }
     await shell.openExternal(signedUrl)
     log.info('[CustomerAccess] Opened subscription portal in system browser')
   }

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -151,7 +151,7 @@ describe('EnterpriseAccessProvider', () => {
 
     await provider.refreshAccessState()
 
-    expect(updates.at(-1)?.error).toMatch(/firewall or proxy/i)
+    expect(updates.at(-1)?.error).toMatch(/can't reach the server/i)
   })
 
   it('rejects malformed activation codes without making any network calls', async () => {

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -154,6 +154,42 @@ describe('EnterpriseAccessProvider', () => {
     expect(updates.at(-1)?.error).toMatch(/can't reach the server/i)
   })
 
+  it('keeps an activated device activated when a refresh hits a transport failure', async () => {
+    const responses: Array<() => Response> = [
+      // GET /license/status -> activated
+      () => ({ ok: true, json: async () => ({ activated: true }) }) as unknown as Response,
+      // GET /license/inference-config -> managed key
+      () =>
+        ({
+          ok: true,
+          json: async () => ({ provider: 'openrouter', apiKey: 'key-123' }),
+        }) as unknown as Response,
+      // next refresh: offline
+      () => {
+        throw new TypeError('fetch failed', {
+          cause: Object.assign(new Error('getaddrinfo ENOTFOUND backend.example'), {
+            code: 'ENOTFOUND',
+          }),
+        })
+      },
+    ]
+    globalThis.fetch = vi.fn(async () => (responses.shift() as () => Response)()) as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; error: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus, error: state.error })
+    })
+
+    await provider.refreshAccessState()
+    expect(updates.at(-1)?.status).toBe('activated')
+
+    await provider.refreshAccessState()
+
+    expect(updates.at(-1)?.status).toBe('activated')
+    expect(updates.at(-1)?.error).toBeNull()
+  })
+
   it('rejects malformed activation codes without making any network calls', async () => {
     const fetchMock = vi.fn() as unknown as typeof fetch
     globalThis.fetch = fetchMock

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -284,6 +284,39 @@ describe('EnterpriseAccessProvider', () => {
     })
   })
 
+  it('fails the activation with a friendly message when the external-consent bind hits a transport failure', async () => {
+    const responses: Array<() => Response> = [
+      // GET /license/consent-document -> already_approved sentinel
+      () =>
+        ({
+          ok: true,
+          json: async () => ({ state: 'already_approved' }),
+        }) as unknown as Response,
+      // POST /license/activate -> network failure
+      () => {
+        throw new TypeError('fetch failed', {
+          cause: Object.assign(new Error('getaddrinfo ENOTFOUND backend.example'), {
+            code: 'ENOTFOUND',
+          }),
+        })
+      },
+    ]
+    globalThis.fetch = vi.fn(async () => (responses.shift() as () => Response)()) as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; error: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus, error: state.error })
+    })
+
+    await expect(provider.activateEnterpriseLicense(ACTIVATION_CODE)).rejects.toThrow(
+      /can't reach the server/i,
+    )
+    // Not stuck in 'activating': the UI returns to the code-entry form.
+    expect(updates.at(-1)?.status).toBe('error')
+    expect(updates.at(-1)?.error).toMatch(/internet connection/i)
+  })
+
   it('treats 502 on external-consent bind as provisional success and starts polling', async () => {
     const responses = [
       // GET /license/consent-document -> already_approved sentinel

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -92,6 +92,68 @@ describe('EnterpriseAccessProvider', () => {
     expect(consent?.contentType).toBe('application/pdf')
   })
 
+  it('maps transport failures during activation to a friendly message and fails the activation', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError('fetch failed', {
+        cause: Object.assign(new Error('getaddrinfo ENOTFOUND backend.example'), {
+          code: 'ENOTFOUND',
+        }),
+      })
+    }) as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; error: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus, error: state.error })
+    })
+
+    await expect(provider.activateEnterpriseLicense(ACTIVATION_CODE)).rejects.toThrow(
+      /can't reach the server/i,
+    )
+    // Not stuck in 'activating': the UI returns to the code-entry form.
+    expect(updates.at(-1)?.status).toBe('error')
+    expect(updates.at(-1)?.error).toMatch(/internet connection/i)
+  })
+
+  it('keeps the backend error message when the activation code is rejected', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'Invalid activation code' }),
+    })) as unknown as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; error: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus, error: state.error })
+    })
+
+    await expect(provider.activateEnterpriseLicense(ACTIVATION_CODE)).rejects.toThrow(
+      'Invalid activation code',
+    )
+    expect(updates.at(-1)?.error).toBe('Invalid activation code')
+  })
+
+  it('maps transport failures during refresh to a friendly message', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError('fetch failed', {
+        cause: Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
+          code: 'ECONNREFUSED',
+        }),
+      })
+    }) as typeof fetch
+
+    const provider = new EnterpriseAccessProvider(deviceIdentity)
+    const updates: Array<{ status: string | null; error: string | null }> = []
+    provider.setUpdateCallback((state) => {
+      updates.push({ status: state.enterpriseActivationStatus, error: state.error })
+    })
+
+    await provider.refreshAccessState()
+
+    expect(updates.at(-1)?.error).toMatch(/firewall or proxy/i)
+  })
+
   it('rejects malformed activation codes without making any network calls', async () => {
     const fetchMock = vi.fn() as unknown as typeof fetch
     globalThis.fetch = fetchMock

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import type { ConsentOutcome, PendingConsent } from '../../shared/types'
 import log from '@main/utils/logger'
-import { describeNetworkError } from '@main/utils/network-error'
+import { NetworkError, toUserFacingError } from '@main/utils/network-error'
 import type { DeviceIdentity } from '../settings/device-identity'
 import { parseActivationCode } from './activation-code'
 import { BaseAccessProvider, DEVICE_IDENTITY_RETRY_MESSAGE } from './base-access-provider'
@@ -124,8 +124,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       return await fetch(url.toString(), init)
     } catch (error) {
       log.warn('[EnterpriseAccess] Network request failed:', error)
-      const friendly = describeNetworkError(error)
-      throw friendly !== null ? new Error(friendly) : error
+      throw toUserFacingError(error)
     }
   }
 
@@ -169,6 +168,11 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       )
     } catch (error) {
       log.warn('[EnterpriseAccess] Refresh failed:', error)
+      // Being offline is not de-activation: keep an activated device's state
+      // and let the periodic refresh retry.
+      if (error instanceof NetworkError && this.accessState.isEnterpriseActivated) {
+        return
+      }
       this.applyTransition(
         transitionEnterpriseAccess(this.accessState, {
           type: 'activation_failed',

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -379,11 +379,20 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       )
       throw new Error(message)
     }
-    const result = await this.postActivate(
-      { tenant_token: tenantToken, device_id: deviceId, email, outcome: 'accepted' },
-      tenantToken,
-      'Activation failed during external-consent bind',
-    )
+    let result: ActivateResult
+    try {
+      result = await this.postActivate(
+        { tenant_token: tenantToken, device_id: deviceId, email, outcome: 'accepted' },
+        tenantToken,
+        'Activation failed during external-consent bind',
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Activation failed.'
+      this.applyTransition(
+        transitionEnterpriseAccess(this.accessState, { type: 'activation_failed', error: message }),
+      )
+      throw new Error(message)
+    }
 
     if (result.status === 'error') {
       this.applyTransition(

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import type { ConsentOutcome, PendingConsent } from '../../shared/types'
 import log from '@main/utils/logger'
+import { describeNetworkError } from '@main/utils/network-error'
 import type { DeviceIdentity } from '../settings/device-identity'
 import { parseActivationCode } from './activation-code'
 import { BaseAccessProvider, DEVICE_IDENTITY_RETRY_MESSAGE } from './base-access-provider'
@@ -117,6 +118,17 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     return new URL(path, this.resolveBackendBase())
   }
 
+  /** fetch() that rethrows transport failures with a user-facing message. */
+  private async fetchMapped(url: string | URL, init?: RequestInit): Promise<Response> {
+    try {
+      return await fetch(url.toString(), init)
+    } catch (error) {
+      log.warn('[EnterpriseAccess] Network request failed:', error)
+      const friendly = describeNetworkError(error)
+      throw friendly !== null ? new Error(friendly) : error
+    }
+  }
+
   public async refreshAccessState(): Promise<void> {
     if (this.accessState.enterpriseActivationStatus === 'awaiting_consent') {
       return
@@ -196,9 +208,21 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
 
     const descriptorUrl = this.enterpriseUrl('api/license/consent-document')
 
-    const descriptorResponse = await fetch(descriptorUrl.toString(), {
-      headers: bearer(parsed.tenantToken),
-    })
+    let descriptorResponse: Response
+    try {
+      descriptorResponse = await this.fetchMapped(descriptorUrl, {
+        headers: bearer(parsed.tenantToken),
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Activation failed.'
+      this.applyTransition(
+        transitionEnterpriseAccess(this.accessState, {
+          type: 'activation_failed',
+          error: message,
+        }),
+      )
+      throw new Error(message)
+    }
     if (!descriptorResponse.ok) {
       const errorMessage = await this.readErrorMessage(
         descriptorResponse,
@@ -386,7 +410,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     tenantToken: string,
     errorFallback: string,
   ): Promise<ActivateResult> {
-    const response = await fetch(this.enterpriseUrl('api/license/activate'), {
+    const response = await this.fetchMapped(this.enterpriseUrl('api/license/activate'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -445,7 +469,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     if (documentUrl.origin !== new URL(backendBase).origin) {
       throw new Error('Consent document URL is not on the configured backend origin')
     }
-    const response = await fetch(documentUrl.toString(), {
+    const response = await this.fetchMapped(documentUrl, {
       headers: bearer(tenantToken),
     })
     if (!response.ok) {
@@ -522,7 +546,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   private async fetchEnterpriseStatus(deviceId: string): Promise<boolean> {
     const url = this.enterpriseUrl('api/license/status')
 
-    const response = await fetch(url.toString(), { headers: bearer(deviceId) })
+    const response = await this.fetchMapped(url, { headers: bearer(deviceId) })
     if (response.status === 401) {
       return false
     }
@@ -541,7 +565,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
   private async fetchInferenceConfig(deviceId: string): Promise<ManagedInferenceConfig | null> {
     const url = this.enterpriseUrl('api/license/inference-config')
 
-    const response = await fetch(url.toString(), { headers: bearer(deviceId) })
+    const response = await this.fetchMapped(url, { headers: bearer(deviceId) })
     if (response.status === 401) {
       return null
     }

--- a/src/main/utils/network-error.test.ts
+++ b/src/main/utils/network-error.test.ts
@@ -34,16 +34,17 @@ describe('networkErrorCode', () => {
 })
 
 describe('describeNetworkError', () => {
-  it.each(['ENOTFOUND', 'EAI_AGAIN'])('maps %s to the DNS message', (code) => {
-    expect(describeNetworkError(fetchFailed(code))).toMatch(/DNS or proxy settings/)
+  it.each([
+    'ENOTFOUND',
+    'EAI_AGAIN',
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'EHOSTUNREACH',
+    'ENETUNREACH',
+    'UND_ERR_SOCKET',
+  ])('maps %s to the unreachable-server message', (code) => {
+    expect(describeNetworkError(fetchFailed(code))).toMatch(/can't reach the server/i)
   })
-
-  it.each(['ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'UND_ERR_SOCKET'])(
-    'maps %s to the unreachable-server message',
-    (code) => {
-      expect(describeNetworkError(fetchFailed(code))).toMatch(/firewall or proxy/)
-    },
-  )
 
   it.each(['ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT'])(
     'maps %s to the timeout message',
@@ -55,19 +56,19 @@ describe('describeNetworkError', () => {
   it.each(['DEPTH_ZERO_SELF_SIGNED_CERT', 'SELF_SIGNED_CERT_IN_CHAIN', 'CERT_HAS_EXPIRED'])(
     'maps %s to the TLS message',
     (code) => {
-      expect(describeNetworkError(fetchFailed(code))).toMatch(/secure connection failed/i)
+      expect(describeNetworkError(fetchFailed(code))).toMatch(/secure connection/i)
     },
   )
 
   it('keeps unknown codes visible in the generic message', () => {
     expect(describeNetworkError(fetchFailed('UND_ERR_WEIRD'))).toBe(
-      'Network error (UND_ERR_WEIRD). Check your connection and try again.',
+      'Connection problem (UND_ERR_WEIRD). Check your internet connection and try again.',
     )
   })
 
   it('maps a bare fetch failure without a code to the generic message', () => {
     expect(describeNetworkError(fetchFailed())).toBe(
-      'Network error. Check your connection and try again.',
+      'Connection problem. Check your internet connection and try again.',
     )
   })
 

--- a/src/main/utils/network-error.test.ts
+++ b/src/main/utils/network-error.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { describeNetworkError, networkErrorCode } from './network-error'
+import {
+  describeNetworkError,
+  networkErrorCode,
+  NetworkError,
+  toUserFacingError,
+} from './network-error'
 
 function fetchFailed(code?: string): TypeError {
   const cause =
@@ -53,12 +58,15 @@ describe('describeNetworkError', () => {
     },
   )
 
-  it.each(['DEPTH_ZERO_SELF_SIGNED_CERT', 'SELF_SIGNED_CERT_IN_CHAIN', 'CERT_HAS_EXPIRED'])(
-    'maps %s to the TLS message',
-    (code) => {
-      expect(describeNetworkError(fetchFailed(code))).toMatch(/secure connection/i)
-    },
-  )
+  it.each([
+    'DEPTH_ZERO_SELF_SIGNED_CERT',
+    'SELF_SIGNED_CERT_IN_CHAIN',
+    'CERT_HAS_EXPIRED',
+    'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+    'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  ])('maps %s to the TLS message', (code) => {
+    expect(describeNetworkError(fetchFailed(code))).toMatch(/secure connection/i)
+  })
 
   it('keeps unknown codes visible in the generic message', () => {
     expect(describeNetworkError(fetchFailed('UND_ERR_WEIRD'))).toBe(
@@ -85,5 +93,18 @@ describe('describeNetworkError', () => {
       describeNetworkError(Object.assign(new Error('x'), { code: 'ERR_INVALID_ARG_TYPE' })),
     ).toBeNull()
     expect(describeNetworkError(undefined)).toBeNull()
+  })
+})
+
+describe('toUserFacingError', () => {
+  it('wraps transport failures in a NetworkError with the friendly message', () => {
+    const mapped = toUserFacingError(fetchFailed('ENOTFOUND'))
+    expect(mapped).toBeInstanceOf(NetworkError)
+    expect((mapped as Error).message).toMatch(/can't reach the server/i)
+  })
+
+  it('returns non-network errors unchanged', () => {
+    const original = new Error('Invalid activation code')
+    expect(toUserFacingError(original)).toBe(original)
   })
 })

--- a/src/main/utils/network-error.test.ts
+++ b/src/main/utils/network-error.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { describeNetworkError, networkErrorCode } from './network-error'
+
+function fetchFailed(code?: string): TypeError {
+  const cause =
+    code !== undefined ? Object.assign(new Error(`syscall failed ${code}`), { code }) : undefined
+  return new TypeError('fetch failed', cause !== undefined ? { cause } : undefined)
+}
+
+describe('networkErrorCode', () => {
+  it('reads the code from the direct cause', () => {
+    expect(networkErrorCode(fetchFailed('ENOTFOUND'))).toBe('ENOTFOUND')
+  })
+
+  it('walks nested cause chains', () => {
+    const inner = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' })
+    const error = new TypeError('fetch failed', { cause: new Error('wrapped', { cause: inner }) })
+    expect(networkErrorCode(error)).toBe('ECONNREFUSED')
+  })
+
+  it('descends into AggregateError causes', () => {
+    const aggregate = new AggregateError([
+      Object.assign(new Error('connect ECONNREFUSED ::1'), { code: 'ECONNREFUSED' }),
+    ])
+    expect(networkErrorCode(new TypeError('fetch failed', { cause: aggregate }))).toBe(
+      'ECONNREFUSED',
+    )
+  })
+
+  it('returns undefined when no code exists', () => {
+    expect(networkErrorCode(fetchFailed())).toBeUndefined()
+    expect(networkErrorCode('not an error')).toBeUndefined()
+  })
+})
+
+describe('describeNetworkError', () => {
+  it.each(['ENOTFOUND', 'EAI_AGAIN'])('maps %s to the DNS message', (code) => {
+    expect(describeNetworkError(fetchFailed(code))).toMatch(/DNS or proxy settings/)
+  })
+
+  it.each(['ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'UND_ERR_SOCKET'])(
+    'maps %s to the unreachable-server message',
+    (code) => {
+      expect(describeNetworkError(fetchFailed(code))).toMatch(/firewall or proxy/)
+    },
+  )
+
+  it.each(['ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT'])(
+    'maps %s to the timeout message',
+    (code) => {
+      expect(describeNetworkError(fetchFailed(code))).toMatch(/timed out/i)
+    },
+  )
+
+  it.each(['DEPTH_ZERO_SELF_SIGNED_CERT', 'SELF_SIGNED_CERT_IN_CHAIN', 'CERT_HAS_EXPIRED'])(
+    'maps %s to the TLS message',
+    (code) => {
+      expect(describeNetworkError(fetchFailed(code))).toMatch(/secure connection failed/i)
+    },
+  )
+
+  it('keeps unknown codes visible in the generic message', () => {
+    expect(describeNetworkError(fetchFailed('UND_ERR_WEIRD'))).toBe(
+      'Network error (UND_ERR_WEIRD). Check your connection and try again.',
+    )
+  })
+
+  it('maps a bare fetch failure without a code to the generic message', () => {
+    expect(describeNetworkError(fetchFailed())).toBe(
+      'Network error. Check your connection and try again.',
+    )
+  })
+
+  it('maps abort/timeout errors', () => {
+    const abort = new Error('This operation was aborted')
+    abort.name = 'AbortError'
+    expect(describeNetworkError(abort)).toMatch(/timed out/i)
+  })
+
+  it('returns null for non-network errors', () => {
+    expect(describeNetworkError(new Error('boom'))).toBeNull()
+    expect(describeNetworkError(new Error('Invalid activation code'))).toBeNull()
+    expect(
+      describeNetworkError(Object.assign(new Error('x'), { code: 'ERR_INVALID_ARG_TYPE' })),
+    ).toBeNull()
+    expect(describeNetworkError(undefined)).toBeNull()
+  })
+})

--- a/src/main/utils/network-error.ts
+++ b/src/main/utils/network-error.ts
@@ -20,7 +20,9 @@ function isTlsCode(code: string): boolean {
     code.startsWith('ERR_TLS') ||
     code.startsWith('ERR_SSL') ||
     code.startsWith('CERT_') ||
-    code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' ||
+    // OpenSSL verification failures: UNABLE_TO_GET_ISSUER_CERT_LOCALLY (common
+    // behind TLS-intercepting corporate proxies), UNABLE_TO_VERIFY_LEAF_SIGNATURE, …
+    code.startsWith('UNABLE_TO_') ||
     code.includes('SELF_SIGNED')
   )
 }
@@ -66,4 +68,16 @@ export function describeNetworkError(error: unknown): string | null {
       : 'Connection problem. Check your internet connection and try again.'
   }
   return null
+}
+
+/** A network transport failure rewritten with a user-facing message. */
+export class NetworkError extends Error {}
+
+/**
+ * NetworkError with a user-facing message when the error is a transport
+ * failure; the original error otherwise.
+ */
+export function toUserFacingError(error: unknown): unknown {
+  const friendly = describeNetworkError(error)
+  return friendly !== null ? new NetworkError(friendly) : error
 }

--- a/src/main/utils/network-error.ts
+++ b/src/main/utils/network-error.ts
@@ -1,5 +1,6 @@
-const DNS_CODES = new Set(['ENOTFOUND', 'EAI_AGAIN'])
 const CONNECT_CODES = new Set([
+  'ENOTFOUND',
+  'EAI_AGAIN',
   'ECONNREFUSED',
   'ECONNRESET',
   'EHOSTUNREACH',
@@ -46,26 +47,23 @@ export function networkErrorCode(error: unknown): string | undefined {
 export function describeNetworkError(error: unknown): string | null {
   const code = networkErrorCode(error)
   if (code !== undefined) {
-    if (DNS_CODES.has(code)) {
-      return "Can't reach the server. Check your internet connection and DNS or proxy settings."
-    }
     if (CONNECT_CODES.has(code)) {
-      return "Can't reach the server. Check your internet connection and any firewall or proxy."
+      return "Can't reach the server. Check your internet connection and try again."
     }
     if (TIMEOUT_CODES.has(code)) {
-      return 'Connection timed out. Check your network and try again.'
+      return 'The connection timed out. Check your internet connection and try again.'
     }
     if (isTlsCode(code)) {
-      return 'Secure connection failed. A firewall or proxy may be intercepting traffic.'
+      return "Couldn't set up a secure connection. If you're on a company network, ask your IT department."
     }
   }
   if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
-    return 'Connection timed out. Check your network and try again.'
+    return 'The connection timed out. Check your internet connection and try again.'
   }
   if (error instanceof TypeError && error.message.toLowerCase().includes('fetch')) {
     return code !== undefined
-      ? `Network error (${code}). Check your connection and try again.`
-      : 'Network error. Check your connection and try again.'
+      ? `Connection problem (${code}). Check your internet connection and try again.`
+      : 'Connection problem. Check your internet connection and try again.'
   }
   return null
 }

--- a/src/main/utils/network-error.ts
+++ b/src/main/utils/network-error.ts
@@ -1,0 +1,71 @@
+const DNS_CODES = new Set(['ENOTFOUND', 'EAI_AGAIN'])
+const CONNECT_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPIPE',
+  'UND_ERR_SOCKET',
+])
+const TIMEOUT_CODES = new Set([
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+])
+
+function isTlsCode(code: string): boolean {
+  return (
+    code.startsWith('ERR_TLS') ||
+    code.startsWith('ERR_SSL') ||
+    code.startsWith('CERT_') ||
+    code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' ||
+    code.includes('SELF_SIGNED')
+  )
+}
+
+/** Best-effort error code from the undici/Node cause chain (e.g. ENOTFOUND). */
+export function networkErrorCode(error: unknown): string | undefined {
+  let current: unknown = error
+  for (let depth = 0; depth < 4; depth++) {
+    if (!(current instanceof Error)) return undefined
+    const code = (current as { code?: unknown }).code
+    if (typeof code === 'string' && code !== '') return code
+    current =
+      current instanceof AggregateError && current.errors.length > 0
+        ? current.errors[0]
+        : current.cause
+  }
+  return undefined
+}
+
+/**
+ * Brief user-facing message for a fetch() transport rejection, or null if the
+ * error is not a network transport failure.
+ */
+export function describeNetworkError(error: unknown): string | null {
+  const code = networkErrorCode(error)
+  if (code !== undefined) {
+    if (DNS_CODES.has(code)) {
+      return "Can't reach the server. Check your internet connection and DNS or proxy settings."
+    }
+    if (CONNECT_CODES.has(code)) {
+      return "Can't reach the server. Check your internet connection and any firewall or proxy."
+    }
+    if (TIMEOUT_CODES.has(code)) {
+      return 'Connection timed out. Check your network and try again.'
+    }
+    if (isTlsCode(code)) {
+      return 'Secure connection failed. A firewall or proxy may be intercepting traffic.'
+    }
+  }
+  if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
+    return 'Connection timed out. Check your network and try again.'
+  }
+  if (error instanceof TypeError && error.message.toLowerCase().includes('fetch')) {
+    return code !== undefined
+      ? `Network error (${code}). Check your connection and try again.`
+      : 'Network error. Check your connection and try again.'
+  }
+  return null
+}


### PR DESCRIPTION
Fixes DEU-200 — https://linear.app/deusxmachina/issue/DEU-200/better-error-message-on-no-connection

## Problem

Transport-level network failures (no internet, DNS failure, connection refused, timeout, TLS interception) surfaced in the "Activate device" step as the raw undici error `fetch failed` — both as a toast and inline red text. Unactionable. Worse, an unguarded fetch after the state machine entered `activation_started` could leave the UI stuck on "Activating this device...".

## Changes

- New `src/main/utils/network-error.ts`: `describeNetworkError()` walks the undici error cause chain and maps codes to brief, plain-language messages (no dev jargon):
  - DNS / refused / unreachable → "Can't reach the server. Check your internet connection and try again."
  - Timeouts → "The connection timed out. Check your internet connection and try again."
  - TLS/cert failures → "Couldn't set up a secure connection. If you're on a company network, ask your IT department."
  - Unknown transport codes → "Connection problem (CODE). Check your internet connection and try again."
  - Non-network errors pass through untouched; full technical detail is logged in the main process.
- Enterprise provider: all five bare `fetch()` calls now go through a `fetchMapped()` wrapper. Covers both the activation toast and the inline error set by the background status refresh. Backend-provided messages (e.g. invalid activation code) are unchanged.
- Bug fix: the consent-document fetch now transitions to `activation_failed` on network failure instead of leaving the UI stuck on the provisioning view.
- Customer provider: `openSubscriptionPortal` gets the same mapping (previously leaked raw `fetch failed`).

## Testing

- Unit tests for every message bucket, cause-chain walking, and AggregateError handling.
- Provider tests: transport failure during activation → friendly message + error state (not stuck); backend rejection message preserved; transport failure during refresh → friendly inline message.
- Probed real undici errors under Electron's Node (bogus host, refused port) — both produce the exact `TypeError: fetch failed` + cause-code shape the mapper handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)