### PR TITLE
refactor: replace as-unknown-as double-casts with proper typing

### DIFF
--- a/.agents/skills/release-plugin/SKILL.md
+++ b/.agents/skills/release-plugin/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: deploy-plugin
+name: release-plugin
 description: Deploy the MemoryLane Claude Code plugin by verifying only plugin/marketplace files changed, bumping the plugin version, then committing and pushing.
 ---
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,10 +15,41 @@
   ],
   "parser": "@typescript-eslint/parser",
   "rules": {
-    // false-positives on better-sqlite3, whose typings export Database both as
-    // the default and as a named member
-    "import/no-named-as-default": "off"
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": ["**/test-utils"],
+            "message": "Test helpers are test-only; do not import them from production code."
+          }
+        ]
+      }
+    ]
   },
+  "overrides": [
+    {
+      // false-positives on better-sqlite3, whose typings export Database both
+      // as the default and as a named member (fires even on type-only imports)
+      "files": [
+        "src/main/storage/**/*.ts",
+        "src/main/services/strip-database-for-upload.ts",
+        "src/main/services/strip-database-for-upload.test.ts",
+        "src/main/services/upload-prep-worker.test.ts",
+        "src/main/ui/database-import.ts"
+      ],
+      "rules": { "import/no-named-as-default": "off" }
+    },
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/test-utils.ts",
+        "src/main/eval/task-replay.ts"
+      ],
+      "rules": { "no-restricted-imports": "off" }
+    }
+  ],
   "ignorePatterns": ["*.config.ts", "build/", "dist/"], // because we use dynamic imports in paths.ts
   "settings": {
     "import/resolver": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,11 @@
     "prettier"
   ],
   "parser": "@typescript-eslint/parser",
