### PR TITLE
fix(types): make tsc --noEmit green outside the double-cast cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "make:enterprise:win": "cross-env EDITION=enterprise npm run make:win",
     "make:win:signed": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/make-win-signed.ps1",
     "lint": "eslint --ext .ts,.tsx .",
+    "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "node ./scripts/enode.js ./node_modules/vitest/vitest.mjs",

--- a/src/main/access/enterprise-access-provider.ts
+++ b/src/main/access/enterprise-access-provider.ts
@@ -150,7 +150,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       const config = await this.fetchInferenceConfig(deviceId)
       if (config) {
         log.info(`[EnterpriseAccess] Received managed inference config (${config.provider})`)
-        this.scheduleTokenRefresh(deviceId, config)
+        this.scheduleTokenRefresh(config)
         this.applyTransition(
           transitionEnterpriseAccess(this.accessState, {
             type: 'activation_completed',
@@ -544,7 +544,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
       }
 
       this.clearTimers()
-      this.scheduleTokenRefresh(deviceId, config)
+      this.scheduleTokenRefresh(config)
       this.applyTransition(
         transitionEnterpriseAccess(this.accessState, {
           type: 'activation_completed',
@@ -626,7 +626,7 @@ export class EnterpriseAccessProvider extends BaseAccessProvider {
     return { provider: 'openrouter', apiKey: data.apiKey }
   }
 
-  private scheduleTokenRefresh(deviceId: string, config: ManagedInferenceConfig): void {
+  private scheduleTokenRefresh(config: ManagedInferenceConfig): void {
     this.clearTokenRefresh()
     if (config.provider !== 'vertex' || config.expiresAt === undefined) {
       return

--- a/src/main/activity/activity-extractor.test.ts
+++ b/src/main/activity/activity-extractor.test.ts
@@ -141,7 +141,7 @@ describe('ActivityExtractor', () => {
   it('enforces maxConcurrent worker limit', async () => {
     let running = 0
     let maxRunning = 0
-    let releaseGate: (() => void) | null = null
+    let releaseGate!: () => void
     const gate = new Promise<void>((resolve) => {
       releaseGate = resolve
     })
@@ -171,14 +171,14 @@ describe('ActivityExtractor', () => {
     }
 
     await waitFor(() => maxRunning === 2, 'Expected worker concurrency to reach configured max')
-    releaseGate?.()
+    releaseGate()
 
     await waitFor(() => persistedCount === 5, 'Expected all activities to be persisted')
     expect(maxRunning).toBe(2)
   })
 
   it('acks only contiguous completed offsets when tasks finish out of order', async () => {
-    let releaseFirst: (() => void) | null = null
+    let releaseFirst!: () => void
     const firstGate = new Promise<void>((resolve) => {
       releaseFirst = resolve
     })
@@ -207,7 +207,7 @@ describe('ActivityExtractor', () => {
     await waitFor(() => persisted.includes('fast'), 'Expected fast activity to finish first')
     expect(await activityStream.getAck(consumerId)).toBeNull()
 
-    releaseFirst?.()
+    releaseFirst()
     await waitFor(
       async () => (await activityStream.getAck(consumerId)) === 1,
       'Expected ack to advance after gap closes',

--- a/src/main/apps/installed-apps.ts
+++ b/src/main/apps/installed-apps.ts
@@ -286,7 +286,7 @@ async function resolveWindowsShortcutTargets(
         },
         (err, out) => {
           if (err) reject(err)
-          else resolve(typeof out === 'string' ? out : out.toString('utf-8'))
+          else resolve(out)
         },
       )
     })

--- a/src/main/recorder/screen-capturer.test.ts
+++ b/src/main/recorder/screen-capturer.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ScreenCaptureBackend } from './native-screenshot'
+import type { Frame } from './screen-capturer'
 
 vi.mock('../../logger', () => ({
   default: {
@@ -32,7 +33,7 @@ describe('ScreenCapturer.setDisplayId', () => {
   })
 
   it('does not send command when displayId has not changed', () => {
-    const stream = new InMemoryStream()
+    const stream = new InMemoryStream<Frame>()
     const capturer = new ScreenCapturer({ outputDir: '/tmp/test', stream })
 
     capturer.setDisplayId(2)
@@ -45,7 +46,7 @@ describe('ScreenCapturer.setDisplayId', () => {
 
   it('sends command when displayId changes', () => {
     vi.mocked(mockBackend.send).mockClear()
-    const stream = new InMemoryStream()
+    const stream = new InMemoryStream<Frame>()
     const capturer = new ScreenCapturer({ outputDir: '/tmp/test', stream })
 
     capturer.setDisplayId(1)
@@ -60,7 +61,7 @@ describe('ScreenCapturer.setDisplayId', () => {
 
   it('treats undefined and null as equivalent (reset to main)', () => {
     vi.mocked(mockBackend.send).mockClear()
-    const stream = new InMemoryStream()
+    const stream = new InMemoryStream<Frame>()
     const capturer = new ScreenCapturer({ outputDir: '/tmp/test', stream })
 
     capturer.setDisplayId(undefined)
@@ -71,7 +72,7 @@ describe('ScreenCapturer.setDisplayId', () => {
   })
 
   it('sends command when switching back to a previous displayId', () => {
-    const stream = new InMemoryStream()
+    const stream = new InMemoryStream<Frame>()
     const capturer = new ScreenCapturer({ outputDir: '/tmp/test', stream })
 
     capturer.setDisplayId(1)
@@ -82,7 +83,7 @@ describe('ScreenCapturer.setDisplayId', () => {
   })
 
   it('replays the active display selection after start', async () => {
-    const stream = new InMemoryStream()
+    const stream = new InMemoryStream<Frame>()
     const capturer = new ScreenCapturer({ outputDir: '/tmp/test', stream })
 
     capturer.setDisplayId(4)

--- a/src/main/services/upload-prep-worker.ts
+++ b/src/main/services/upload-prep-worker.ts
@@ -36,7 +36,8 @@ if (parentPort) {
       const buf = prepareUploadSync(data.tempPath, data.stripOptions)
       // Copy out an exact-size ArrayBuffer and transfer it (zero-copy) so a
       // large compressed blob doesn't get structured-cloned across the boundary.
-      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+      const ab = new ArrayBuffer(buf.byteLength)
+      new Uint8Array(ab).set(buf)
       parentPort.postMessage({ ok: true, gzip: ab }, [ab])
     } catch (err) {
       parentPort.postMessage({

--- a/src/main/storage/types.ts
+++ b/src/main/storage/types.ts
@@ -21,13 +21,4 @@ export interface ActivitySummary {
   summary: string
 }
 
-/** Activity with window context but without heavy ocr_text and vector fields. */
-export interface ActivityDetail {
-  id: string
-  startTimestamp: number
-  endTimestamp: number
-  appName: string
-  windowTitle: string
-  tld: string | null
-  summary: string
-}
+export type { ActivityDetail } from '../../shared/types'

--- a/src/main/ui/database-export.ts
+++ b/src/main/ui/database-export.ts
@@ -1,4 +1,5 @@
-import { app, dialog, type BrowserWindow } from 'electron'
+import { app, type BrowserWindow } from 'electron'
+import { showSaveDialog } from '@main/ui/dialogs'
 import fs from 'node:fs'
 import * as fsPromises from 'node:fs/promises'
 import os from 'node:os'
@@ -29,7 +30,7 @@ export async function exportDatabaseZip({
       app.getPath('documents'),
       buildTimestampedZipName('memorylane-db-export'),
     )
-    const saveResult = await dialog.showSaveDialog(parentWindow ?? undefined, {
+    const saveResult = await showSaveDialog(parentWindow, {
       title: 'Export Database ZIP',
       defaultPath,
       buttonLabel: 'Export',

--- a/src/main/ui/database-import.ts
+++ b/src/main/ui/database-import.ts
@@ -1,4 +1,5 @@
-import { dialog, type BrowserWindow } from 'electron'
+import { type BrowserWindow } from 'electron'
+import { showMessageBox, showOpenDialog } from '@main/ui/dialogs'
 import Database from 'better-sqlite3'
 import fs from 'node:fs'
 import * as fsPromises from 'node:fs/promises'
@@ -122,7 +123,7 @@ export async function importDatabase({
   const stagingPath = `${pendingPath}.partial`
 
   try {
-    const openResult = await dialog.showOpenDialog(parentWindow ?? undefined, {
+    const openResult = await showOpenDialog(parentWindow, {
       title: 'Import Database',
       buttonLabel: 'Import',
       properties: ['openFile'],
@@ -134,7 +135,7 @@ export async function importDatabase({
     }
     const selectedPath = openResult.filePaths[0]
 
-    const confirm = await dialog.showMessageBox(parentWindow ?? undefined, {
+    const confirm = await showMessageBox(parentWindow, {
       type: 'warning',
       buttons: ['Cancel', 'Import and Replace'],
       defaultId: 0,

--- a/src/main/ui/dialogs.ts
+++ b/src/main/ui/dialogs.ts
@@ -1,0 +1,34 @@
+import {
+  dialog,
+  type BrowserWindow,
+  type MessageBoxOptions,
+  type MessageBoxReturnValue,
+  type OpenDialogOptions,
+  type OpenDialogReturnValue,
+  type SaveDialogOptions,
+  type SaveDialogReturnValue,
+} from 'electron'
+
+// Electron's dialog API accepts a parent window or no argument, but not
+// undefined; these wrappers let call sites pass an optional parent through.
+
+export function showSaveDialog(
+  parent: BrowserWindow | null | undefined,
+  options: SaveDialogOptions,
+): Promise<SaveDialogReturnValue> {
+  return parent ? dialog.showSaveDialog(parent, options) : dialog.showSaveDialog(options)
+}
+
+export function showOpenDialog(
+  parent: BrowserWindow | null | undefined,
+  options: OpenDialogOptions,
+): Promise<OpenDialogReturnValue> {
+  return parent ? dialog.showOpenDialog(parent, options) : dialog.showOpenDialog(options)
+}
+
+export function showMessageBox(
+  parent: BrowserWindow | null | undefined,
+  options: MessageBoxOptions,
+): Promise<MessageBoxReturnValue> {
+  return parent ? dialog.showMessageBox(parent, options) : dialog.showMessageBox(options)
+}

--- a/src/main/ui/logs-export.ts
+++ b/src/main/ui/logs-export.ts
@@ -1,4 +1,5 @@
-import { app, dialog, type BrowserWindow } from 'electron'
+import { app, type BrowserWindow } from 'electron'
+import { showSaveDialog } from '@main/ui/dialogs'
 import fs from 'node:fs'
 import * as fsPromises from 'node:fs/promises'
 import path from 'node:path'
@@ -94,7 +95,7 @@ export async function exportLogsZip({
       app.getPath('documents'),
       buildTimestampedZipName('memorylane-logs-export'),
     )
-    const saveResult = await dialog.showSaveDialog(parentWindow ?? undefined, {
+    const saveResult = await showSaveDialog(parentWindow, {
       title: 'Export Logs ZIP',
       defaultPath,
       buttonLabel: 'Export',

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -5,15 +5,8 @@
  * Singleton window that hides on close instead of destroying.
  */
 
-import {
-  app,
-  BrowserWindow,
-  dialog,
-  ipcMain,
-  IpcMainInvokeEvent,
-  nativeTheme,
-  shell,
-} from 'electron'
+import { app, BrowserWindow, ipcMain, IpcMainInvokeEvent, nativeTheme, shell } from 'electron'
+import { showOpenDialog, showSaveDialog } from '@main/ui/dialogs'
 import path from 'node:path'
 import { syncAutoStartSetting } from '@main/system/auto-start'
 import { DEFAULT_EDITION, type AppEditionConfig } from '../../shared/edition'
@@ -971,7 +964,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     'main-window:chooseDatabaseExportDirectory',
     async (_event: IpcMainInvokeEvent, initialPath?: string) => {
       try {
-        const result = await dialog.showOpenDialog(getMainWindow() ?? undefined, {
+        const result = await showOpenDialog(getMainWindow(), {
           properties: ['openDirectory', 'createDirectory'],
           defaultPath:
             typeof initialPath === 'string' && /\S/.test(initialPath) ? initialPath : undefined,
@@ -1334,7 +1327,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     async (_event: IpcMainInvokeEvent, name: unknown) => {
       if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
       if (typeof name !== 'string') return { success: false as const, error: 'Invalid arguments' }
-      const result = await dialog.showSaveDialog(getMainWindow() ?? undefined, {
+      const result = await showSaveDialog(getMainWindow(), {
         title: 'Export Eval Fixture',
         defaultPath: path.join(app.getPath('desktop'), `${name}.zip`),
         buttonLabel: 'Export',
@@ -1497,7 +1490,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     async (_event: IpcMainInvokeEvent, name: unknown) => {
       if (!deps) return { success: false as const, error: 'Dependencies not initialized' }
       if (typeof name !== 'string') return { success: false as const, error: 'Invalid arguments' }
-      const result = await dialog.showSaveDialog(getMainWindow() ?? undefined, {
+      const result = await showSaveDialog(getMainWindow(), {
         title: 'Export Task Golden',
         defaultPath: path.join(app.getPath('desktop'), `${name}.zip`),
         buttonLabel: 'Export',

--- a/src/main/ui/model-settings.test.ts
+++ b/src/main/ui/model-settings.test.ts
@@ -37,6 +37,8 @@ function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings
     excludedApps: [],
     excludedUrlPatterns: [],
     activeVendor: 'openrouter',
+    modelsByVendor: {},
+    newTaskMinerEnabled: true,
     semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
     semanticSnapshotModel: VENDOR_PRESETS.openrouter.semanticSnapshot[0].id,
     patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,

--- a/src/main/ui/vendor-switch.test.ts
+++ b/src/main/ui/vendor-switch.test.ts
@@ -49,6 +49,8 @@ function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings
     excludedApps: [],
     excludedUrlPatterns: [],
     activeVendor: 'openrouter',
+    modelsByVendor: {},
+    newTaskMinerEnabled: true,
     semanticVideoModel: '',
     semanticSnapshotModel: '',
     patternDetectionModel: '',

--- a/src/main/ui/zip.test.ts
+++ b/src/main/ui/zip.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import * as fsPromises from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { open as openZip } from 'yauzl'
+import { open as openZip, type Entry } from 'yauzl'
 import { buildTimestampedZipName, createZipWithFiles, ensureZipExtension } from './zip'
 
 function listZipEntries(zipPath: string): Promise<string[]> {
@@ -26,7 +26,7 @@ function readZipEntry(zipPath: string, entryName: string): Promise<string> {
   return new Promise((resolve, reject) => {
     openZip(zipPath, { lazyEntries: true }, (err, zip) => {
       if (err || !zip) return reject(err ?? new Error('failed to open zip'))
-      zip.on('entry', (entry: { fileName: string }) => {
+      zip.on('entry', (entry: Entry) => {
         if (entry.fileName !== entryName) return zip.readEntry()
         zip.openReadStream(entry, (streamErr, stream) => {
           if (streamErr || !stream) return reject(streamErr ?? new Error('failed to read entry'))

--- a/src/renderer/pages/main-window/pages/SettingsPage.tsx
+++ b/src/renderer/pages/main-window/pages/SettingsPage.tsx
@@ -74,7 +74,8 @@ export function SettingsPage({
   const commitNumericSetting = useCallback(
     (key: NumericCaptureSetting, value: number): void => {
       setForm((prev) => (prev ? { ...prev, [key]: value } : prev))
-      save({ [key]: value } as Pick<CaptureSettings, NumericCaptureSetting>)
+      const patch: Partial<Pick<CaptureSettings, NumericCaptureSetting>> = { [key]: value }
+      save(patch)
     },
     [save],
   )

--- a/src/renderer/ua-data.d.ts
+++ b/src/renderer/ua-data.d.ts
@@ -1,0 +1,6 @@
+// navigator.userAgentData is not yet in TypeScript's DOM lib.
+interface Navigator {
+  readonly userAgentData?: {
+    readonly platform?: string
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -200,7 +200,16 @@ export interface ObservationState {
   }
 }
 
-export type { ActivityDetail } from '../main/storage/types'
+/** Activity with window context but without heavy ocr_text and vector fields. */
+export interface ActivityDetail {
+  id: string
+  startTimestamp: number
+  endTimestamp: number
+  appName: string
+  windowTitle: string
+  tld: string | null
+  summary: string
+}
 
 export interface ActivityDigest {
   totalCount: number

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,7 +7,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@main/*": ["./src/main/*"],
-      "@constants": ["./src/shared/constants"]
+      "@constants": ["./src/shared/constants"],
+      "@types": ["./src/shared/types"]
     }
   },
   "include": ["src/main/**/*", "src/preload/**/*", "src/shared/**/*", "electron.vite.config.ts"]


### PR DESCRIPTION
## Summary

Fixes all 30 pre-existing `tsc --noEmit` errors except the 15 fetch-mock ones that #223 already fixes on its branch. Once both PRs merge, `tsc --noEmit` is fully green on both tsconfig projects.

Config and shared types:
- Add the missing `@types` path alias to `tsconfig.node.json` (was only in the root and web configs) — unblocks `cluster-view.ts`, `apply-review.ts`, `cluster-review-score.ts` and the downstream implicit-any errors in `cluster-view.test.ts`.
- Move `ActivityDetail` into `src/shared/types.ts` (storage re-exports it for main-side imports). Fixes the "re-export doesn't bind a local name" TS2304 and the web project's TS6307 from shared code reaching into `src/main`.

Production code:
- New optional-parent dialog wrappers (`src/main/ui/dialogs.ts`): Electron's `dialog.show*` accepts a window or no argument but not `undefined`; the 7 call sites passing `parentWindow ?? undefined` now route through the wrappers.
- `upload-prep-worker`: explicit `ArrayBuffer` copy instead of `buf.buffer.slice(...)`, which is typed `ArrayBuffer | SharedArrayBuffer`.
- Drop the unused `deviceId` param of `scheduleTokenRefresh` and a dead Buffer branch in `installed-apps` (with `encoding: 'utf-8'`, `execFile` output is always a string).
- Ambient declaration for the experimental `navigator.userAgentData` (renderer).
- `SettingsPage`: typed numeric-setting patch object instead of a non-overlapping cast.

Tests:
- Definite-assignment promise gates in `activity-extractor.test.ts` (the `let x: fn | null` pattern narrows to `null` at the call site).
- `InMemoryStream<Frame>` type params in `screen-capturer.test.ts`.
- yauzl `Entry` annotation in `zip.test.ts`.
- `CaptureSettings` fixtures gain the required `modelsByVendor`/`newTaskMinerEnabled` fields.

## Test plan

- [x] Full suite: 1131 tests pass
- [x] `tsc --noEmit` node project: only the 15 errors owned by #223 remain; web project: 0 errors
- [x] `npm run lint`: 0 errors (the 34 better-sqlite3 warnings are silenced on the #223 branch)
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)