### PR TITLE
refactor(storage): use @types alias for ActivityDetail re-export

### DIFF
--- a/src/main/storage/types.ts
+++ b/src/main/storage/types.ts
@@ -21,4 +21,4 @@ export interface ActivitySummary {
   summary: string
 }
 
-export type { ActivityDetail } from '../../shared/types'
+export type { ActivityDetail } from '@types'


### PR DESCRIPTION
Follow-up to #224: the `ActivityDetail` re-export in `src/main/storage/types.ts` used a deep relative path; use the `@types` alias (available in `tsconfig.node.json` since #224). Type-only, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)