+  "rules": {
+    // false-positives on better-sqlite3, whose typings export Database both as
+    // the default and as a named member
+    "import/no-named-as-default": "off"
+  },
   "ignorePatterns": ["*.config.ts", "build/", "dist/"], // because we use dynamic imports in paths.ts
   "settings": {
     "import/resolver": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
   "settings": {
     "import/resolver": {
       "typescript": {
+        "noWarnOnMultipleProjects": true,
         "project": [
           "./tsconfig.json",
           "./tsconfig.web.json",

--- a/src/main/access/customer-access-provider.test.ts
+++ b/src/main/access/customer-access-provider.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 const { openExternalMock } = vi.hoisted(() => ({
   openExternalMock: vi.fn(async () => undefined),
@@ -23,20 +23,19 @@ import { CustomerAccessProvider } from './customer-access-provider'
 import { MANAGED_KEY_CONFIG } from '../../shared/constants'
 import { DeviceIdentityUnavailableError, type DeviceIdentity } from '../settings/device-identity'
 
-type FetchCall = [unknown, RequestInit | undefined]
+type FetchCall = Parameters<typeof fetch>
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
-  return { ok, status, json: async () => body, text: async () => '' } as unknown as Response
+  return { ok, status, json: async () => body, text: async () => '' } as Response
 }
 
-function makeFetchMock(responses: Response[]): typeof fetch {
+function makeFetchMock(responses: Response[]): Mock<typeof fetch> {
   const queue = [...responses]
-  return vi.fn(async () => queue.shift() as Response) as unknown as typeof fetch
+  return vi.fn<typeof fetch>(async () => queue.shift() as Response)
 }
 
-function findCall(fetchMock: typeof fetch, urlPart: string): FetchCall {
-  const calls = (fetchMock as unknown as { mock: { calls: FetchCall[] } }).mock.calls
-  const call = calls.find((c) => String(c[0]).includes(urlPart))
+function findCall(fetchMock: Mock<typeof fetch>, urlPart: string): FetchCall {
+  const call = fetchMock.mock.calls.find((c) => String(c[0]).includes(urlPart))
   if (!call) throw new Error(`No fetch call to ${urlPart}`)
   return call
 }
@@ -50,7 +49,7 @@ describe('CustomerAccessProvider', () => {
   const originalFetch = globalThis.fetch
   const deviceIdentity = {
     getDeviceId: () => 'device-123',
-  } as unknown as DeviceIdentity
+  } as DeviceIdentity
 
   beforeEach(() => {
     vi.useFakeTimers()
@@ -199,13 +198,13 @@ describe('CustomerAccessProvider', () => {
   })
 
   it('surfaces a retry error and skips the backend when device identity is unavailable during checkout', async () => {
-    const fetchMock = vi.fn() as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>()
     globalThis.fetch = fetchMock
     const throwingIdentity = {
-      getDeviceId: () => {
+      getDeviceId: (): string => {
         throw new DeviceIdentityUnavailableError('secure storage unavailable')
       },
-    } as unknown as DeviceIdentity
+    } as DeviceIdentity
     const provider = new CustomerAccessProvider(throwingIdentity)
     const updates: Array<{ status: string | null }> = []
     provider.setUpdateCallback((state) => {
@@ -214,23 +213,23 @@ describe('CustomerAccessProvider', () => {
 
     await provider.startCheckout('explorer')
 
-    expect((fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(0)
+    expect(fetchMock.mock.calls).toHaveLength(0)
     expect(openExternalMock).not.toHaveBeenCalled()
     expect(updates.map((u) => u.status)).not.toContain('polling')
   })
 
   it('throws a clean retry error from the portal when device identity is unavailable', async () => {
-    const fetchMock = vi.fn() as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>()
     globalThis.fetch = fetchMock
     const throwingIdentity = {
-      getDeviceId: () => {
+      getDeviceId: (): string => {
         throw new DeviceIdentityUnavailableError('secure storage unavailable')
       },
-    } as unknown as DeviceIdentity
+    } as DeviceIdentity
     const provider = new CustomerAccessProvider(throwingIdentity)
 
     await expect(provider.openSubscriptionPortal()).rejects.toThrow(/temporarily unavailable/i)
-    expect((fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(0)
+    expect(fetchMock.mock.calls).toHaveLength(0)
     expect(openExternalMock).not.toHaveBeenCalled()
   })
 
@@ -280,9 +279,9 @@ describe('CustomerAccessProvider', () => {
     })
 
     it('keeps the managed key when fetch itself throws (network error)', async () => {
-      globalThis.fetch = vi.fn(async () => {
+      globalThis.fetch = vi.fn<typeof fetch>(async () => {
         throw new TypeError('network error')
-      }) as unknown as typeof fetch
+      })
       const provider = new CustomerAccessProvider(deviceIdentity)
       const payloads: unknown[] = []
       provider.setUpdateCallback((_, payload) => payloads.push(payload))
@@ -293,13 +292,13 @@ describe('CustomerAccessProvider', () => {
     })
 
     it('keeps the managed key and skips the backend when device identity is unavailable', async () => {
-      const fetchMock = vi.fn() as unknown as typeof fetch
+      const fetchMock = vi.fn<typeof fetch>()
       globalThis.fetch = fetchMock
       const throwingIdentity = {
-        getDeviceId: () => {
+        getDeviceId: (): string => {
           throw new DeviceIdentityUnavailableError('secure storage unavailable')
         },
-      } as unknown as DeviceIdentity
+      } as DeviceIdentity
       const provider = new CustomerAccessProvider(throwingIdentity)
       const payloads: unknown[] = []
       provider.setUpdateCallback((_, payload) => payloads.push(payload))
@@ -307,7 +306,7 @@ describe('CustomerAccessProvider', () => {
       await provider.refreshAccessState()
 
       expect(payloads).toEqual([])
-      expect((fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(0)
+      expect(fetchMock.mock.calls).toHaveLength(0)
     })
 
     it('invalidates the managed key on an authoritative 200 {key: null}', async () => {
@@ -344,16 +343,14 @@ describe('CustomerAccessProvider', () => {
       await provider.startCheckout('explorer')
 
       const payloads: unknown[] = []
-      const callsBefore = (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls.length
+      const callsBefore = fetchMock.mock.calls.length
       provider.setUpdateCallback((_, payload) => payloads.push(payload))
 
       await provider.refreshAccessState()
 
       expect(payloads).toEqual([])
       // No new fetch fired — refresh short-circuited on the polling guard.
-      expect((fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(
-        callsBefore,
-      )
+      expect(fetchMock.mock.calls.length).toBe(callsBefore)
     })
   })
 })

--- a/src/main/access/customer-access-provider.test.ts
+++ b/src/main/access/customer-access-provider.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 const { openExternalMock } = vi.hoisted(() => ({
-  openExternalMock: vi.fn(async () => undefined),
+  openExternalMock: vi.fn<(url: string) => Promise<void>>(async () => undefined),
 }))
 
 vi.mock('electron', () => ({
@@ -22,12 +22,9 @@ vi.mock('@main/utils/logger', () => ({
 import { CustomerAccessProvider } from './customer-access-provider'
 import { MANAGED_KEY_CONFIG } from '../../shared/constants'
 import { DeviceIdentityUnavailableError, type DeviceIdentity } from '../settings/device-identity'
+import { jsonResponse } from '@main/utils/test-utils'
 
 type FetchCall = Parameters<typeof fetch>
-
-function jsonResponse(body: unknown, ok = true, status = 200): Response {
-  return { ok, status, json: async () => body, text: async () => '' } as Response
-}
 
 function makeFetchMock(responses: Response[]): Mock<typeof fetch> {
   const queue = [...responses]
@@ -119,7 +116,7 @@ describe('CustomerAccessProvider', () => {
     expect(JSON.parse(String(linkCall[1]?.body))).toEqual({ plan: 'explorer' })
 
     expect(openExternalMock).toHaveBeenCalledWith(signedUrl)
-    const openedUrl = openExternalMock.mock.calls[0]?.[0] as string
+    const openedUrl = openExternalMock.mock.calls[0]?.[0]
     expect(openedUrl).not.toContain('device_id=')
   })
 
@@ -152,7 +149,7 @@ describe('CustomerAccessProvider', () => {
     expect(String(linkCall[0])).not.toContain('device_id=')
 
     expect(openExternalMock).toHaveBeenCalledWith(signedUrl)
-    const openedUrl = openExternalMock.mock.calls[0]?.[0] as string
+    const openedUrl = openExternalMock.mock.calls[0]?.[0]
     expect(openedUrl).not.toContain('device_id=')
   })
 

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -97,13 +97,13 @@ describe('EnterpriseAccessProvider', () => {
   })
 
   it('maps transport failures during activation to a friendly message and fails the activation', async () => {
-    globalThis.fetch = vi.fn(async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(async () => {
       throw new TypeError('fetch failed', {
         cause: Object.assign(new Error('getaddrinfo ENOTFOUND backend.example'), {
           code: 'ENOTFOUND',
         }),
       })
-    }) as typeof fetch
+    })
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; error: string | null }> = []
@@ -120,11 +120,9 @@ describe('EnterpriseAccessProvider', () => {
   })
 
   it('keeps the backend error message when the activation code is rejected', async () => {
-    globalThis.fetch = vi.fn(async () => ({
-      ok: false,
-      status: 403,
-      json: async () => ({ error: 'Invalid activation code' }),
-    })) as unknown as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () =>
+      jsonResponse({ error: 'Invalid activation code' }, false, 403),
+    )
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; error: string | null }> = []
@@ -139,13 +137,13 @@ describe('EnterpriseAccessProvider', () => {
   })
 
   it('maps transport failures during refresh to a friendly message', async () => {
-    globalThis.fetch = vi.fn(async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(async () => {
       throw new TypeError('fetch failed', {
         cause: Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
           code: 'ECONNREFUSED',
         }),
       })
-    }) as typeof fetch
+    })
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; error: string | null }> = []
@@ -161,13 +159,9 @@ describe('EnterpriseAccessProvider', () => {
   it('keeps an activated device activated when a refresh hits a transport failure', async () => {
     const responses: Array<() => Response> = [
       // GET /license/status -> activated
-      () => ({ ok: true, json: async () => ({ activated: true }) }) as unknown as Response,
+      () => jsonResponse({ activated: true }),
       // GET /license/inference-config -> managed key
-      () =>
-        ({
-          ok: true,
-          json: async () => ({ provider: 'openrouter', apiKey: 'key-123' }),
-        }) as unknown as Response,
+      () => jsonResponse({ provider: 'openrouter', apiKey: 'key-123' }),
       // next refresh: offline
       () => {
         throw new TypeError('fetch failed', {
@@ -177,7 +171,7 @@ describe('EnterpriseAccessProvider', () => {
         })
       },
     ]
-    globalThis.fetch = vi.fn(async () => (responses.shift() as () => Response)()) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => (responses.shift() as () => Response)())
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; error: string | null }> = []
@@ -321,11 +315,7 @@ describe('EnterpriseAccessProvider', () => {
   it('fails the activation with a friendly message when the external-consent bind hits a transport failure', async () => {
     const responses: Array<() => Response> = [
       // GET /license/consent-document -> already_approved sentinel
-      () =>
-        ({
-          ok: true,
-          json: async () => ({ state: 'already_approved' }),
-        }) as unknown as Response,
+      () => jsonResponse({ state: 'already_approved' }),
       // POST /license/activate -> network failure
       () => {
         throw new TypeError('fetch failed', {
@@ -335,7 +325,7 @@ describe('EnterpriseAccessProvider', () => {
         })
       },
     ]
-    globalThis.fetch = vi.fn(async () => (responses.shift() as () => Response)()) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => (responses.shift() as () => Response)())
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; error: string | null }> = []

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -13,6 +13,7 @@ vi.mock('@main/utils/logger', () => ({
 import { EnterpriseAccessProvider } from './enterprise-access-provider'
 import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
 import { DeviceIdentityUnavailableError, type DeviceIdentity } from '../settings/device-identity'
+import { jsonResponse } from '@main/utils/test-utils'
 
 const TENANT_TOKEN = 'tt_GigKRAyNbQ1U8jBSEKTq7uiiufT392Si'
 const EMAIL = 'alice@corp.com'
@@ -29,10 +30,6 @@ const ACTIVATION_CODE = `${TENANT_TOKEN}.${urlsafeBase64(EMAIL)}`
 
 const DEFAULT_DOC_BYTES = Buffer.from('%PDF-1.4 fake consent doc')
 const DEFAULT_DOC_SHA = createHash('sha256').update(DEFAULT_DOC_BYTES).digest('hex')
-
-function jsonResponse(body: unknown, ok = true, status = 200): Response {
-  return { ok, status, json: async () => body } as Response
-}
 
 function descriptorResponse(
   overrides: {

--- a/src/main/access/enterprise-access-provider.test.ts
+++ b/src/main/access/enterprise-access-provider.test.ts
@@ -30,6 +30,10 @@ const ACTIVATION_CODE = `${TENANT_TOKEN}.${urlsafeBase64(EMAIL)}`
 const DEFAULT_DOC_BYTES = Buffer.from('%PDF-1.4 fake consent doc')
 const DEFAULT_DOC_SHA = createHash('sha256').update(DEFAULT_DOC_BYTES).digest('hex')
 
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return { ok, status, json: async () => body } as Response
+}
+
 function descriptorResponse(
   overrides: {
     sha256?: string
@@ -48,7 +52,7 @@ function descriptorResponse(
       title: overrides.title ?? 'Employee data consent',
       content_type: overrides.contentType ?? 'application/pdf',
     }),
-  } as unknown as Response
+  } as Response
 }
 
 function pdfResponse(bytes: Buffer = DEFAULT_DOC_BYTES): Response {
@@ -56,14 +60,14 @@ function pdfResponse(bytes: Buffer = DEFAULT_DOC_BYTES): Response {
     ok: true,
     arrayBuffer: async () =>
       bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
-  } as unknown as Response
+  } as Response
 }
 
 describe('EnterpriseAccessProvider', () => {
   const originalFetch = globalThis.fetch
   const deviceIdentity = {
     getDeviceId: () => 'device-123',
-  } as unknown as DeviceIdentity
+  } as DeviceIdentity
 
   beforeEach(() => {
     vi.useFakeTimers()
@@ -76,7 +80,7 @@ describe('EnterpriseAccessProvider', () => {
 
   it('parks in awaiting_consent after fetching descriptor and verifying the PDF', async () => {
     const responses = [descriptorResponse(), pdfResponse()]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null }> = []
@@ -191,7 +195,7 @@ describe('EnterpriseAccessProvider', () => {
   })
 
   it('rejects malformed activation codes without making any network calls', async () => {
-    const fetchMock = vi.fn() as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>()
     globalThis.fetch = fetchMock
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
@@ -203,14 +207,14 @@ describe('EnterpriseAccessProvider', () => {
     await expect(provider.activateEnterpriseLicense('not-a-code')).rejects.toThrow(
       /must start with `tt_`/,
     )
-    expect((fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(0)
+    expect(fetchMock.mock.calls).toHaveLength(0)
     expect(updates.at(-1)?.status).toBe('error')
   })
 
   it('rejects descriptors with disallowed content types', async () => {
-    globalThis.fetch = vi.fn(async () =>
+    globalThis.fetch = vi.fn<typeof fetch>(async () =>
       descriptorResponse({ contentType: 'text/html' }),
-    ) as unknown as typeof fetch
+    )
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null }> = []
@@ -224,7 +228,7 @@ describe('EnterpriseAccessProvider', () => {
 
   it('rejects descriptors whose url points off the configured backend origin', async () => {
     const responses = [descriptorResponse({ url: 'https://attacker.example/leak' })]
-    const fetchMock = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => responses.shift() as Response)
     globalThis.fetch = fetchMock
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
@@ -237,7 +241,7 @@ describe('EnterpriseAccessProvider', () => {
       /backend origin/i,
     )
     // Descriptor was fetched, but the off-origin document fetch must not have happened.
-    const calls = (fetchMock as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    const calls = fetchMock.mock.calls
     expect(calls).toHaveLength(1)
     expect(String(calls[0][0])).toContain('/license/consent-document')
     expect(updates.at(-1)?.status).toBe('error')
@@ -248,7 +252,7 @@ describe('EnterpriseAccessProvider', () => {
       descriptorResponse({ sha256: 'a'.repeat(64) }),
       pdfResponse(Buffer.from([1, 2, 3, 4])),
     ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null }> = []
@@ -266,30 +270,24 @@ describe('EnterpriseAccessProvider', () => {
     const fetchCalls: Array<{ url: string; init?: RequestInit }> = []
     const responses = [
       // GET /license/consent-document -> already_approved sentinel
-      {
-        ok: true,
-        json: async () => ({ state: 'already_approved', version: 0 }),
-      } as unknown as Response,
+      jsonResponse({ state: 'already_approved', version: 0 }),
       // POST /license/activate (outcome=accepted, no document_version)
-      { ok: true, json: async () => ({ ok: true }) } as unknown as Response,
+      jsonResponse({ ok: true }),
       // GET /license/status (poll #1: activated)
-      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
+      jsonResponse({ activated: true }),
       // GET /license/inference-config
-      {
-        ok: true,
-        json: async () => ({
-          provider: 'openrouter',
-          apiKey: 'sk-or-enterprise',
-          project: null,
-          location: null,
-          expiresAt: null,
-        }),
-      } as unknown as Response,
+      jsonResponse({
+        provider: 'openrouter',
+        apiKey: 'sk-or-enterprise',
+        project: null,
+        location: null,
+        expiresAt: null,
+      }),
     ]
-    globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    globalThis.fetch = vi.fn<typeof fetch>(async (input, init) => {
       fetchCalls.push({ url: String(input), init })
       return responses.shift() as Response
-    }) as typeof fetch
+    })
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; payload?: unknown }> = []
@@ -356,30 +354,20 @@ describe('EnterpriseAccessProvider', () => {
   it('treats 502 on external-consent bind as provisional success and starts polling', async () => {
     const responses = [
       // GET /license/consent-document -> already_approved sentinel
-      {
-        ok: true,
-        json: async () => ({ state: 'already_approved' }),
-      } as unknown as Response,
+      jsonResponse({ state: 'already_approved' }),
       // POST /license/activate fails with 502
-      {
-        ok: false,
-        status: 502,
-        json: async () => ({ error: 'upstream' }),
-      } as unknown as Response,
+      jsonResponse({ error: 'upstream' }, false, 502),
       // poll resolves anyway
-      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
-      {
-        ok: true,
-        json: async () => ({
-          provider: 'openrouter',
-          apiKey: 'sk-or-enterprise',
-          project: null,
-          location: null,
-          expiresAt: null,
-        }),
-      } as unknown as Response,
+      jsonResponse({ activated: true }),
+      jsonResponse({
+        provider: 'openrouter',
+        apiKey: 'sk-or-enterprise',
+        project: null,
+        location: null,
+        expiresAt: null,
+      }),
     ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null }> = []
@@ -395,10 +383,7 @@ describe('EnterpriseAccessProvider', () => {
   })
 
   it('rejects descriptors with an unknown state value as malformed', async () => {
-    globalThis.fetch = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ state: 'pending_review' }),
-    })) as unknown as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => jsonResponse({ state: 'pending_review' }))
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; error: string | null }> = []
@@ -415,22 +400,19 @@ describe('EnterpriseAccessProvider', () => {
       descriptorResponse(),
       pdfResponse(),
       // POST /license/activate
-      { ok: true, json: async () => ({ ok: true }) } as unknown as Response,
+      jsonResponse({ ok: true }),
       // GET /license/status (poll #1: activated)
-      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
+      jsonResponse({ activated: true }),
       // GET /license/inference-config
-      {
-        ok: true,
-        json: async () => ({
-          provider: 'openrouter',
-          apiKey: 'sk-or-enterprise',
-          project: null,
-          location: null,
-          expiresAt: null,
-        }),
-      } as unknown as Response,
+      jsonResponse({
+        provider: 'openrouter',
+        apiKey: 'sk-or-enterprise',
+        project: null,
+        location: null,
+        expiresAt: null,
+      }),
     ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; payload?: unknown }> = []
@@ -452,13 +434,13 @@ describe('EnterpriseAccessProvider', () => {
 
   it('keeps the consent prompt open and throws a retry error when identity is unavailable at consent submit', async () => {
     const responses = [descriptorResponse(), pdfResponse()]
-    const fetchMock = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => responses.shift() as Response)
     globalThis.fetch = fetchMock
     const throwingIdentity = {
-      getDeviceId: () => {
+      getDeviceId: (): string => {
         throw new DeviceIdentityUnavailableError('secure storage unavailable')
       },
-    } as unknown as DeviceIdentity
+    } as DeviceIdentity
 
     const provider = new EnterpriseAccessProvider(throwingIdentity)
     const updates: Array<{ status: string | null }> = []
@@ -468,8 +450,7 @@ describe('EnterpriseAccessProvider', () => {
 
     await provider.activateEnterpriseLicense(ACTIVATION_CODE)
     expect(updates.at(-1)?.status).toBe('awaiting_consent')
-    const fetchCountAfterActivate = (fetchMock as unknown as { mock: { calls: unknown[] } }).mock
-      .calls.length
+    const fetchCountAfterActivate = fetchMock.mock.calls.length
 
     await expect(provider.submitConsentDecision('accepted')).rejects.toThrow(
       /temporarily unavailable/i,
@@ -477,9 +458,7 @@ describe('EnterpriseAccessProvider', () => {
 
     // No activate POST was attempted, the prompt stays open, and we did not
     // fall into the error state — the user can simply retry.
-    expect((fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(
-      fetchCountAfterActivate,
-    )
+    expect(fetchMock.mock.calls.length).toBe(fetchCountAfterActivate)
     expect(updates.at(-1)?.status).toBe('awaiting_consent')
     expect(await provider.getPendingConsent()).not.toBeNull()
   })
@@ -489,32 +468,26 @@ describe('EnterpriseAccessProvider', () => {
     const responses = [
       descriptorResponse(),
       pdfResponse(),
-      { ok: true, json: async () => ({ ok: true }) } as unknown as Response,
-      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
-      {
-        ok: true,
-        json: async () => ({
-          provider: 'vertex',
-          apiKey: 'ya29.fake-token',
-          project: 'demo-project-42',
-          location: 'us-central1',
-          expiresAt: expiresAtSec,
-        }),
-      } as unknown as Response,
+      jsonResponse({ ok: true }),
+      jsonResponse({ activated: true }),
+      jsonResponse({
+        provider: 'vertex',
+        apiKey: 'ya29.fake-token',
+        project: 'demo-project-42',
+        location: 'us-central1',
+        expiresAt: expiresAtSec,
+      }),
       // Refetch ~60s before expiresAt — second inference-config call.
-      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
-      {
-        ok: true,
-        json: async () => ({
-          provider: 'vertex',
-          apiKey: 'ya29.refreshed-token',
-          project: 'demo-project-42',
-          location: 'us-central1',
-          expiresAt: expiresAtSec + 3600,
-        }),
-      } as unknown as Response,
+      jsonResponse({ activated: true }),
+      jsonResponse({
+        provider: 'vertex',
+        apiKey: 'ya29.refreshed-token',
+        project: 'demo-project-42',
+        location: 'us-central1',
+        expiresAt: expiresAtSec + 3600,
+      }),
     ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; payload?: unknown }> = []
@@ -550,27 +523,24 @@ describe('EnterpriseAccessProvider', () => {
     const responses = [
       descriptorResponse({ version: 7 }),
       pdfResponse(),
-      { ok: true, json: async () => ({ ok: true }) } as unknown as Response,
-      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
-      {
-        ok: true,
-        json: async () => ({
-          provider: 'openrouter',
-          apiKey: 'sk-or-enterprise',
-          project: null,
-          location: null,
-          expiresAt: null,
-        }),
-      } as unknown as Response,
+      jsonResponse({ ok: true }),
+      jsonResponse({ activated: true }),
+      jsonResponse({
+        provider: 'openrouter',
+        apiKey: 'sk-or-enterprise',
+        project: null,
+        location: null,
+        expiresAt: null,
+      }),
     ]
-    const fetchMock = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => responses.shift() as Response)
     globalThis.fetch = fetchMock
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     await provider.activateEnterpriseLicense(ACTIVATION_CODE)
     await provider.submitConsentDecision('accepted')
 
-    const calls = (fetchMock as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    const calls = fetchMock.mock.calls
     const activateCall = calls.find((c) => String(c[0]).includes('/license/activate'))
     expect(activateCall).toBeDefined()
     const init = activateCall![1] as RequestInit
@@ -589,20 +559,17 @@ describe('EnterpriseAccessProvider', () => {
     const responses = [
       descriptorResponse(),
       pdfResponse(),
-      { ok: true, json: async () => ({ ok: true }) } as unknown as Response,
-      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
-      {
-        ok: true,
-        json: async () => ({
-          provider: 'openrouter',
-          apiKey: 'sk-or-enterprise',
-          project: null,
-          location: null,
-          expiresAt: null,
-        }),
-      } as unknown as Response,
+      jsonResponse({ ok: true }),
+      jsonResponse({ activated: true }),
+      jsonResponse({
+        provider: 'openrouter',
+        apiKey: 'sk-or-enterprise',
+        project: null,
+        location: null,
+        expiresAt: null,
+      }),
     ]
-    const fetchMock = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => responses.shift() as Response)
     globalThis.fetch = fetchMock
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
@@ -610,9 +577,7 @@ describe('EnterpriseAccessProvider', () => {
     await provider.submitConsentDecision('accepted')
     await vi.advanceTimersByTimeAsync(ENTERPRISE_BACKEND_CONFIG.POLL_INTERVAL_MS)
 
-    const calls = (
-      fetchMock as unknown as { mock: { calls: [unknown, RequestInit | undefined][] } }
-    ).mock.calls
+    const calls = fetchMock.mock.calls
 
     const descriptorCall = calls.find((c) => String(c[0]).includes('/license/consent-document'))!
     expect(String(descriptorCall[0])).not.toContain('tenant_token=')
@@ -634,12 +599,8 @@ describe('EnterpriseAccessProvider', () => {
   })
 
   it('returns to inactive when consent is declined', async () => {
-    const responses = [
-      descriptorResponse(),
-      pdfResponse(),
-      { ok: true, json: async () => ({ declined: true }) } as unknown as Response,
-    ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    const responses = [descriptorResponse(), pdfResponse(), jsonResponse({ declined: true })]
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null }> = []
@@ -658,25 +619,18 @@ describe('EnterpriseAccessProvider', () => {
       descriptorResponse(),
       pdfResponse(),
       // POST /license/activate fails with 502
-      {
-        ok: false,
-        status: 502,
-        json: async () => ({ error: 'upstream' }),
-      } as unknown as Response,
+      jsonResponse({ error: 'upstream' }, false, 502),
       // poll resolves anyway
-      { ok: true, json: async () => ({ activated: true }) } as unknown as Response,
-      {
-        ok: true,
-        json: async () => ({
-          provider: 'openrouter',
-          apiKey: 'sk-or-enterprise',
-          project: null,
-          location: null,
-          expiresAt: null,
-        }),
-      } as unknown as Response,
+      jsonResponse({ activated: true }),
+      jsonResponse({
+        provider: 'openrouter',
+        apiKey: 'sk-or-enterprise',
+        project: null,
+        location: null,
+        expiresAt: null,
+      }),
     ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null }> = []
@@ -695,13 +649,9 @@ describe('EnterpriseAccessProvider', () => {
     const responses = [
       descriptorResponse(),
       pdfResponse(),
-      {
-        ok: false,
-        status: 502,
-        json: async () => ({ error: 'Upstream failed' }),
-      } as unknown as Response,
+      jsonResponse({ error: 'Upstream failed' }, false, 502),
     ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null }> = []
@@ -716,23 +666,21 @@ describe('EnterpriseAccessProvider', () => {
 
   it('skips refresh while awaiting_consent', async () => {
     const responses = [descriptorResponse(), pdfResponse()]
-    const fetchMock = vi.fn(
-      async () => (responses.shift() ?? descriptorResponse()) as Response,
-    ) as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => responses.shift() ?? descriptorResponse())
     globalThis.fetch = fetchMock
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     await provider.activateEnterpriseLicense(ACTIVATION_CODE)
 
-    const before = (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls.length
+    const before = fetchMock.mock.calls.length
     await provider.refreshAccessState()
-    const after = (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls.length
+    const after = fetchMock.mock.calls.length
     expect(after).toBe(before)
   })
 
   it('times out the consent decision and surfaces an error', async () => {
     const responses = [descriptorResponse(), pdfResponse()]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; error: string | null }> = []
@@ -753,11 +701,9 @@ describe('EnterpriseAccessProvider', () => {
   })
 
   it('treats 401 on /status as inactive (unknown device pre-activation)', async () => {
-    globalThis.fetch = vi.fn(async () => ({
-      ok: false,
-      status: 401,
-      json: async () => ({ error: 'unauthorized' }),
-    })) as unknown as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () =>
+      jsonResponse({ error: 'unauthorized' }, false, 401),
+    )
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; error: string | null }> = []
@@ -772,10 +718,7 @@ describe('EnterpriseAccessProvider', () => {
   })
 
   it('publishes invalidation on refresh when license status is inactive', async () => {
-    globalThis.fetch = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ activated: false }),
-    })) as unknown as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => jsonResponse({ activated: false }))
 
     const provider = new EnterpriseAccessProvider(deviceIdentity)
     const updates: Array<{ status: string | null; payload?: unknown }> = []

--- a/src/main/activity/sqlite-activity-sink.test.ts
+++ b/src/main/activity/sqlite-activity-sink.test.ts
@@ -46,10 +46,14 @@ function makeExtracted(activityId: string): ExtractedActivity {
   }
 }
 
+function makeRepo(add: ActivityRepository['add']): ActivityRepository {
+  return { add } as ActivityRepository
+}
+
 describe('SqliteActivitySink', () => {
   it('persists mapped extracted activity', async () => {
     const add = vi.fn()
-    const repo = { add } as unknown as ActivityRepository
+    const repo = makeRepo(add)
     const sink = new SqliteActivitySink(repo)
     const activity = makeActivity('activity-1')
     const extracted = makeExtracted('activity-1')
@@ -73,7 +77,7 @@ describe('SqliteActivitySink', () => {
 
   it('throws on activityId mismatch', async () => {
     const add = vi.fn()
-    const repo = { add } as unknown as ActivityRepository
+    const repo = makeRepo(add)
     const sink = new SqliteActivitySink(repo)
     const activity = makeActivity('activity-1')
     const extracted = makeExtracted('activity-2')
@@ -86,7 +90,7 @@ describe('SqliteActivitySink', () => {
     const add = vi.fn().mockImplementation(() => {
       throw new Error('UNIQUE constraint failed: activities.id')
     })
-    const repo = { add } as unknown as ActivityRepository
+    const repo = makeRepo(add)
     const sink = new SqliteActivitySink(repo)
     const activity = makeActivity('activity-1')
     const extracted = makeExtracted('activity-1')
@@ -100,7 +104,7 @@ describe('SqliteActivitySink', () => {
     const add = vi.fn().mockImplementation(() => {
       throw storageError
     })
-    const repo = { add } as unknown as ActivityRepository
+    const repo = makeRepo(add)
     const sink = new SqliteActivitySink(repo)
     const activity = makeActivity('activity-1')
     const extracted = makeExtracted('activity-1')

--- a/src/main/apps/installed-apps.test.ts
+++ b/src/main/apps/installed-apps.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Dirent } from 'fs'
 
-vi.mock('fs/promises', () => ({ readdir: vi.fn() }))
+const { readdirMock } = vi.hoisted(() => ({
+  readdirMock: vi.fn<(dir: string) => Promise<Dirent[]>>(),
+}))
+
+vi.mock('fs/promises', () => ({ readdir: readdirMock }))
 vi.mock('child_process', () => ({ execFile: vi.fn() }))
 vi.mock('@main/utils/logger', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -17,32 +21,31 @@ function dirent(name: string, isDir: boolean): Dirent {
     isSymbolicLink: () => false,
     isFIFO: () => false,
     isSocket: () => false,
-  } as unknown as Dirent
+  } as Dirent
 }
 
-async function setupReaddir(tree: Record<string, Array<[string, boolean]>>): Promise<void> {
-  const fsp = await import('fs/promises')
-  vi.mocked(fsp.readdir).mockImplementation((async (dir: string) => {
+function setupReaddir(tree: Record<string, Array<[string, boolean]>>): void {
+  readdirMock.mockImplementation(async (dir) => {
     const entries = tree[dir.replace(/\\/g, '/')]
     if (!entries) return []
     return entries.map(([n, d]) => dirent(n, d))
-  }) as unknown as typeof fsp.readdir)
+  })
 }
 
 async function setupPowershellOutput(lines: string[]): Promise<void> {
   const cp = await import('child_process')
-  vi.mocked(cp.execFile).mockImplementation(((...args: unknown[]) => {
+  vi.mocked(cp.execFile).mockImplementation((...args: unknown[]) => {
     const cb = args[args.length - 1]
     if (typeof cb === 'function') {
       ;(cb as (e: Error | null, out: string, err: string) => void)(null, lines.join('\n'), '')
     }
     return {} as ReturnType<typeof cp.execFile>
-  }) as unknown as typeof cp.execFile)
+  })
 }
 
 async function setupPowershellFailure(): Promise<void> {
   const cp = await import('child_process')
-  vi.mocked(cp.execFile).mockImplementation(((...args: unknown[]) => {
+  vi.mocked(cp.execFile).mockImplementation((...args: unknown[]) => {
     const cb = args[args.length - 1]
     if (typeof cb === 'function') {
       ;(cb as (e: Error | null, out: string, err: string) => void)(
@@ -52,7 +55,7 @@ async function setupPowershellFailure(): Promise<void> {
       )
     }
     return {} as ReturnType<typeof cp.execFile>
-  }) as unknown as typeof cp.execFile)
+  })
 }
 
 describe('listInstalledApps (windows)', () => {
@@ -72,7 +75,7 @@ describe('listInstalledApps (windows)', () => {
   it('keeps only shortcuts whose target is an .exe and uses the exe stem as matchToken', async () => {
     const programsA = 'C:/ProgramData/Microsoft/Windows/Start Menu/Programs'
     const programsB = 'C:/AppData/Microsoft/Windows/Start Menu/Programs'
-    await setupReaddir({
+    setupReaddir({
       [programsA]: [
         ['Google Chrome.lnk', false],
         ['Event Viewer.lnk', false],
@@ -103,7 +106,7 @@ describe('listInstalledApps (windows)', () => {
 
   it('returns empty list when powershell resolver fails', async () => {
     const programs = 'C:/ProgramData/Microsoft/Windows/Start Menu/Programs'
-    await setupReaddir({
+    setupReaddir({
       [programs]: [['Google Chrome.lnk', false]],
       'C:/AppData/Microsoft/Windows/Start Menu/Programs': [],
     })
@@ -116,7 +119,7 @@ describe('listInstalledApps (windows)', () => {
 
   it('dedupes multiple shortcuts pointing to the same exe', async () => {
     const programs = 'C:/ProgramData/Microsoft/Windows/Start Menu/Programs'
-    await setupReaddir({
+    setupReaddir({
       [programs]: [
         ['Python 3.14 (64-bit).lnk', false],
         ['Python 3.14.lnk', false],

--- a/src/main/eval/eval-recorder.test.ts
+++ b/src/main/eval/eval-recorder.test.ts
@@ -31,10 +31,10 @@ let frameStream: InMemoryStream<Frame>
 let eventStream: InMemoryStream<EventWindow>
 let harness: PipelineHarness
 let capture: RuntimeCaptureController
-let setRetain: ReturnType<typeof vi.fn>
-let sweepNow: ReturnType<typeof vi.fn>
-let startCapture: ReturnType<typeof vi.fn>
-let stopCapture: ReturnType<typeof vi.fn>
+let setRetain: (value: boolean) => void
+let sweepNow: () => void
+let startCapture: () => void
+let stopCapture: () => void
 let capturing: boolean
 
 beforeEach(() => {
@@ -52,21 +52,25 @@ beforeEach(() => {
   })
   capturing = false
 
+  const flush: () => void = vi.fn()
+  const drainActivities: () => Promise<void> = vi.fn().mockResolvedValue(undefined)
+  const waitForIdle: () => Promise<void> = vi.fn().mockResolvedValue(undefined)
+
   harness = {
     frameStream,
     eventStream,
-    eventCapturer: { flush: vi.fn() },
-    drainActivities: vi.fn().mockResolvedValue(undefined),
+    eventCapturer: { flush },
+    drainActivities,
     setRetainScreenshots: setRetain,
     sweepNow,
-  } as unknown as PipelineHarness
+  } as PipelineHarness
 
   capture = {
     isCapturingNow: () => capturing,
     startCapture,
     stopCapture,
-    waitForIdle: vi.fn().mockResolvedValue(undefined),
-  } as unknown as RuntimeCaptureController
+    waitForIdle,
+  } as RuntimeCaptureController
 })
 
 afterEach(() => {

--- a/src/main/processor/ocr-windows-native.test.ts
+++ b/src/main/processor/ocr-windows-native.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
 import { extractTextWindowsNative, probeWindowsNativeOcrReadiness } from './ocr-windows-native'
 
@@ -10,7 +11,7 @@ vi.mock('child_process', () => ({
   spawn: vi.fn(),
 }))
 
-interface MockChildProcess extends EventEmitter {
+type MockChildProcess = ChildProcess & {
   readonly stdout: EventEmitter
   readonly stderr: EventEmitter
   readonly kill: ReturnType<typeof vi.fn>
@@ -41,9 +42,7 @@ describe('extractTextWindowsNative', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = extractTextWindowsNative('C:\\tmp\\shot.png')
 
@@ -59,9 +58,7 @@ describe('extractTextWindowsNative', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = extractTextWindowsNative('C:\\tmp\\shot.png')
 
@@ -77,9 +74,7 @@ describe('extractTextWindowsNative', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = extractTextWindowsNative('C:\\tmp\\shot.png')
 
@@ -96,9 +91,7 @@ describe('extractTextWindowsNative', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = extractTextWindowsNative('C:\\tmp\\shot.png')
 
@@ -115,9 +108,7 @@ describe('extractTextWindowsNative', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = extractTextWindowsNative('C:\\tmp\\shot.png')
 
@@ -140,9 +131,7 @@ describe('extractTextWindowsNative', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = extractTextWindowsNative('C:\\tmp\\shot.png')
 
@@ -166,9 +155,7 @@ describe('extractTextWindowsNative', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = extractTextWindowsNative('C:\\tmp\\shot.png')
 
@@ -195,9 +182,7 @@ describe('extractTextWindowsNative', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = extractTextWindowsNative('C:\\tmp\\shot.png')
     const expectation = expect(promise).rejects.toThrow('[OCR:windows:timeout]')
@@ -220,9 +205,7 @@ describe('probeWindowsNativeOcrReadiness', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = probeWindowsNativeOcrReadiness()
 
@@ -255,9 +238,7 @@ describe('probeWindowsNativeOcrReadiness', () => {
 
     const mockChild = createMockChildProcess()
     vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const promise = probeWindowsNativeOcrReadiness()
 

--- a/src/main/recorder/app-watcher-win.test.ts
+++ b/src/main/recorder/app-watcher-win.test.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
 import { PassThrough } from 'stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -20,7 +21,7 @@ vi.mock('@main/utils/logger', () => ({
   default: mockLogger,
 }))
 
-interface MockChildProcess extends EventEmitter {
+type MockChildProcess = ChildProcess & {
   stdout: PassThrough
   stderr: PassThrough
   pid: number
@@ -65,9 +66,7 @@ describe('app-watcher-win backend', () => {
 
     vi.mocked(fs.existsSync).mockReturnValue(true)
     const child = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      child as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(child)
 
     const mod = await import('./app-watcher-win')
     const callback = vi.fn()
@@ -97,9 +96,7 @@ describe('app-watcher-win backend', () => {
 
     vi.mocked(fs.existsSync).mockReturnValue(true)
     const child = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      child as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(child)
 
     const mod = await import('./app-watcher-win')
     const callback = vi.fn()
@@ -121,9 +118,7 @@ describe('app-watcher-win backend', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true)
     const firstChild = createMockChildProcess(111)
     const secondChild = createMockChildProcess(222)
-    vi.mocked(childProcess.spawn)
-      .mockReturnValueOnce(firstChild as unknown as ReturnType<typeof childProcess.spawn>)
-      .mockReturnValueOnce(secondChild as unknown as ReturnType<typeof childProcess.spawn>)
+    vi.mocked(childProcess.spawn).mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild)
 
     const mod = await import('./app-watcher-win')
     mod.startAppWatcherWin(vi.fn())
@@ -141,9 +136,7 @@ describe('app-watcher-win backend', () => {
 
     vi.mocked(fs.existsSync).mockReturnValue(true)
     const child = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      child as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(child)
 
     const mod = await import('./app-watcher-win')
     mod.startAppWatcherWin(() => {

--- a/src/main/recorder/native-screenshot.test.ts
+++ b/src/main/recorder/native-screenshot.test.ts
@@ -103,9 +103,7 @@ describe('ScreenshotDaemon', () => {
     const { ScreenshotDaemon } = await import('./native-screenshot')
 
     const child = createMockChildProcess(303)
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      child as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(child)
 
     const daemon = new ScreenshotDaemon({
       getExecutable: () => ({ command: '/tmp/screenshot', args: [] }),

--- a/src/main/recorder/native-screenshot.test.ts
+++ b/src/main/recorder/native-screenshot.test.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
 import { PassThrough } from 'stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -21,7 +22,7 @@ vi.mock('@main/utils/logger', () => ({
   default: mockLogger,
 }))
 
-interface MockChildProcess extends EventEmitter {
+type MockChildProcess = ChildProcess & {
   stdin: PassThrough
   stdout: PassThrough
   stderr: PassThrough
@@ -74,9 +75,7 @@ describe('ScreenshotDaemon', () => {
 
     const firstChild = createMockChildProcess(101)
     const secondChild = createMockChildProcess(202)
-    vi.mocked(childProcess.spawn)
-      .mockReturnValueOnce(firstChild as unknown as ReturnType<typeof childProcess.spawn>)
-      .mockReturnValueOnce(secondChild as unknown as ReturnType<typeof childProcess.spawn>)
+    vi.mocked(childProcess.spawn).mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild)
 
     const daemon = new ScreenshotDaemon({
       getExecutable: () => ({ command: '/tmp/screenshot', args: [] }),

--- a/src/main/semantic/activity-semantic-service.integration.test.ts
+++ b/src/main/semantic/activity-semantic-service.integration.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import type { Activity, ActivityFrame } from '@main/activity/activity-types'
 import { ActivitySemanticService, SemanticFileDebugDumper } from './activity-semantic-service'
 import { InferenceProviderImpl } from '@main/llm/index'
+import type { VendorCredentialsManager } from '@main/settings/vendor-credentials-manager'
 import { FfmpegVideoStitcher } from '@main/video/video-stitcher'
 import { VENDOR_PRESETS } from '@/shared/vendor-defaults'
 
@@ -133,10 +134,10 @@ describeIntegration('semantic service integration', () => {
       copyMediaAssets: true,
     })
     const apiKey = process.env.OPENROUTER_API_KEY ?? ''
+    const getCredentials: VendorCredentialsManager['getCredentials'] = () =>
+      apiKey ? { apiKey } : null
     const provider = new InferenceProviderImpl({
-      credentials: {
-        getCredentials: () => (apiKey ? { apiKey } : null),
-      } as unknown as import('@main/settings/vendor-credentials-manager').VendorCredentialsManager,
+      credentials: { getCredentials } as VendorCredentialsManager,
       getActiveVendor: () => 'openrouter',
     })
     const service = new ActivitySemanticService(provider, {

--- a/src/main/semantic/activity-semantic-service.ollama.integration.test.ts
+++ b/src/main/semantic/activity-semantic-service.ollama.integration.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import type { Activity, ActivityFrame } from '@main/activity/activity-types'
 import { ActivitySemanticService, SemanticFileDebugDumper } from './activity-semantic-service'
 import { InferenceProviderImpl } from '@main/llm/index'
+import type { VendorCredentialsManager } from '@main/settings/vendor-credentials-manager'
 import { FfmpegVideoStitcher } from '@main/video/video-stitcher'
 
 const RUN_INTEGRATION = process.env.RUN_SEMANTIC_OLLAMA_INTEGRATION === '1'
@@ -125,13 +126,12 @@ describeIntegration('semantic service ollama custom endpoint integration', () =>
       copyMediaAssets: true,
     })
 
+    const getCredentials: VendorCredentialsManager['getCredentials'] = () => ({
+      apiKey: OLLAMA_API_KEY ?? '',
+      baseURL: OLLAMA_BASE_URL,
+    })
     const provider = new InferenceProviderImpl({
-      credentials: {
-        getCredentials: () => ({
-          apiKey: OLLAMA_API_KEY ?? '',
-          baseURL: OLLAMA_BASE_URL,
-        }),
-      } as unknown as import('@main/settings/vendor-credentials-manager').VendorCredentialsManager,
+      credentials: { getCredentials } as VendorCredentialsManager,
       getActiveVendor: () => 'openai-compatible',
     })
     const service = new ActivitySemanticService(provider, {

--- a/src/main/semantic/activity-semantic-service.test.ts
+++ b/src/main/semantic/activity-semantic-service.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 import { ACTIVITY_CONFIG, VISUAL_DETECTOR_CONFIG } from '@constants'
 import type { Activity, ActivityFrame } from '@main/activity/activity-types'
 import { ActivitySemanticService, SemanticFileDebugDumper } from './activity-semantic-service'
@@ -91,7 +91,7 @@ interface FetchCall {
 type FetchHandler = (call: FetchCall) => unknown | Promise<unknown>
 
 interface FetchMock {
-  fn: ReturnType<typeof vi.fn>
+  fn: Mock<(url: RequestInfo | URL, init?: RequestInit) => Promise<Response>>
   calls: FetchCall[]
   setHandler: (handler: FetchHandler) => void
 }
@@ -222,7 +222,7 @@ function setupService(options: SetupOptions = {}): {
   const provider = new InferenceProviderImpl({
     credentials: vendorCredentials,
     getActiveVendor: () => activeVendor,
-    fetch: fetchMock.fn as unknown as typeof globalThis.fetch,
+    fetch: fetchMock.fn,
   })
 
   // For custom-endpoint runs, the configured model becomes the only model for
@@ -242,7 +242,7 @@ function setupService(options: SetupOptions = {}): {
     usageTracker: options.usageTracker ?? { recordUsage: vi.fn() },
     summaryModeTracker: options.summaryModeTracker ?? { record: vi.fn() },
     debugDumper: options.debugDumper,
-    fetchImpl: fetchMock.fn as unknown as typeof globalThis.fetch,
+    fetchImpl: fetchMock.fn,
     healthStatePath: options.healthStatePath,
   })
   return { service, fetchMock, provider }

--- a/src/main/semantic/invoke.test.ts
+++ b/src/main/semantic/invoke.test.ts
@@ -26,11 +26,11 @@ function jsonResponse(body: unknown, init: ResponseInit = { status: 200 }): Resp
 
 describe('invokeRawVideoCompletion', () => {
   it('parses a successful chat-completion response', async () => {
-    const fetchImpl = (async () =>
+    const fetchImpl: typeof globalThis.fetch = async () =>
       jsonResponse({
         choices: [{ message: { content: 'a summary' } }],
         usage: { prompt_tokens: 10, completion_tokens: 4 },
-      })) as unknown as typeof globalThis.fetch
+      })
 
     const outcome = await invokeRawVideoCompletion({
       route: makeRoute(),
@@ -46,7 +46,7 @@ describe('invokeRawVideoCompletion', () => {
   })
 
   it('formats structured error responses with code/provider_message details', async () => {
-    const fetchImpl = (async () =>
+    const fetchImpl: typeof globalThis.fetch = async () =>
       jsonResponse(
         {
           error: {
@@ -56,7 +56,7 @@ describe('invokeRawVideoCompletion', () => {
           },
         },
         { status: 400, statusText: 'Bad Request' },
-      )) as unknown as typeof globalThis.fetch
+      )
 
     await expect(
       invokeRawVideoCompletion({
@@ -70,12 +70,12 @@ describe('invokeRawVideoCompletion', () => {
   })
 
   it('falls back to raw response text on a non-OK non-JSON body', async () => {
-    const fetchImpl = (async () =>
+    const fetchImpl: typeof globalThis.fetch = async () =>
       new Response('upstream is down', {
         status: 502,
         statusText: 'Bad Gateway',
         headers: { 'content-type': 'text/plain' },
-      })) as unknown as typeof globalThis.fetch
+      })
 
     await expect(
       invokeRawVideoCompletion({
@@ -89,8 +89,7 @@ describe('invokeRawVideoCompletion', () => {
   })
 
   it('throws "Empty response body" when an OK response has no body', async () => {
-    const fetchImpl = (async () =>
-      new Response('', { status: 200 })) as unknown as typeof globalThis.fetch
+    const fetchImpl: typeof globalThis.fetch = async () => new Response('', { status: 200 })
 
     await expect(
       invokeRawVideoCompletion({
@@ -104,9 +103,9 @@ describe('invokeRawVideoCompletion', () => {
   })
 
   it('propagates fetch errors (e.g. abort/network)', async () => {
-    const fetchImpl = (async () => {
+    const fetchImpl: typeof globalThis.fetch = async () => {
       throw new Error('aborted by test')
-    }) as unknown as typeof globalThis.fetch
+    }
 
     await expect(
       invokeRawVideoCompletion({
@@ -120,10 +119,10 @@ describe('invokeRawVideoCompletion', () => {
   })
 
   it('rejects content types that are not text or input_video', async () => {
-    const fetchImpl = (async () =>
+    const fetchImpl: typeof globalThis.fetch = async () =>
       jsonResponse({
         choices: [{ message: { content: 'ok' } }],
-      })) as unknown as typeof globalThis.fetch
+      })
 
     await expect(
       invokeRawVideoCompletion({
@@ -140,10 +139,10 @@ describe('invokeRawVideoCompletion', () => {
 
   it('omits the Authorization header when apiKey is empty (Ollama case)', async () => {
     let seenHeaders: Record<string, string> | null = null
-    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+    const fetchImpl: typeof globalThis.fetch = async (_url, init) => {
       seenHeaders = (init?.headers as Record<string, string>) ?? {}
       return jsonResponse({ choices: [{ message: { content: 'ok' } }] })
-    }) as unknown as typeof globalThis.fetch
+    }
 
     await invokeRawVideoCompletion({
       route: makeRoute({ apiKey: '' }),

--- a/src/main/services/database-upload-sync.test.ts
+++ b/src/main/services/database-upload-sync.test.ts
@@ -15,12 +15,15 @@ vi.mock('./upload-prep', () => ({
 }))
 
 function mockFetchResponse(status: number, body: object | string) {
-  return vi.fn(async () => ({
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => (typeof body === 'object' ? body : JSON.parse(body)),
-    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
-  }))
+  return vi.fn<typeof fetch>(
+    async () =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => (typeof body === 'object' ? body : JSON.parse(body)),
+        text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+      }) as Response,
+  )
 }
 
 describe('DatabaseUploadSync', () => {
@@ -37,7 +40,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_123',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -62,7 +65,7 @@ describe('DatabaseUploadSync', () => {
     expect(backupToFile).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    const [url, init] = fetchMock.mock.calls[0]
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
     expect(url.toString()).toBe('http://localhost:8000/api/device/upload')
     expect(init.method).toBe('POST')
     expect(init.body).toBeInstanceOf(FormData)
@@ -76,7 +79,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_123',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -97,7 +100,7 @@ describe('DatabaseUploadSync', () => {
     await vi.advanceTimersByTimeAsync?.(0).catch(() => undefined)
     await sync.stop()
 
-    const [, init] = fetchMock.mock.calls[0]
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
     const part = (init.body as FormData).get('file') as Blob
     expect(part).toBeInstanceOf(Blob)
 
@@ -111,7 +114,7 @@ describe('DatabaseUploadSync', () => {
 
   it('skips upload when not activated', async () => {
     const fetchMock = mockFetchResponse(201, { ok: true })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -137,7 +140,7 @@ describe('DatabaseUploadSync', () => {
 
   it('cleans up temp file on upload failure', async () => {
     const fetchMock = mockFetchResponse(500, 'server error')
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const tempFiles: string[] = []
     const backupToFile = vi.fn(async (dest: string) => {
@@ -166,7 +169,7 @@ describe('DatabaseUploadSync', () => {
 
   it('cleans up temp file on backup failure', async () => {
     const fetchMock = mockFetchResponse(201, { ok: true })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async () => {
       throw new Error('backup failed')
@@ -196,7 +199,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_1',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -226,7 +229,7 @@ describe('DatabaseUploadSync', () => {
 
   it('skips automatic upload when sync is disabled', async () => {
     const fetchMock = mockFetchResponse(201, { ok: true })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -252,7 +255,7 @@ describe('DatabaseUploadSync', () => {
 
   it('triggerUpload returns error when sync is disabled', async () => {
     const fetchMock = mockFetchResponse(201, { ok: true })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -283,7 +286,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_1',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -320,7 +323,7 @@ describe('DatabaseUploadSync', () => {
 
   it('skips startup upload when already uploaded earlier today', async () => {
     const fetchMock = mockFetchResponse(201, { ok: true })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -351,7 +354,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_1',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -378,7 +381,7 @@ describe('DatabaseUploadSync', () => {
 
   it('records the timestamp only on a successful upload', async () => {
     const fetchMock = mockFetchResponse(500, 'server error')
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -410,7 +413,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_1',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -440,7 +443,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_1',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -473,7 +476,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_1',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     let syncOn = true
     let resolveBackup!: () => void
@@ -523,7 +526,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_1',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const backupToFile = vi.fn(async (dest: string) => {
       fs.writeFileSync(dest, 'dbcontent')
@@ -568,7 +571,7 @@ describe('DatabaseUploadSync', () => {
       upload_id: 'up_1',
       checksum_sha256: 'abc',
     })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     let resolveBackup!: () => void
     const backupGate = new Promise<void>((resolve) => {

--- a/src/main/services/device-report-sync.test.ts
+++ b/src/main/services/device-report-sync.test.ts
@@ -11,11 +11,11 @@ const EXPECTED_PLATFORM =
   process.platform === 'darwin' ? 'macos' : process.platform === 'win32' ? 'windows' : null
 
 function okResponse(): Response {
-  return { ok: true, status: 200, json: async () => ({}) } as unknown as Response
+  return { ok: true, status: 200, json: async () => ({}) } as Response
 }
 
 function errorResponse(status: number): Response {
-  return { ok: false, status, json: async () => ({}) } as unknown as Response
+  return { ok: false, status, json: async () => ({}) } as Response
 }
 
 describe('DeviceReportSync', () => {
@@ -50,8 +50,8 @@ describe('DeviceReportSync', () => {
   })
 
   it('POSTs the version with the device bearer to api/device/report', async () => {
-    const fetchMock = vi.fn(async () => okResponse())
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse())
+    globalThis.fetch = fetchMock
 
     const { service, writeStored } = makeService()
     await service.sync()
@@ -68,8 +68,8 @@ describe('DeviceReportSync', () => {
   })
 
   it('does not POST when the stored version already matches (loaded on start)', async () => {
-    const fetchMock = vi.fn(async () => okResponse())
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse())
+    globalThis.fetch = fetchMock
 
     const { service } = makeService({ readStored: () => ({ version: '1.3.0' }) })
     service.start()
@@ -80,8 +80,8 @@ describe('DeviceReportSync', () => {
   })
 
   it('POSTs once, then stays quiet on subsequent syncs (report only on change)', async () => {
-    const fetchMock = vi.fn(async () => okResponse())
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse())
+    globalThis.fetch = fetchMock
 
     const { service } = makeService()
     await service.sync()
@@ -91,8 +91,8 @@ describe('DeviceReportSync', () => {
   })
 
   it('does not POST when the backend URL is empty', async () => {
-    const fetchMock = vi.fn(async () => okResponse())
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse())
+    globalThis.fetch = fetchMock
 
     const { service } = makeService({ getBackendUrl: () => '' })
     await service.sync()
@@ -101,8 +101,8 @@ describe('DeviceReportSync', () => {
   })
 
   it('skips while inactive, then reports once activated', async () => {
-    const fetchMock = vi.fn(async () => okResponse())
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse())
+    globalThis.fetch = fetchMock
 
     let activated = false
     const { service, writeStored } = makeService({ isActivated: () => activated })
@@ -118,8 +118,8 @@ describe('DeviceReportSync', () => {
 
   it('does not record the version on a non-200 and retries on the next sync', async () => {
     const responses: Response[] = [errorResponse(500), okResponse()]
-    const fetchMock = vi.fn(async () => responses.shift() as Response)
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => responses.shift() as Response)
+    globalThis.fetch = fetchMock
 
     const { service, writeStored } = makeService()
     await expect(service.sync()).resolves.toBeUndefined()
@@ -132,8 +132,8 @@ describe('DeviceReportSync', () => {
   })
 
   it('swallows a transient device-identity error and does not advance state', async () => {
-    const fetchMock = vi.fn(async () => okResponse())
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse())
+    globalThis.fetch = fetchMock
 
     const { service, writeStored } = makeService({
       getDeviceId: () => {

--- a/src/main/services/log-upload-sync.test.ts
+++ b/src/main/services/log-upload-sync.test.ts
@@ -13,12 +13,15 @@ import type { LogUploadState } from './log-upload-store'
 const NOW = 1_700_000_000_000
 
 function mockFetchResponse(status: number, body: object | string = { ok: true }) {
-  return vi.fn(async () => ({
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => (typeof body === 'object' ? body : JSON.parse(body)),
-    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
-  }))
+  return vi.fn<typeof fetch>(
+    async () =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => (typeof body === 'object' ? body : JSON.parse(body)),
+        text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+      }) as Response,
+  )
 }
 
 describe('LogUploadSync', () => {
@@ -68,14 +71,14 @@ describe('LogUploadSync', () => {
 
   it('uploads a zipped bundle with Bearer auth when activated and changed', async () => {
     const fetchMock = mockFetchResponse(200)
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { sync, zipFiles, state } = makeSync()
     sync.requestSync('startup')
     await sync.stop()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit]
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
     expect(url.toString()).toBe('http://localhost:8000/api/device/logs')
     expect(init.method).toBe('POST')
     expect(init.body).toBeInstanceOf(FormData)
@@ -93,7 +96,7 @@ describe('LogUploadSync', () => {
 
   it('skips when sharing is disabled', async () => {
     const fetchMock = mockFetchResponse(200)
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { sync, zipFiles } = makeSync({ isSyncEnabled: () => false })
     sync.requestSync('startup')
@@ -105,7 +108,7 @@ describe('LogUploadSync', () => {
 
   it('skips when the device is not activated', async () => {
     const fetchMock = mockFetchResponse(200)
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { sync, zipFiles } = makeSync({ isActivated: () => false })
     sync.requestSync('startup')
@@ -117,7 +120,7 @@ describe('LogUploadSync', () => {
 
   it('skips a second upload when the logs are unchanged', async () => {
     const fetchMock = mockFetchResponse(200)
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { sync, zipFiles } = makeSync()
     sync.requestSync('first')
@@ -132,7 +135,7 @@ describe('LogUploadSync', () => {
 
   it('throttles a changed bundle within the min interval', async () => {
     const fetchMock = mockFetchResponse(200)
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { sync, zipFiles } = makeSync({ minIntervalMs: 10_000 })
     // A recent upload with a different signature: changed, but throttled.
@@ -152,7 +155,7 @@ describe('LogUploadSync', () => {
 
   it('does not advance the marker when the upload fails', async () => {
     const fetchMock = mockFetchResponse(500, 'server error')
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { sync, state } = makeSync()
     sync.requestSync('startup')
@@ -164,7 +167,7 @@ describe('LogUploadSync', () => {
 
   it('triggerUpload returns an error when sharing is disabled', async () => {
     const fetchMock = mockFetchResponse(200)
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { sync, zipFiles } = makeSync({ isSyncEnabled: () => false })
     const result = await sync.triggerUpload()
@@ -176,7 +179,7 @@ describe('LogUploadSync', () => {
 
   it('triggerUpload forces an upload even when logs are unchanged', async () => {
     const fetchMock = mockFetchResponse(200)
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { sync } = makeSync()
     // First upload establishes the marker (signature recorded).
@@ -190,7 +193,7 @@ describe('LogUploadSync', () => {
 
   it('triggerUpload surfaces an upload failure', async () => {
     const fetchMock = mockFetchResponse(500, 'server error')
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { sync, state } = makeSync()
     const result = await sync.triggerUpload()

--- a/src/main/services/ml-worker.test.ts
+++ b/src/main/services/ml-worker.test.ts
@@ -5,7 +5,7 @@ import type { EmbeddingService } from '@main/processor/embedding'
 
 const fakeService = {
   embedBatch: async (texts: string[]) => texts.map(() => [1, 0, 0]),
-} as unknown as EmbeddingService
+} as EmbeddingService
 
 describe('packVectors / unpackVectors', () => {
   it('round-trips row vectors through one buffer', () => {
@@ -54,11 +54,10 @@ describe('handleMlWorkerRequest', () => {
   })
 
   it('maps a thrown error to ok:false', async () => {
-    const failing = {
-      embedBatch: async () => {
-        throw new Error('boom')
-      },
-    } as unknown as EmbeddingService
+    const failingEmbedBatch: EmbeddingService['embedBatch'] = async () => {
+      throw new Error('boom')
+    }
+    const failing = { embedBatch: failingEmbedBatch } as EmbeddingService
     const response = await handleMlWorkerRequest(
       { id: 3, type: 'embedBatch', texts: ['x'] },
       failing,

--- a/src/main/services/ml-worker.ts
+++ b/src/main/services/ml-worker.ts
@@ -57,7 +57,7 @@ interface ParentPortLike {
   on(event: 'message', listener: (e: { data: MlWorkerRequest }) => void): void
   postMessage(message: MlWorkerResponse | WorkerLogEvent): void
 }
-const parentPort = (process as unknown as { parentPort?: ParentPortLike }).parentPort
+const parentPort = process.parentPort as ParentPortLike | undefined
 if (parentPort) {
   forwardLogsToParent(parentPort)
   parentPort.on('message', ({ data }) => {

--- a/src/main/services/remote-blacklist-service.test.ts
+++ b/src/main/services/remote-blacklist-service.test.ts
@@ -7,7 +7,7 @@ vi.mock('@main/utils/logger', () => ({
 import { RemoteBlacklistService } from './remote-blacklist-service'
 
 function jsonResponse(body: unknown): Response {
-  return { ok: true, status: 200, json: async () => body } as unknown as Response
+  return { ok: true, status: 200, json: async () => body } as Response
 }
 
 describe('RemoteBlacklistService', () => {
@@ -39,10 +39,10 @@ describe('RemoteBlacklistService', () => {
   })
 
   it('fetches with the device bearer and exposes the synced blacklist', async () => {
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn<typeof fetch>(async () =>
       jsonResponse({ excludedApps: ['slack', 1, 'msedge'], excludedUrlPatterns: ['*bank*'] }),
     )
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    globalThis.fetch = fetchMock
 
     const { service, onChange } = makeService()
     await service.sync()
@@ -64,8 +64,8 @@ describe('RemoteBlacklistService', () => {
   })
 
   it('does not fetch or notify when the device is not activated', async () => {
-    const fetchMock = vi.fn()
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>()
+    globalThis.fetch = fetchMock
 
     const { service, onChange } = makeService({ isActivated: () => false })
     await service.sync()
@@ -76,9 +76,9 @@ describe('RemoteBlacklistService', () => {
   })
 
   it('notifies only when the blacklist actually changes', async () => {
-    globalThis.fetch = vi.fn(async () =>
+    globalThis.fetch = vi.fn<typeof fetch>(async () =>
       jsonResponse({ excludedApps: ['slack'], excludedUrlPatterns: [] }),
-    ) as unknown as typeof fetch
+    )
 
     const { service, onChange } = makeService()
     await service.sync()
@@ -90,9 +90,9 @@ describe('RemoteBlacklistService', () => {
   it('keeps the last blacklist on 401 (does not clear on deactivation)', async () => {
     const responses: Response[] = [
       jsonResponse({ excludedApps: ['slack'], excludedUrlPatterns: ['*bank*'] }),
-      { ok: false, status: 401, json: async () => ({}) } as unknown as Response,
+      { ok: false, status: 401, json: async () => ({}) } as Response,
     ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const { service, onChange } = makeService()
     await service.sync()
@@ -107,9 +107,9 @@ describe('RemoteBlacklistService', () => {
   it('keeps the last blacklist and swallows the error on a failed fetch', async () => {
     const responses: Response[] = [
       jsonResponse({ excludedApps: ['slack'], excludedUrlPatterns: [] }),
-      { ok: false, status: 500, json: async () => ({}) } as unknown as Response,
+      { ok: false, status: 500, json: async () => ({}) } as Response,
     ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const { service, onChange } = makeService()
     await service.sync()
@@ -124,7 +124,7 @@ describe('RemoteBlacklistService', () => {
       jsonResponse({ excludedApps: ['slack'], excludedUrlPatterns: [] }),
       jsonResponse({ excludedApps: [], excludedUrlPatterns: [] }),
     ]
-    globalThis.fetch = vi.fn(async () => responses.shift() as Response) as unknown as typeof fetch
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
     const writeStored = vi.fn()
     const { service, onChange } = makeService({ writeStored })
@@ -137,9 +137,9 @@ describe('RemoteBlacklistService', () => {
   })
 
   it('persists the blacklist to the store whenever it changes', async () => {
-    globalThis.fetch = vi.fn(async () =>
+    globalThis.fetch = vi.fn<typeof fetch>(async () =>
       jsonResponse({ excludedApps: ['slack'], excludedUrlPatterns: ['*bank*'] }),
-    ) as unknown as typeof fetch
+    )
 
     const writeStored = vi.fn()
     const { service } = makeService({ writeStored })
@@ -152,8 +152,10 @@ describe('RemoteBlacklistService', () => {
   })
 
   it('loads the cached blacklist on start() and enforces it before any fetch', async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ excludedApps: [], excludedUrlPatterns: [] }))
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      jsonResponse({ excludedApps: [], excludedUrlPatterns: [] }),
+    )
+    globalThis.fetch = fetchMock
 
     const cached = { apps: ['slack'], urlPatterns: ['*bank*'] }
     const { service, onChange } = makeService({ readStored: () => cached })
@@ -167,9 +169,9 @@ describe('RemoteBlacklistService', () => {
   })
 
   it('treats an empty/missing cache on start() as a no-op', async () => {
-    globalThis.fetch = vi.fn(async () =>
+    globalThis.fetch = vi.fn<typeof fetch>(async () =>
       jsonResponse({ excludedApps: [], excludedUrlPatterns: [] }),
-    ) as unknown as typeof fetch
+    )
 
     const { service, onChange } = makeService({ readStored: () => null })
     service.start()

--- a/src/main/services/remote-blacklist-service.test.ts
+++ b/src/main/services/remote-blacklist-service.test.ts
@@ -5,10 +5,7 @@ vi.mock('@main/utils/logger', () => ({
 }))
 
 import { RemoteBlacklistService } from './remote-blacklist-service'
-
-function jsonResponse(body: unknown): Response {
-  return { ok: true, status: 200, json: async () => body } as Response
-}
+import { jsonResponse } from '@main/utils/test-utils'
 
 describe('RemoteBlacklistService', () => {
   const originalFetch = globalThis.fetch
@@ -90,7 +87,7 @@ describe('RemoteBlacklistService', () => {
   it('keeps the last blacklist on 401 (does not clear on deactivation)', async () => {
     const responses: Response[] = [
       jsonResponse({ excludedApps: ['slack'], excludedUrlPatterns: ['*bank*'] }),
-      { ok: false, status: 401, json: async () => ({}) } as Response,
+      jsonResponse({}, false, 401),
     ]
     globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 
@@ -107,7 +104,7 @@ describe('RemoteBlacklistService', () => {
   it('keeps the last blacklist and swallows the error on a failed fetch', async () => {
     const responses: Response[] = [
       jsonResponse({ excludedApps: ['slack'], excludedUrlPatterns: [] }),
-      { ok: false, status: 500, json: async () => ({}) } as Response,
+      jsonResponse({}, false, 500),
     ]
     globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
 

--- a/src/main/services/task-miner/clustering/signatures.test.ts
+++ b/src/main/services/task-miner/clustering/signatures.test.ts
@@ -4,13 +4,10 @@ import type { StorageService } from '@main/storage'
 import type { Sighting } from '@main/storage/sighting-repository'
 
 const upserted = new Map<string, number[] | null>()
-const storage = {
-  clusters: {
-    upsertSignature: (id: string, vector: number[] | null) => {
-      upserted.set(id, vector)
-    },
-  },
-} as unknown as StorageService
+const upsertSignature: StorageService['clusters']['upsertSignature'] = (id, vector) => {
+  upserted.set(id, vector)
+}
+const storage = { clusters: { upsertSignature } } as StorageService
 
 // Mimics EmbeddingService's blank contract: blank text → zero vector.
 const embedder = {

--- a/src/main/services/task-miner/task-miner.test.ts
+++ b/src/main/services/task-miner/task-miner.test.ts
@@ -17,7 +17,7 @@ vi.mock('./clustering', () => ({ runClustering: vi.fn(async () => ({})) }))
 const mockedRunDetection = vi.mocked(runDetection)
 const mockedRunClustering = vi.mocked(runClustering)
 
-const configuredProvider = { isConfigured: () => true } as unknown as InferenceProvider
+const configuredProvider = { isConfigured: () => true } as InferenceProvider
 const embedder: MinerEmbedder = {
   embed: async () => [0.1, 0.2, 0.3],
   embedBatch: async (texts) => texts.map(() => [0.1, 0.2, 0.3]),

--- a/src/main/services/upload-prep-worker.ts
+++ b/src/main/services/upload-prep-worker.ts
@@ -28,7 +28,7 @@ interface ParentPortLike {
   on(event: 'message', listener: (e: { data: UploadPrepRequest }) => void): void
   postMessage(message: UploadPrepResponse | WorkerLogEvent, transfer?: ArrayBuffer[]): void
 }
-const parentPort = (process as unknown as { parentPort?: ParentPortLike }).parentPort
+const parentPort = process.parentPort as ParentPortLike | undefined
 if (parentPort) {
   forwardLogsToParent(parentPort)
   parentPort.on('message', ({ data }) => {

--- a/src/main/utils/test-utils.ts
+++ b/src/main/utils/test-utils.ts
@@ -1,0 +1,8 @@
+export function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as Response
+}

--- a/src/main/video/video-stitcher.test.ts
+++ b/src/main/video/video-stitcher.test.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
 import * as fs from 'fs'
 import * as os from 'os'
@@ -74,9 +75,7 @@ describe('FfmpegVideoStitcher', () => {
     const outputPath = path.join(tempDir, 'out.mp4')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -135,9 +134,7 @@ describe('FfmpegVideoStitcher', () => {
     const frameC = createFrame(tempDir, 'c.png')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -166,9 +163,7 @@ describe('FfmpegVideoStitcher', () => {
     const frameB = createFrame(tempDir, 'b.png')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -197,9 +192,7 @@ describe('FfmpegVideoStitcher', () => {
     const outputPath = path.join(tempDir, 'out.mp4')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -279,9 +272,7 @@ describe('FfmpegVideoStitcher', () => {
     const frameB = createFrame(tempDir, 'b.png')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -311,9 +302,7 @@ describe('FfmpegVideoStitcher', () => {
     const frameB = createFrame(tempDir, 'b.png')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(
-      mockChild as unknown as ReturnType<typeof childProcess.spawn>,
-    )
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({

--- a/src/main/video/video-stitcher.test.ts
+++ b/src/main/video/video-stitcher.test.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
+import { PassThrough } from 'stream'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
@@ -12,15 +13,15 @@ vi.mock('child_process', () => ({
   spawn: vi.fn(),
 }))
 
-interface MockChildProcess extends EventEmitter {
-  stdout: EventEmitter
-  stderr: EventEmitter
+type MockChildProcess = ChildProcess & {
+  stdout: PassThrough
+  stderr: PassThrough
 }
 
 function createMockChildProcess(): MockChildProcess {
   const processEmitter = new EventEmitter() as MockChildProcess
-  processEmitter.stdout = new EventEmitter()
-  processEmitter.stderr = new EventEmitter()
+  processEmitter.stdout = new PassThrough()
+  processEmitter.stderr = new PassThrough()
   return processEmitter
 }
 
@@ -75,7 +76,7 @@ describe('FfmpegVideoStitcher', () => {
     const outputPath = path.join(tempDir, 'out.mp4')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -134,7 +135,7 @@ describe('FfmpegVideoStitcher', () => {
     const frameC = createFrame(tempDir, 'c.png')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -163,7 +164,7 @@ describe('FfmpegVideoStitcher', () => {
     const frameB = createFrame(tempDir, 'b.png')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -192,7 +193,7 @@ describe('FfmpegVideoStitcher', () => {
     const outputPath = path.join(tempDir, 'out.mp4')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -272,7 +273,7 @@ describe('FfmpegVideoStitcher', () => {
     const frameB = createFrame(tempDir, 'b.png')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({
@@ -302,7 +303,7 @@ describe('FfmpegVideoStitcher', () => {
     const frameB = createFrame(tempDir, 'b.png')
 
     const mockChild = createMockChildProcess()
-    vi.mocked(childProcess.spawn).mockReturnValue(mockChild as ChildProcess)
+    vi.mocked(childProcess.spawn).mockReturnValue(mockChild)
 
     const stitcher = new FfmpegVideoStitcher()
     const promise = stitcher.stitch({

--- a/src/renderer/components/theme-provider.tsx
+++ b/src/renderer/components/theme-provider.tsx
@@ -10,7 +10,7 @@ function useTheme() {
 }
 
 function getAPI(): MainWindowAPI {
-  const api = (window as unknown as { mainWindowAPI?: MainWindowAPI }).mainWindowAPI
+  const api = window.mainWindowAPI
   if (!api) throw new Error('mainWindowAPI not available')
   return api
 }

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -1,3 +1,7 @@
+interface Window {
+  mainWindowAPI?: import('@types').MainWindowAPI
+}
+
 declare module '*.png' {
   const src: string
   export default src

--- a/src/renderer/hooks/use-main-window-api.ts
+++ b/src/renderer/hooks/use-main-window-api.ts
@@ -1,7 +1,7 @@
 import type { MainWindowAPI } from '@types'
 
 export function useMainWindowAPI(): MainWindowAPI {
-  const api = (window as unknown as { mainWindowAPI?: MainWindowAPI }).mainWindowAPI
+  const api = window.mainWindowAPI
   if (api === undefined) throw new Error('mainWindowAPI not available')
   return api
 }


### PR DESCRIPTION
## Summary

Removes the `as unknown as` double-casts (25 files). Each one was a spot where type checking was fully disabled; nearly all had a properly-typed alternative:

- **fetch mocks** — `vi.fn() as unknown as typeof fetch` → `vi.fn<typeof fetch>()`. The mock keeps its own typing, which also eliminates every reverse-cast of the form `(fetchMock as unknown as { mock: ... }).mock.calls`.
- **Partial `Response`/`DeviceIdentity` literals** — single comparable `as` casts; a shared `jsonResponse` helper (`@main/utils/test-utils`) for the three files that repeated the same literal.
- **`ChildProcess` mocks** (video-stitcher, OCR, app-watcher, native-screenshot) — mock types are intersections (`ChildProcess & { stdout: PassThrough; ... }`), so call sites need no cast at all.
- **Service fakes** (semantic, task-miner, eval) — contextually typed consts like `const languageModel: InferenceProvider['languageModel'] = ...` plus one single boundary cast.
- **`window.mainWindowAPI`** — global `Window` augmentation in `src/renderer/env.d.ts`; call sites are plain `window.mainWindowAPI`.
- **utilityProcess workers** — `process.parentPort` is already declared by Electron's types; both workers now use a single narrowing cast to their message-typed port interface.

Kept (3): the two `createVertex(...) as unknown as SdkProvider` casts in `adapters.ts` (genuine cross-package `ai` SDK type mismatch) and one in `mcp/tools.test.ts` where the mock deliberately simplifies the SDK's generic `registerTool` signature.

Typing the mocks properly also fixed 15 pre-existing `tsc --noEmit` errors as a side effect (41 on main → 26 here).

Post-review updates:
- Rebased onto main; cleaned up the five new double-casts #220 and #222 introduced while this PR was open.
- Typed `openExternalMock`, shared the `jsonResponse` helper, and made the video-stitcher spawn mock cast-free like the other spawn tests.
- Disabled `import/no-named-as-default`: all 34 repo warnings were the same false positive on better-sqlite3's `Database` default export (fires even on type-only imports).

## Test plan

- [x] Full suite: 1131 tests / 111 files pass (skips are env-gated integration tests)
- [x] `tsc --noEmit` on both tsconfig projects: no new errors vs. baseline (15 fewer)
- [x] `npm run lint`: 0 errors, 0 warnings
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)