### PR TITLE
feat(mcp): serve task-mining clusters from the pattern tools

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -211,6 +211,54 @@ describe('command handlers', () => {
       activityIds: ['act-3'],
       confidence: 0.9,
     })
+
+    // Seed a task cluster with two member sightings (recent, inside the stats window)
+    const now = Date.now()
+    const HOUR_MS = 60 * 60 * 1000
+    storage.clusters.create({
+      id: 'clu-1',
+      label: 'Code Review',
+      description: 'Reviewing PRs on GitHub',
+      centroid: null,
+      kind: 'procedure',
+      mechanism: 'Automate with gh CLI',
+      labelModel: '',
+      labeledSize: 2,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const sightings = [
+      {
+        id: 'clu-sight-old',
+        title: 'Code Review',
+        subject: 'PR 41',
+        description: 'Reviewed a pull request',
+        apps: ['Chrome'],
+        activityIds: ['act-1'],
+        startedAt: now - 5 * HOUR_MS,
+        endedAt: now - 4 * HOUR_MS,
+        interactionMin: 6,
+        runId: 'run-1',
+        detectedAt: now - 4 * HOUR_MS,
+      },
+      {
+        id: 'clu-sight-new',
+        title: 'Code Review',
+        subject: 'PR 42',
+        description: 'Reviewed a pull request',
+        apps: ['Chrome'],
+        activityIds: ['act-3'],
+        startedAt: now - 2 * HOUR_MS,
+        endedAt: now - HOUR_MS,
+        interactionMin: 4,
+        runId: 'run-1',
+        detectedAt: now - HOUR_MS,
+      },
+    ]
+    for (const s of sightings) {
+      storage.sightings.add(s)
+      storage.clusters.addMembership('clu-1', s.id, now)
+    }
   })
 
   afterEach(() => {
@@ -369,53 +417,38 @@ describe('command handlers', () => {
   // -- patterns --
 
   describe('cmdPatterns', () => {
-    it('should return all patterns', async () => {
-      const result = (await cmdPatterns([], storage)) as Array<Record<string, unknown>>
-      expect(result.length).toBe(1)
-      expect(result[0].name).toBe('Code Review')
-      expect(result[0].sightingCount).toBe(1)
+    it('should return the clusters view', async () => {
+      const result = (await cmdPatterns([], storage)) as Record<string, unknown>
+      const clusters = result.clusters as Array<Record<string, unknown>>
+      expect(clusters.length).toBe(1)
+      expect(clusters[0].id).toBe('clu-1')
+      expect(clusters[0].title).toBe('Code Review')
+      expect(clusters[0].timesSeen).toBe(2)
+      expect(result.hiddenCount).toBe(0)
     })
 
-    it('should search patterns by --query', async () => {
-      const result = (await cmdPatterns(['--query', 'Review'], storage)) as Array<
-        Record<string, unknown>
-      >
-      expect(result.length).toBe(1)
+    it('should filter by --query case-insensitively', async () => {
+      const result = (await cmdPatterns(['--query', 'GH CLI'], storage)) as Record<string, unknown>
+      expect((result.clusters as unknown[]).length).toBe(1)
     })
 
     it('should return empty for non-matching query', async () => {
-      const result = (await cmdPatterns(['--query', 'zzzzz'], storage)) as unknown[]
-      expect(result.length).toBe(0)
+      const result = (await cmdPatterns(['--query', 'zzzzz'], storage)) as Record<string, unknown>
+      expect((result.clusters as unknown[]).length).toBe(0)
     })
   })
 
   // -- pattern --
 
   describe('cmdPattern', () => {
-    it('should return pattern by id', async () => {
-      const result = (await cmdPattern(['pat-1'], storage)) as Record<string, unknown>
+    it('should return pattern info with runs newest-first', async () => {
+      const result = (await cmdPattern(['clu-1'], storage)) as Record<string, unknown>
       const pattern = result.pattern as Record<string, unknown>
-      expect(pattern.id).toBe('pat-1')
-      expect(pattern.name).toBe('Code Review')
-    })
-
-    it('should include sightings when --run-id is given', async () => {
-      const result = (await cmdPattern(['pat-1', '--run-id', 'run-abc'], storage)) as Record<
-        string,
-        unknown
-      >
-      expect(result.pattern).toBeDefined()
-      const sightings = result.sightings as Array<Record<string, unknown>>
-      expect(sightings.length).toBe(1)
-      expect(sightings[0].evidence).toBe('Saw PR review')
-    })
-
-    it('should return empty sightings for unknown run-id', async () => {
-      const result = (await cmdPattern(['pat-1', '--run-id', 'run-xxx'], storage)) as Record<
-        string,
-        unknown
-      >
-      expect((result.sightings as unknown[]).length).toBe(0)
+      expect(pattern.id).toBe('clu-1')
+      expect(pattern.title).toBe('Code Review')
+      expect(pattern.timesSeen).toBe(2)
+      const runs = result.runs as Array<Record<string, unknown>>
+      expect(runs.map((r) => r.id)).toEqual(['clu-sight-new', 'clu-sight-old'])
     })
 
     it('should throw for unknown pattern id', async () => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -436,6 +436,18 @@ describe('command handlers', () => {
       const result = (await cmdPatterns(['--query', 'zzzzz'], storage)) as Record<string, unknown>
       expect((result.clusters as unknown[]).length).toBe(0)
     })
+
+    it('should fail with the friendly hint when cluster tables are missing', async () => {
+      const barePath = path.join(os.tmpdir(), 'temp_cli_unmigrated_test.db')
+      deleteDbFiles(barePath)
+      const bare = new StorageService(barePath)
+      try {
+        await expect(cmdPatterns([], bare)).rejects.toThrow('Task-mining tables not found')
+      } finally {
+        bare.close()
+        deleteDbFiles(barePath)
+      }
+    })
   })
 
   // -- pattern --
@@ -447,6 +459,29 @@ describe('command handlers', () => {
       expect(pattern.id).toBe('clu-1')
       expect(pattern.title).toBe('Code Review')
       expect(pattern.timesSeen).toBe(2)
+      const runs = result.runs as Array<Record<string, unknown>>
+      expect(runs.map((r) => r.id)).toEqual(['clu-sight-new', 'clu-sight-old'])
+    })
+
+    it('should exclude runs outside the stats window', async () => {
+      const staleStart = Date.now() - 100 * 24 * 60 * 60 * 1000
+      storage.sightings.add({
+        id: 'clu-sight-stale',
+        title: 'Code Review',
+        subject: 'PR 1',
+        description: 'Reviewed a pull request',
+        apps: ['Chrome'],
+        activityIds: ['act-1'],
+        startedAt: staleStart,
+        endedAt: staleStart + 60 * 60 * 1000,
+        interactionMin: 5,
+        runId: 'run-0',
+        detectedAt: staleStart,
+      })
+      storage.clusters.addMembership('clu-1', 'clu-sight-stale', staleStart)
+
+      const result = (await cmdPattern(['clu-1'], storage)) as Record<string, unknown>
+      expect((result.pattern as Record<string, unknown>).timesSeen).toBe(2)
       const runs = result.runs as Array<Record<string, unknown>>
       expect(runs.map((r) => r.id)).toEqual(['clu-sight-new', 'clu-sight-old'])
     })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ setLogger({ debug: noop, info: noop })
 import * as fs from 'fs'
 import * as path from 'path'
 import { StorageService } from '@main/storage'
+import { buildClusterInfo, computeClustersView, countObservedDays } from '@main/ui/cluster-view'
 import { getDefaultDbPath } from '@main/utils/paths'
 import { parseTimeString } from '@main/mcp/parse-time'
 import { sampleEntries } from '@main/mcp/formatting'
@@ -205,28 +206,30 @@ export async function cmdPatterns(rest: string[], storage: StorageService): Prom
   const { flags } = parseFlags(rest)
   const query = flags.query as string | undefined
 
-  if (query) {
-    return storage.patterns.searchPatterns(query)
-  }
-  return storage.patterns.getAllPatterns()
+  const { clusters, hiddenCount, observedDays } = computeClustersView(storage, Date.now())
+  if (!query) return { observedDays, hiddenCount, clusters }
+
+  const q = query.toLowerCase()
+  const matches = clusters.filter((c) =>
+    [c.title, c.description, c.mechanism, c.apps.join(' ')].some((field) =>
+      field.toLowerCase().includes(q),
+    ),
+  )
+  return { observedDays, hiddenCount, clusters: matches }
 }
 
 export async function cmdPattern(rest: string[], storage: StorageService): Promise<unknown> {
-  const { flags, positional } = parseFlags(rest)
-  if (positional.length === 0) fail('Usage: pattern <id> [--run-id ID]')
+  const { positional } = parseFlags(rest)
+  if (positional.length === 0) fail('Usage: pattern <id>')
 
   const id = positional[0]
-  const pattern = storage.patterns.getPatternById(id)
-  if (!pattern) fail(`Pattern not found: ${id}`)
+  const cluster = storage.clusters.getById(id)
+  if (!cluster) fail(`Pattern not found: ${id}`)
 
-  const runId = flags['run-id'] as string | undefined
-  const result: Record<string, unknown> = { pattern }
-
-  if (runId) {
-    result.sightings = storage.patterns.getSightingsByRunId(runId)
-  }
-
-  return result
+  const now = Date.now()
+  const members = storage.clusters.getMembers(id) // started_at ASC
+  const pattern = buildClusterInfo(cluster, members, countObservedDays(storage, now), now)
+  return { pattern, runs: members.slice().reverse() }
 }
 
 // ---------------------------------------------------------------------------
@@ -264,8 +267,8 @@ Commands:
   search <query>               Search activities (FTS, vector, or both)
   timeline                     List activities by time range
   activity <id...>             Get activity details by ID(s)
-  patterns                     List detected patterns
-  pattern <id>                 Get pattern details and sightings
+  patterns                     List recurring task patterns
+  pattern <id>                 Get pattern details and runs
   set-db <path>                Save database path to config
   get-db                       Show resolved database path
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,15 @@ setLogger({ debug: noop, info: noop })
 import * as fs from 'fs'
 import * as path from 'path'
 import { StorageService } from '@main/storage'
-import { buildClusterInfo, computeClustersView, countObservedDays } from '@main/ui/cluster-view'
+import {
+  buildClusterInfo,
+  computeClustersView,
+  countObservedDays,
+  filterClusters,
+  isMissingClusterTables,
+  statsWindowStart,
+  MISSING_TABLES_TEXT,
+} from '@main/ui/cluster-view'
 import { getDefaultDbPath } from '@main/utils/paths'
 import { parseTimeString } from '@main/mcp/parse-time'
 import { sampleEntries } from '@main/mcp/formatting'
@@ -202,20 +210,25 @@ export async function cmdActivity(rest: string[], storage: StorageService): Prom
   return activities
 }
 
+/** Rethrows as a friendly CliError when the DB predates the cluster tables. */
+function withClusterTables<T>(read: () => T): T {
+  try {
+    return read()
+  } catch (err) {
+    if (isMissingClusterTables(err)) fail(MISSING_TABLES_TEXT)
+    throw err
+  }
+}
+
 export async function cmdPatterns(rest: string[], storage: StorageService): Promise<unknown> {
   const { flags } = parseFlags(rest)
   const query = flags.query as string | undefined
 
-  const { clusters, hiddenCount, observedDays } = computeClustersView(storage, Date.now())
-  if (!query) return { observedDays, hiddenCount, clusters }
-
-  const q = query.toLowerCase()
-  const matches = clusters.filter((c) =>
-    [c.title, c.description, c.mechanism, c.apps.join(' ')].some((field) =>
-      field.toLowerCase().includes(q),
-    ),
+  const { clusters, hiddenCount, observedDays } = withClusterTables(() =>
+    computeClustersView(storage, Date.now()),
   )
-  return { observedDays, hiddenCount, clusters: matches }
+  if (!query) return { observedDays, hiddenCount, clusters }
+  return { observedDays, hiddenCount, clusters: filterClusters(clusters, query) }
 }
 
 export async function cmdPattern(rest: string[], storage: StorageService): Promise<unknown> {
@@ -223,13 +236,15 @@ export async function cmdPattern(rest: string[], storage: StorageService): Promi
   if (positional.length === 0) fail('Usage: pattern <id>')
 
   const id = positional[0]
-  const cluster = storage.clusters.getById(id)
+  const cluster = withClusterTables(() => storage.clusters.getById(id))
   if (!cluster) fail(`Pattern not found: ${id}`)
 
   const now = Date.now()
   const members = storage.clusters.getMembers(id) // started_at ASC
   const pattern = buildClusterInfo(cluster, members, countObservedDays(storage, now), now)
-  return { pattern, runs: members.slice().reverse() }
+  // Same window as the stats, so pattern.timesSeen matches runs.length.
+  const runs = members.filter((m) => m.startedAt >= statsWindowStart(now)).reverse()
+  return { pattern, runs }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,7 +5,9 @@
     "rootDir": "../..",
     "declaration": false,
     "paths": {
-      "@main/*": ["../../src/main/*"]
+      "@main/*": ["../../src/main/*"],
+      "@/*": ["../../src/*"],
+      "@types": ["../../src/shared/types"]
     }
   },
   "include": ["src/**/*", "../../src/main/**/*"]

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   esbuildOptions(options) {
     options.alias = {
       '@main': path.resolve(__dirname, '../../src/main'),
+      '@': path.resolve(__dirname, '../../src'),
     }
   },
   external: ['better-sqlite3', 'sqlite-vec', '@huggingface/transformers', 'onnxruntime-node'],

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     options.alias = {
       '@main': path.resolve(__dirname, '../../src/main'),
       '@': path.resolve(__dirname, '../../src'),
+      '@types': path.resolve(__dirname, '../../src/shared/types'),
     }
   },
   external: ['better-sqlite3', 'sqlite-vec', '@huggingface/transformers', 'onnxruntime-node'],

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@main': resolve(__dirname, '../../src/main'),
+      '@types': resolve(__dirname, '../../src/shared/types'),
+      '@': resolve(__dirname, '../../src'),
     },
   },
   test: {

--- a/src/main/mcp/prompts.ts
+++ b/src/main/mcp/prompts.ts
@@ -121,12 +121,12 @@ export function registerPrompts(server: McpServer): void {
               text:
                 `Look at my detected workflow patterns and automate everything you can.${focusLine}\n\n` +
                 '## Step 1 — Discover\n\n' +
-                'Call list_patterns to get all detected patterns with stats.\n' +
-                'For the top patterns (by sighting count), call get_pattern_details to ' +
-                'understand the evidence and the automation idea already stored with the pattern.\n' +
-                'For the highest-confidence sightings, call get_activity_details on their activity IDs ' +
+                'Call list_patterns to get all recurring task patterns with stats.\n' +
+                'For the top patterns (by times seen), call get_pattern_details to ' +
+                'see the individual runs and the "Replace with" recommendation stored with the pattern.\n' +
+                'For recent runs, call get_activity_details on their activity IDs ' +
                 'to read the OCR evidence — this shows exactly what was on screen.\n' +
-                'If a pattern is still unclear, use browse_timeline around the sighting timestamps ' +
+                'If a pattern is still unclear, use browse_timeline around the run timestamps ' +
                 '(±15 minutes) to see what happened before and after for more context.\n\n' +
                 '## Step 2 — Check existing skills\n\n' +
                 'Before creating anything, check what skills already exist. ' +
@@ -138,7 +138,7 @@ export function registerPrompts(server: McpServer): void {
                 '- **Automatable**: You can build a skill that does the thing (or most of it) ' +
                 'next time it comes up. Proceed to step 4.\n' +
                 '- **Not automatable**: The pattern is just normal work, requires too much ' +
-                'creative judgment, or has fewer than 2 sightings. Skip it — mention it in ' +
+                'creative judgment, or has fewer than 2 runs. Skip it — mention it in ' +
                 'the summary with a one-line reason.\n\n' +
                 'Be honest. "User writes code in VS Code" is not automatable. ' +
                 '"User copies Jira ticket ID, creates git branch, opens PR template" is.\n\n' +
@@ -146,8 +146,8 @@ export function registerPrompts(server: McpServer): void {
                 'For each automatable pattern, use the skill-creator skill you have to create a new skill. ' +
                 'Provide it with a clear description of what the skill should do, based on:\n' +
                 '- The pattern name and description\n' +
-                '- The automation_idea stored in the pattern\n' +
-                '- Any additional context from sightings or activity details\n\n' +
+                '- The "Replace with" recommendation stored with the pattern (when present)\n' +
+                '- Any additional context from runs or activity details\n\n' +
                 'Let the skill-creator handle the file format and placement. ' +
                 'Just give it the best possible brief of what the skill needs to accomplish.\n\n' +
                 '## Step 5 — Report\n\n' +

--- a/src/main/mcp/server.ts
+++ b/src/main/mcp/server.ts
@@ -50,12 +50,13 @@ Results are ranked by semantic relevance and return summary-first context, inclu
 - **get_activity_details** — fetch full activity details including OCR screen text \
 for specific activity IDs returned by the other tools. Use this only when exact \
 on-screen text is needed; do not use OCR as the primary source for inferring user activity.
-- **list_patterns** — show all detected workflow patterns with sighting counts. \
-Use for "what patterns have you found?", "show my habits", or pattern review prompts.
-- **search_patterns** — find patterns matching a keyword. Use when the user asks \
-about patterns involving a specific app or workflow.
-- **get_pattern_details** — drill into a specific pattern to see its evidence and \
-sightings. Use after list_patterns or search_patterns.
+- **list_patterns** — show recurring tasks mined from screen activity, with \
+frequency and time stats. Use for "what do I do repeatedly?", "show my habits", \
+or automation review prompts.
+- **search_patterns** — find recurring tasks matching a keyword. Use when the user \
+asks about patterns involving a specific app or workflow.
+- **get_pattern_details** — drill into one recurring task to see its individual \
+runs and their activity IDs. Use after list_patterns or search_patterns.
 - **get_user_context** — retrieve the auto-generated user profile for grounding context. \
 Consider calling it early in a conversation for personalized responses, but don't \
 over-anchor on it.
@@ -66,7 +67,7 @@ over-anchor on it.
 2. Exact-text question: search_context/browse_timeline → get_activity_details on key IDs → quote OCR text.
 3. Drill-down: start broad with browse_timeline, then refine with search_context.
 4. Mixed question: use summaries for narrative and OCR only for precise supporting details.
-5. Automate patterns: list_patterns → get_pattern_details → write .claude/skills/ for each automatable pattern.
+5. Automate patterns: list_patterns → get_pattern_details → get_activity_details on a run's activity IDs → write .claude/skills/ for each automatable pattern.
 
 ## Tips
 

--- a/src/main/mcp/tools.test.ts
+++ b/src/main/mcp/tools.test.ts
@@ -1,11 +1,23 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import * as os from 'os'
+import * as path from 'path'
 // eslint-disable-next-line import/no-unresolved
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { registerTools, type EditionContext } from './tools'
+import { registerTools, type EditionContext, type MCPServices } from './tools'
+import { StorageService, type Cluster, type Sighting } from '../storage'
+import { applyMigrations } from '../storage/migrator'
+import { deleteDbFiles } from '../storage/test-utils'
+import type { EmbeddingService } from '../processor/embedding'
 
-type Handler = (args: unknown) => Promise<{ content: { type: string; text: string }[] }>
+type Handler = (args: unknown) => Promise<{
+  content: { type: string; text: string }[]
+  isError?: boolean
+}>
 
-function registerWithMockServer(ctx: EditionContext): Map<string, Handler> {
+function registerWithMockServer(
+  ctx: EditionContext,
+  getServices: () => MCPServices | null = () => null,
+): Map<string, Handler> {
   const handlers = new Map<string, Handler>()
   const mockServer = {
     registerTool: (name: string, _meta: unknown, handler: Handler): void => {
@@ -15,7 +27,7 @@ function registerWithMockServer(ctx: EditionContext): Map<string, Handler> {
 
   registerTools(
     mockServer,
-    () => null,
+    getServices,
     async () => {},
     () => ctx,
   )
@@ -61,5 +73,233 @@ describe('get_db_path tool', () => {
     expect(payload.path).toBe('/tmp/custom.db')
     expect(payload.defaultForEdition).not.toMatch(/Enterprise/)
     expect(payload.defaultForEdition).toMatch(/MemoryLane(-dev)?[\\/]memorylane(?:-dev)?\.db$/)
+  })
+})
+
+describe('pattern tools (task clusters)', () => {
+  const TEST_DB_PATH = path.join(os.tmpdir(), 'temp_mcp_tools_test.db')
+  const ctx: EditionContext = {
+    edition: 'customer',
+    source: 'default',
+    currentDbPath: TEST_DB_PATH,
+  }
+  let storage: StorageService
+  let handlers: Map<string, Handler>
+
+  const HOUR_MS = 60 * 60 * 1000
+  const now = Date.now()
+
+  const createSighting = (overrides: Partial<Sighting> & { id: string }): Sighting => ({
+    id: overrides.id,
+    title: overrides.title ?? 'Test sighting',
+    subject: overrides.subject ?? '',
+    description: overrides.description ?? 'Did the thing',
+    apps: overrides.apps ?? ['TestApp'],
+    activityIds: overrides.activityIds ?? ['act-1'],
+    startedAt: overrides.startedAt ?? now - 2 * HOUR_MS,
+    endedAt: overrides.endedAt ?? now - HOUR_MS,
+    interactionMin: overrides.interactionMin ?? 5,
+    runId: overrides.runId ?? 'run-1',
+    detectedAt: overrides.detectedAt ?? now - HOUR_MS,
+  })
+
+  const createCluster = (overrides: Partial<Cluster> & { id: string }): Cluster => ({
+    id: overrides.id,
+    label: overrides.label ?? '',
+    description: overrides.description ?? '',
+    centroid: overrides.centroid ?? null,
+    kind: overrides.kind ?? '',
+    mechanism: overrides.mechanism ?? '',
+    labelModel: overrides.labelModel ?? '',
+    labeledSize: overrides.labeledSize ?? 0,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  })
+
+  const addClusterWithMembers = (cluster: Cluster, sightings: Sighting[]): void => {
+    storage.clusters.create(cluster)
+    for (const s of sightings) {
+      storage.sightings.add(s)
+      storage.clusters.addMembership(cluster.id, s.id, now)
+    }
+  }
+
+  beforeEach(() => {
+    deleteDbFiles(TEST_DB_PATH)
+    storage = new StorageService(TEST_DB_PATH)
+    applyMigrations(storage.getDatabase())
+    const services: MCPServices = { storage, embeddingService: {} as EmbeddingService }
+    handlers = registerWithMockServer(ctx, () => services)
+  })
+
+  afterEach(() => {
+    storage.close()
+    deleteDbFiles(TEST_DB_PATH)
+  })
+
+  describe('list_patterns', () => {
+    it('returns the mining empty state when no clusters exist', async () => {
+      const result = await handlers.get('list_patterns')!({})
+      expect(result.isError).toBeUndefined()
+      expect(result.content[0].text).toContain('No recurring task patterns found yet')
+    })
+
+    it('lists a labeled cluster with stats and apps', async () => {
+      addClusterWithMembers(
+        createCluster({ id: 'c1', label: 'Invoice processing', description: 'Copies totals' }),
+        [
+          createSighting({ id: 's1', apps: ['Excel'], interactionMin: 4 }),
+          createSighting({ id: 's2', apps: ['Excel', 'Chrome'], interactionMin: 8 }),
+        ],
+      )
+
+      const text = (await handlers.get('list_patterns')!({})).content[0].text
+      expect(text).toContain('1 recurring task pattern')
+      expect(text).toContain('c1 | Invoice processing')
+      expect(text).toContain('Excel, Chrome')
+      expect(text).toContain('seen 2x')
+      expect(text).toContain('avg 6 min active/run')
+      expect(text).toContain('Copies totals')
+    })
+
+    it('falls back to the most common member title for unlabeled clusters', async () => {
+      addClusterWithMembers(createCluster({ id: 'c1', label: '' }), [
+        createSighting({ id: 's1', title: 'Weekly report', interactionMin: 15 }),
+        createSighting({ id: 's2', title: 'Weekly report', interactionMin: 15 }),
+        createSighting({ id: 's3', title: 'Other thing', interactionMin: 15 }),
+      ])
+
+      const text = (await handlers.get('list_patterns')!({})).content[0].text
+      expect(text).toContain('c1 | Weekly report')
+    })
+
+    it('hides one-off noise clusters and reports the hidden count', async () => {
+      addClusterWithMembers(createCluster({ id: 'c-noise' }), [
+        createSighting({ id: 's1', interactionMin: 5 }),
+      ])
+      addClusterWithMembers(createCluster({ id: 'c-real', label: 'Real task' }), [
+        createSighting({ id: 's2' }),
+        createSighting({ id: 's3' }),
+      ])
+
+      const text = (await handlers.get('list_patterns')!({})).content[0].text
+      expect(text).toContain('1 recurring task pattern (1 hidden as one-off noise)')
+      expect(text).toContain('c-real')
+      expect(text).not.toContain('c-noise')
+    })
+
+    it('renders kind and the Replace with recommendation', async () => {
+      addClusterWithMembers(
+        createCluster({ id: 'c1', kind: 'procedure', mechanism: 'A script that fills the form' }),
+        [createSighting({ id: 's1' }), createSighting({ id: 's2' })],
+      )
+
+      const text = (await handlers.get('list_patterns')!({})).content[0].text
+      expect(text).toContain('Kind: procedure | Replace with: A script that fills the form')
+    })
+  })
+
+  describe('search_patterns', () => {
+    beforeEach(() => {
+      addClusterWithMembers(
+        createCluster({
+          id: 'c1',
+          label: 'Invoice processing',
+          description: 'Copies totals into the ledger',
+          mechanism: 'Automate with a spreadsheet macro',
+        }),
+        [
+          createSighting({ id: 's1', apps: ['Excel'] }),
+          createSighting({ id: 's2', apps: ['Excel'] }),
+        ],
+      )
+    })
+
+    it.each([
+      ['title', 'INVOICE'],
+      ['description', 'ledger'],
+      ['app', 'excel'],
+      ['mechanism', 'macro'],
+    ])('matches by %s case-insensitively', async (_field, query) => {
+      const text = (await handlers.get('search_patterns')!({ query })).content[0].text
+      expect(text).toContain(`1 pattern matching "${query}"`)
+      expect(text).toContain('c1')
+    })
+
+    it('reports when nothing matches', async () => {
+      const text = (await handlers.get('search_patterns')!({ query: 'zzz' })).content[0].text
+      expect(text).toBe('No patterns matching "zzz".')
+    })
+  })
+
+  describe('get_pattern_details', () => {
+    it('reports an unknown pattern ID', async () => {
+      const text = (await handlers.get('get_pattern_details')!({ patternId: 'nope' })).content[0]
+        .text
+      expect(text).toBe('No pattern found with ID "nope".')
+    })
+
+    it('returns the header plus runs newest-first with activity IDs', async () => {
+      addClusterWithMembers(createCluster({ id: 'c1', label: 'Daily standup notes' }), [
+        createSighting({
+          id: 's-old',
+          startedAt: now - 5 * HOUR_MS,
+          endedAt: now - 4 * HOUR_MS,
+          activityIds: ['act-old'],
+        }),
+        createSighting({
+          id: 's-new',
+          startedAt: now - 2 * HOUR_MS,
+          endedAt: now - HOUR_MS,
+          subject: 'sprint 12',
+          activityIds: ['act-a', 'act-b'],
+        }),
+      ])
+
+      const text = (await handlers.get('get_pattern_details')!({ patternId: 'c1' })).content[0].text
+      expect(text).toContain('c1 | Daily standup notes')
+      expect(text).toContain('Runs (2, newest first):')
+      expect(text.indexOf('s-new')).toBeLessThan(text.indexOf('s-old'))
+      expect(text).toContain('Test sighting — sprint 12')
+      expect(text).toContain('Activity IDs: act-a, act-b')
+    })
+
+    it('truncates runs to the limit, newest first', async () => {
+      addClusterWithMembers(createCluster({ id: 'c1' }), [
+        createSighting({ id: 's-old', startedAt: now - 5 * HOUR_MS, endedAt: now - 4 * HOUR_MS }),
+        createSighting({ id: 's-new', startedAt: now - 2 * HOUR_MS, endedAt: now - HOUR_MS }),
+      ])
+
+      const text = (await handlers.get('get_pattern_details')!({ patternId: 'c1', limit: 1 }))
+        .content[0].text
+      expect(text).toContain('Runs (showing 1 of 2, newest first):')
+      expect(text).toContain('s-new')
+      expect(text).not.toContain('s-old')
+    })
+  })
+
+  describe('missing task-mining tables', () => {
+    it('returns a friendly error from all three tools when the DB was never migrated', async () => {
+      const freshPath = path.join(os.tmpdir(), 'temp_mcp_tools_unmigrated_test.db')
+      deleteDbFiles(freshPath)
+      const bare = new StorageService(freshPath)
+      const services: MCPServices = { storage: bare, embeddingService: {} as EmbeddingService }
+      const bareHandlers = registerWithMockServer(ctx, () => services)
+
+      try {
+        for (const [name, args] of [
+          ['list_patterns', {}],
+          ['search_patterns', { query: 'x' }],
+          ['get_pattern_details', { patternId: 'c1' }],
+        ] as const) {
+          const result = await bareHandlers.get(name)!(args)
+          expect(result.isError).toBe(true)
+          expect(result.content[0].text).toContain('Task-mining tables not found')
+        }
+      } finally {
+        bare.close()
+        deleteDbFiles(freshPath)
+      }
+    })
   })
 })

--- a/src/main/mcp/tools.test.ts
+++ b/src/main/mcp/tools.test.ts
@@ -6,8 +6,9 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { registerTools, type EditionContext, type MCPServices } from './tools'
 import { StorageService, type Cluster, type Sighting } from '../storage'
 import { applyMigrations } from '../storage/migrator'
-import { deleteDbFiles } from '../storage/test-utils'
+import { createStoredActivity, deleteDbFiles } from '../storage/test-utils'
 import type { EmbeddingService } from '../processor/embedding'
+import { CLUSTER_VIEW_CONFIG } from '@/shared/constants'
 
 type Handler = (args: unknown) => Promise<{
   content: { type: string; text: string }[]
@@ -87,6 +88,7 @@ describe('pattern tools (task clusters)', () => {
   let handlers: Map<string, Handler>
 
   const HOUR_MS = 60 * 60 * 1000
+  const DAY_MS = 24 * HOUR_MS
   const now = Date.now()
 
   const createSighting = (overrides: Partial<Sighting> & { id: string }): Sighting => ({
@@ -142,6 +144,31 @@ describe('pattern tools (task clusters)', () => {
       const result = await handlers.get('list_patterns')!({})
       expect(result.isError).toBeUndefined()
       expect(result.content[0].text).toContain('No recurring task patterns found yet')
+    })
+
+    it('reports hidden one-offs in the empty state when all clusters are noise', async () => {
+      addClusterWithMembers(createCluster({ id: 'c-noise' }), [
+        createSighting({ id: 's1', interactionMin: 5 }),
+      ])
+
+      const text = (await handlers.get('list_patterns')!({})).content[0].text
+      expect(text).toContain('mining is working')
+      expect(text).toContain('1 task has been seen only once')
+      expect(text).not.toContain('No recurring task patterns found yet')
+    })
+
+    it('reports runs per week once activity days are observed', async () => {
+      storage.activities.add(createStoredActivity({ id: 'act-d1', startTimestamp: now - DAY_MS }))
+      storage.activities.add(
+        createStoredActivity({ id: 'act-d2', startTimestamp: now - 2 * DAY_MS }),
+      )
+      addClusterWithMembers(createCluster({ id: 'c1', label: 'Real task' }), [
+        createSighting({ id: 's1' }),
+        createSighting({ id: 's2' }),
+      ])
+
+      const text = (await handlers.get('list_patterns')!({})).content[0].text
+      expect(text).toContain('~7.0/wk over 2 observed days')
     })
 
     it('lists a labeled cluster with stats and apps', async () => {
@@ -258,7 +285,9 @@ describe('pattern tools (task clusters)', () => {
 
       const text = (await handlers.get('get_pattern_details')!({ patternId: 'c1' })).content[0].text
       expect(text).toContain('c1 | Daily standup notes')
-      expect(text).toContain('Runs (2, newest first):')
+      expect(text).toContain(
+        `Runs (2 in the last ${CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS} days, newest first):`,
+      )
       expect(text.indexOf('s-new')).toBeLessThan(text.indexOf('s-old'))
       expect(text).toContain('Test sighting — sprint 12')
       expect(text).toContain('Activity IDs: act-a, act-b')
@@ -272,9 +301,47 @@ describe('pattern tools (task clusters)', () => {
 
       const text = (await handlers.get('get_pattern_details')!({ patternId: 'c1', limit: 1 }))
         .content[0].text
-      expect(text).toContain('Runs (showing 1 of 2, newest first):')
+      expect(text).toContain(
+        `Runs (showing 1 of 2 in the last ${CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS} days, newest first):`,
+      )
       expect(text).toContain('s-new')
       expect(text).not.toContain('s-old')
+    })
+
+    it('excludes runs older than the stats window so the run count matches the header', async () => {
+      const staleStart = now - (CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS + 5) * DAY_MS
+      addClusterWithMembers(createCluster({ id: 'c1' }), [
+        createSighting({
+          id: 's-stale',
+          startedAt: staleStart,
+          endedAt: staleStart + HOUR_MS,
+          detectedAt: staleStart + HOUR_MS,
+        }),
+        createSighting({ id: 's-recent' }),
+      ])
+
+      const text = (await handlers.get('get_pattern_details')!({ patternId: 'c1' })).content[0].text
+      expect(text).toContain('seen 1x')
+      expect(text).toContain(
+        `Runs (1 in the last ${CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS} days, newest first):`,
+      )
+      expect(text).not.toContain('s-stale')
+    })
+
+    it('distinguishes a stale cluster from one with no runs at all', async () => {
+      const staleStart = now - (CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS + 5) * DAY_MS
+      addClusterWithMembers(createCluster({ id: 'c-stale' }), [
+        createSighting({
+          id: 's-stale',
+          startedAt: staleStart,
+          endedAt: staleStart + HOUR_MS,
+          detectedAt: staleStart + HOUR_MS,
+        }),
+      ])
+
+      const text = (await handlers.get('get_pattern_details')!({ patternId: 'c-stale' })).content[0]
+        .text
+      expect(text).toContain(`No runs in the last ${CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS} days.`)
     })
   })
 

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -14,7 +14,7 @@ import { getDefaultDbPath } from '@main/utils/paths'
 import type { AppEdition } from '../../shared/edition'
 import type { StorageService, Sighting } from '../storage'
 import type { EmbeddingService } from '../processor/embedding'
-import { buildClusterInfo, isBelowNoiseFloor, type ClusterMember } from '@main/ui/cluster-view'
+import { buildClusterInfo, computeClustersView, countObservedDays } from '@main/ui/cluster-view'
 import { CLUSTER_VIEW_CONFIG } from '@/shared/constants'
 import type { ClusterInfo } from '../../shared/types'
 import log from '@main/utils/logger'
@@ -193,7 +193,12 @@ export function registerTools(
         patternId: z
           .string()
           .describe('Pattern ID (from list_patterns or search_patterns results)'),
-        limit: z.number().optional().describe('Maximum runs to return, newest first (default: 20)'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe('Maximum runs to return, newest first (default: 20)'),
       },
     },
     (params) => handleGetPatternDetails(getServices(), params),
@@ -585,8 +590,6 @@ async function handleBrowseTimeline(
 // Pattern tool handlers
 // ---------------------------------------------------------------------------
 
-const DAY_MS = 24 * 60 * 60 * 1000
-
 const MISSING_TABLES_TEXT =
   'Task-mining tables not found in this database. Launch the MemoryLane app once ' +
   '(it creates them on startup) and let task mining run, then retry.'
@@ -594,7 +597,7 @@ const MISSING_TABLES_TEXT =
 function isMissingClusterTables(error: unknown): boolean {
   return (
     error instanceof Error &&
-    /no such table: (clusters|cluster_sightings|sightings)/.test(error.message)
+    /no such table: (clusters|cluster_sightings|sightings|mining_days)/.test(error.message)
   )
 }
 
@@ -607,40 +610,6 @@ function patternToolError(action: string, error: unknown) {
     content: [{ type: 'text' as const, text }],
     isError: true,
   }
-}
-
-function countObservedDays(storage: StorageService, now: number): number {
-  const windowStart = now - CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS * DAY_MS
-  return storage.activities.countDistinctActiveDays(windowStart, now)
-}
-
-/** ClusterInfos for all visible clusters, most frequent first, plus noise-floor hidden count. */
-function computeClusterInfos(storage: StorageService): {
-  clusters: ClusterInfo[]
-  hiddenCount: number
-  observedDays: number
-} {
-  const now = Date.now()
-  const membersByCluster = new Map<string, ClusterMember[]>()
-  for (const { clusterId, ...member } of storage.clusters.getMemberDigest()) {
-    let list = membersByCluster.get(clusterId)
-    if (!list) {
-      list = []
-      membersByCluster.set(clusterId, list)
-    }
-    list.push(member)
-  }
-  const observedDays = countObservedDays(storage, now)
-  const infos = storage.clusters
-    .getAll()
-    .map((c) => buildClusterInfo(c, membersByCluster.get(c.id) ?? [], observedDays, now))
-    // Clusters with no in-window members are dead rows awaiting cleanup, not
-    // "hidden noise" — exclude them from the view and the hidden count.
-    .filter((c) => c.timesSeen > 0)
-  const visible = infos
-    .filter((c) => !isBelowNoiseFloor(c.timesSeen, c.totalActiveMin))
-    .sort((a, b) => b.timesSeen - a.timesSeen || (b.lastSeenAt ?? 0) - (a.lastSeenAt ?? 0))
-  return { clusters: visible, hiddenCount: infos.length - visible.length, observedDays }
 }
 
 function formatClusterLine(c: ClusterInfo): string {
@@ -687,7 +656,7 @@ async function handleListPatterns(services: MCPServices | null) {
 
   try {
     const storage = services.storage
-    const { clusters, hiddenCount, observedDays } = computeClusterInfos(storage)
+    const { clusters, hiddenCount, observedDays } = computeClustersView(storage, Date.now())
 
     if (clusters.length === 0) {
       return {
@@ -733,7 +702,7 @@ async function handleSearchPatterns(services: MCPServices | null, { query }: { q
   }
 
   try {
-    const { clusters } = computeClusterInfos(services.storage)
+    const { clusters } = computeClustersView(services.storage, Date.now())
     const q = query.toLowerCase()
     const matches = clusters.filter((c) =>
       [c.title, c.description, c.mechanism, c.apps.join(' ')].some((field) =>

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -12,8 +12,11 @@ import {
 import { setDbPath, clearDbPath, type DbPathSource } from './config'
 import { getDefaultDbPath } from '@main/utils/paths'
 import type { AppEdition } from '../../shared/edition'
-import type { StorageService, PatternWithStats, PatternSighting } from '../storage'
+import type { StorageService, Sighting } from '../storage'
 import type { EmbeddingService } from '../processor/embedding'
+import { buildClusterInfo, isBelowNoiseFloor, type ClusterMember } from '@main/ui/cluster-view'
+import { CLUSTER_VIEW_CONFIG } from '@/shared/constants'
+import type { ClusterInfo } from '../../shared/types'
 import log from '@main/utils/logger'
 
 export interface MCPServices {
@@ -148,10 +151,13 @@ export function registerTools(
     'list_patterns',
     {
       description:
-        'List all detected workflow patterns with stats (sighting count, last seen, confidence). ' +
-        'Patterns are recurring behaviors identified by the pattern detector across captured screen activity. ' +
-        'Results are ordered by sighting count (most frequent first). ' +
-        'Use search_patterns for keyword filtering.',
+        'List recurring task patterns mined from captured screen activity. ' +
+        'Each pattern is a task the user performs repeatedly, with stats: times seen, ' +
+        'estimated runs per week, average active minutes per run, apps involved, and last seen. ' +
+        'Classified patterns also carry a kind (procedure, monitoring, ambient, dev-loop, judgment) ' +
+        'and a "Replace with" automation recommendation. ' +
+        'Ordered most frequent first; one-off noise is hidden. ' +
+        'Use search_patterns for keyword filtering and get_pattern_details for individual runs.',
       inputSchema: {},
     },
     () => handleListPatterns(getServices()),
@@ -161,12 +167,15 @@ export function registerTools(
     'search_patterns',
     {
       description:
-        'Search detected workflow patterns by keyword. Matches against pattern name, description, and associated apps. ' +
-        'Returns matching patterns with stats. Use list_patterns to see all patterns without filtering.',
+        'Search recurring task patterns by keyword. Case-insensitive match against the pattern ' +
+        'title, description, apps, and automation recommendation. Returns the same stats as ' +
+        'list_patterns. Use list_patterns to see all patterns without filtering.',
       inputSchema: {
         query: z
           .string()
-          .describe('Search keyword to match against pattern name, description, or apps'),
+          .describe(
+            'Keyword to match against pattern title, description, apps, or automation recommendation',
+          ),
       },
     },
     (params) => handleSearchPatterns(getServices(), params),
@@ -176,17 +185,15 @@ export function registerTools(
     'get_pattern_details',
     {
       description:
-        'Fetch a specific pattern by ID with its full details and recent sightings. ' +
-        'Each sighting includes evidence text, confidence score, and the activity IDs that triggered it. ' +
+        'Fetch one recurring task pattern by ID, with its stats and recent individual runs. ' +
+        'Each run includes its time range, active minutes, apps, what was done, and the underlying ' +
+        'activity IDs (pass those to get_activity_details for exact on-screen text). ' +
         'Use after list_patterns or search_patterns to drill into a specific pattern.',
       inputSchema: {
         patternId: z
           .string()
           .describe('Pattern ID (from list_patterns or search_patterns results)'),
-        runId: z
-          .string()
-          .optional()
-          .describe('Optional: filter sightings to a specific detection run ID'),
+        limit: z.number().optional().describe('Maximum runs to return, newest first (default: 20)'),
       },
     },
     (params) => handleGetPatternDetails(getServices(), params),
@@ -578,19 +585,91 @@ async function handleBrowseTimeline(
 // Pattern tool handlers
 // ---------------------------------------------------------------------------
 
-function formatPatternLine(p: PatternWithStats): string {
-  const sightings = `${p.sightingCount} sighting${p.sightingCount !== 1 ? 's' : ''}`
-  const lastSeen = p.lastSeenAt ? `, last seen ${new Date(p.lastSeenAt).toLocaleString()}` : ''
-  const confidence =
-    p.lastConfidence !== null ? `, confidence ${(p.lastConfidence * 100).toFixed(0)}%` : ''
-  return `- ${p.id} | ${p.name} [${p.apps.join(', ')}] (${sightings}${lastSeen}${confidence})\n  ${p.description}\n  Automation idea: ${p.automationIdea}`
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const MISSING_TABLES_TEXT =
+  'Task-mining tables not found in this database. Launch the MemoryLane app once ' +
+  '(it creates them on startup) and let task mining run, then retry.'
+
+function isMissingClusterTables(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /no such table: (clusters|cluster_sightings|sightings)/.test(error.message)
+  )
 }
 
-function formatSightingLine(s: PatternSighting): string {
-  const time = new Date(s.detectedAt).toLocaleString()
-  const confidence = `${(s.confidence * 100).toFixed(0)}%`
-  const duration = s.durationEstimateMin != null ? ` | ~${s.durationEstimateMin} min` : ''
-  return `- ${s.id} | ${time} | confidence: ${confidence}${duration} | run: ${s.runId}\n  Evidence: ${s.evidence}\n  Activity IDs: ${s.activityIds.join(', ')}`
+function patternToolError(action: string, error: unknown) {
+  log.error(`Error ${action}:`, error)
+  const text = isMissingClusterTables(error)
+    ? MISSING_TABLES_TEXT
+    : `Error ${action}: ${error instanceof Error ? error.message : String(error)}`
+  return {
+    content: [{ type: 'text' as const, text }],
+    isError: true,
+  }
+}
+
+function countObservedDays(storage: StorageService, now: number): number {
+  const windowStart = now - CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS * DAY_MS
+  return storage.activities.countDistinctActiveDays(windowStart, now)
+}
+
+/** ClusterInfos for all visible clusters, most frequent first, plus noise-floor hidden count. */
+function computeClusterInfos(storage: StorageService): {
+  clusters: ClusterInfo[]
+  hiddenCount: number
+  observedDays: number
+} {
+  const now = Date.now()
+  const membersByCluster = new Map<string, ClusterMember[]>()
+  for (const { clusterId, ...member } of storage.clusters.getMemberDigest()) {
+    let list = membersByCluster.get(clusterId)
+    if (!list) {
+      list = []
+      membersByCluster.set(clusterId, list)
+    }
+    list.push(member)
+  }
+  const observedDays = countObservedDays(storage, now)
+  const infos = storage.clusters
+    .getAll()
+    .map((c) => buildClusterInfo(c, membersByCluster.get(c.id) ?? [], observedDays, now))
+    // Clusters with no in-window members are dead rows awaiting cleanup, not
+    // "hidden noise" — exclude them from the view and the hidden count.
+    .filter((c) => c.timesSeen > 0)
+  const visible = infos
+    .filter((c) => !isBelowNoiseFloor(c.timesSeen, c.totalActiveMin))
+    .sort((a, b) => b.timesSeen - a.timesSeen || (b.lastSeenAt ?? 0) - (a.lastSeenAt ?? 0))
+  return { clusters: visible, hiddenCount: infos.length - visible.length, observedDays }
+}
+
+function formatClusterLine(c: ClusterInfo): string {
+  const stats = [`seen ${c.timesSeen}x`]
+  if (c.observedDays > 0) {
+    stats.push(`~${c.timesPerWeek.toFixed(1)}/wk over ${c.observedDays} observed days`)
+  }
+  stats.push(`avg ${Math.round(c.avgActiveMin)} min active/run`)
+  if (c.lastSeenAt) stats.push(`last seen ${new Date(c.lastSeenAt).toLocaleString()}`)
+  const lines = [`- ${c.id} | ${c.title} [${c.apps.join(', ')}] (${stats.join(', ')})`]
+  if (c.description) lines.push(`  ${c.description}`)
+  if (c.kind) {
+    lines.push(`  Kind: ${c.kind}${c.mechanism ? ` | Replace with: ${c.mechanism}` : ''}`)
+  }
+  return lines.join('\n')
+}
+
+function formatClusterSightingLine(s: Sighting): string {
+  const start = new Date(s.startedAt).toLocaleString()
+  const end = new Date(s.endedAt).toLocaleString()
+  const activeMin = Math.round(Math.max(0, s.interactionMin))
+  const title = s.subject ? `${s.title} — ${s.subject}` : s.title
+  const lines = [
+    `- ${s.id} | ${start} -> ${end} | ~${activeMin} min active | [${s.apps.join(', ')}]`,
+  ]
+  lines.push(`  ${title}`)
+  if (s.description) lines.push(`  ${s.description}`)
+  lines.push(`  Activity IDs: ${s.activityIds.join(', ')}`)
+  return lines.join('\n')
 }
 
 async function handleListPatterns(services: MCPServices | null) {
@@ -608,42 +687,35 @@ async function handleListPatterns(services: MCPServices | null) {
 
   try {
     const storage = services.storage
-    const patterns = storage.patterns.getAllPatterns()
-    const lastRun = storage.patterns.getLastRunTimestamp()
+    const { clusters, hiddenCount, observedDays } = computeClusterInfos(storage)
 
-    if (patterns.length === 0) {
+    if (clusters.length === 0) {
       return {
         content: [
           {
             type: 'text' as const,
-            text: 'No patterns detected yet. Patterns are identified by the pattern detector as it analyzes screen activity over time.',
+            text: 'No recurring task patterns found yet. Patterns are mined from captured screen activity over time (the task miner runs periodically inside the MemoryLane app).',
           },
         ],
       }
     }
 
-    const lastRunStr = lastRun ? `Last detection run: ${new Date(lastRun).toLocaleString()}` : ''
-    const formatted = patterns.map(formatPatternLine).join('\n\n')
+    const lastMined = Math.max(0, ...storage.miningDays.getAll().map((d) => d.completedAt ?? 0))
+    const lastMinedStr =
+      lastMined > 0 ? ` Last mining run: ${new Date(lastMined).toLocaleString()}` : ''
+    const hiddenStr = hiddenCount > 0 ? ` (${hiddenCount} hidden as one-off noise)` : ''
+    const formatted = clusters.map(formatClusterLine).join('\n\n')
 
     return {
       content: [
         {
           type: 'text' as const,
-          text: `${patterns.length} pattern${patterns.length !== 1 ? 's' : ''} detected. ${lastRunStr}\n\n${formatted}`,
+          text: `${clusters.length} recurring task pattern${clusters.length !== 1 ? 's' : ''}${hiddenStr}. Stats cover the last ${CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS} days (${observedDays} observed day${observedDays !== 1 ? 's' : ''}).${lastMinedStr}\n\n${formatted}`,
         },
       ],
     }
   } catch (error) {
-    log.error('Error listing patterns:', error)
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: `Error listing patterns: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    }
+    return patternToolError('listing patterns', error)
   }
 }
 
@@ -661,10 +733,15 @@ async function handleSearchPatterns(services: MCPServices | null, { query }: { q
   }
 
   try {
-    const storage = services.storage
-    const patterns = storage.patterns.searchPatterns(query)
+    const { clusters } = computeClusterInfos(services.storage)
+    const q = query.toLowerCase()
+    const matches = clusters.filter((c) =>
+      [c.title, c.description, c.mechanism, c.apps.join(' ')].some((field) =>
+        field.toLowerCase().includes(q),
+      ),
+    )
 
-    if (patterns.length === 0) {
+    if (matches.length === 0) {
       return {
         content: [
           {
@@ -675,33 +752,24 @@ async function handleSearchPatterns(services: MCPServices | null, { query }: { q
       }
     }
 
-    const formatted = patterns.map(formatPatternLine).join('\n\n')
+    const formatted = matches.map(formatClusterLine).join('\n\n')
 
     return {
       content: [
         {
           type: 'text' as const,
-          text: `${patterns.length} pattern${patterns.length !== 1 ? 's' : ''} matching "${query}":\n\n${formatted}`,
+          text: `${matches.length} pattern${matches.length !== 1 ? 's' : ''} matching "${query}":\n\n${formatted}`,
         },
       ],
     }
   } catch (error) {
-    log.error('Error searching patterns:', error)
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: `Error searching patterns: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    }
+    return patternToolError('searching patterns', error)
   }
 }
 
 async function handleGetPatternDetails(
   services: MCPServices | null,
-  { patternId, runId }: { patternId: string; runId?: string | undefined },
+  { patternId, limit }: { patternId: string; limit?: number | undefined },
 ) {
   if (!services) {
     return {
@@ -717,9 +785,9 @@ async function handleGetPatternDetails(
 
   try {
     const storage = services.storage
-    const pattern = storage.patterns.getPatternById(patternId)
+    const cluster = storage.clusters.getById(patternId)
 
-    if (!pattern) {
+    if (!cluster) {
       return {
         content: [
           {
@@ -730,47 +798,36 @@ async function handleGetPatternDetails(
       }
     }
 
-    const header = formatPatternLine(pattern)
+    const now = Date.now()
+    const members = storage.clusters.getMembers(patternId) // started_at ASC
+    const info = buildClusterInfo(cluster, members, countObservedDays(storage, now), now)
+    const header = formatClusterLine(info)
 
-    // Get sightings — optionally filtered by runId
-    let sightings: PatternSighting[] = []
-    if (runId) {
-      sightings = storage.patterns
-        .getSightingsByRunId(runId)
-        .filter((s) => s.patternId === patternId)
+    let runsSection = ''
+    if (members.length > 0) {
+      const shown = members
+        .slice()
+        .reverse()
+        .slice(0, limit ?? 20)
+      const runsHeader =
+        shown.length < members.length
+          ? `Runs (showing ${shown.length} of ${members.length}, newest first):`
+          : `Runs (${members.length}, newest first):`
+      runsSection = `\n\n${runsHeader}\n\n${shown.map(formatClusterSightingLine).join('\n\n')}`
     } else {
-      sightings = storage.patterns.getSightingsForPattern(patternId)
-    }
-
-    let sightingsSection = ''
-    if (sightings.length > 0) {
-      const formatted = sightings.map(formatSightingLine).join('\n\n')
-      sightingsSection = `\n\nSightings (${sightings.length}):\n\n${formatted}`
-    } else if (pattern.sightingCount > 0) {
-      sightingsSection = `\n\n${pattern.sightingCount} sighting(s) recorded. Use the runId parameter to view sightings from a specific detection run.`
-    } else {
-      sightingsSection = '\n\nNo sightings recorded yet.'
+      runsSection = '\n\nNo runs recorded yet.'
     }
 
     return {
       content: [
         {
           type: 'text' as const,
-          text: `Pattern details:\n\n${header}${sightingsSection}`,
+          text: `Pattern details:\n\n${header}${runsSection}`,
         },
       ],
     }
   } catch (error) {
-    log.error('Error fetching pattern details:', error)
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: `Error fetching pattern details: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    }
+    return patternToolError('fetching pattern details', error)
   }
 }
 

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -14,7 +14,15 @@ import { getDefaultDbPath } from '@main/utils/paths'
 import type { AppEdition } from '../../shared/edition'
 import type { StorageService, Sighting } from '../storage'
 import type { EmbeddingService } from '../processor/embedding'
-import { buildClusterInfo, computeClustersView, countObservedDays } from '@main/ui/cluster-view'
+import {
+  buildClusterInfo,
+  computeClustersView,
+  countObservedDays,
+  filterClusters,
+  isMissingClusterTables,
+  statsWindowStart,
+  MISSING_TABLES_TEXT,
+} from '@main/ui/cluster-view'
 import { CLUSTER_VIEW_CONFIG } from '@/shared/constants'
 import type { ClusterInfo } from '../../shared/types'
 import log from '@main/utils/logger'
@@ -185,7 +193,8 @@ export function registerTools(
     'get_pattern_details',
     {
       description:
-        'Fetch one recurring task pattern by ID, with its stats and recent individual runs. ' +
+        'Fetch one recurring task pattern by ID, with its stats and the individual runs ' +
+        'inside the stats window. ' +
         'Each run includes its time range, active minutes, apps, what was done, and the underlying ' +
         'activity IDs (pass those to get_activity_details for exact on-screen text). ' +
         'Use after list_patterns or search_patterns to drill into a specific pattern.',
@@ -590,17 +599,6 @@ async function handleBrowseTimeline(
 // Pattern tool handlers
 // ---------------------------------------------------------------------------
 
-const MISSING_TABLES_TEXT =
-  'Task-mining tables not found in this database. Launch the MemoryLane app once ' +
-  '(it creates them on startup) and let task mining run, then retry.'
-
-function isMissingClusterTables(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    /no such table: (clusters|cluster_sightings|sightings|mining_days)/.test(error.message)
-  )
-}
-
 function patternToolError(action: string, error: unknown) {
   log.error(`Error ${action}:`, error)
   const text = isMissingClusterTables(error)
@@ -659,13 +657,12 @@ async function handleListPatterns(services: MCPServices | null) {
     const { clusters, hiddenCount, observedDays } = computeClustersView(storage, Date.now())
 
     if (clusters.length === 0) {
+      const text =
+        hiddenCount > 0
+          ? `No recurring task patterns yet, but mining is working: ${hiddenCount} task${hiddenCount !== 1 ? 's have' : ' has'} been seen only once (hidden as one-off noise). Patterns appear once a task recurs.`
+          : 'No recurring task patterns found yet. Patterns are mined from captured screen activity over time (the task miner runs periodically inside the MemoryLane app).'
       return {
-        content: [
-          {
-            type: 'text' as const,
-            text: 'No recurring task patterns found yet. Patterns are mined from captured screen activity over time (the task miner runs periodically inside the MemoryLane app).',
-          },
-        ],
+        content: [{ type: 'text' as const, text }],
       }
     }
 
@@ -703,12 +700,7 @@ async function handleSearchPatterns(services: MCPServices | null, { query }: { q
 
   try {
     const { clusters } = computeClustersView(services.storage, Date.now())
-    const q = query.toLowerCase()
-    const matches = clusters.filter((c) =>
-      [c.title, c.description, c.mechanism, c.apps.join(' ')].some((field) =>
-        field.toLowerCase().includes(q),
-      ),
-    )
+    const matches = filterClusters(clusters, query)
 
     if (matches.length === 0) {
       return {
@@ -768,9 +760,14 @@ async function handleGetPatternDetails(
     }
 
     const now = Date.now()
-    const members = storage.clusters.getMembers(patternId) // started_at ASC
-    const info = buildClusterInfo(cluster, members, countObservedDays(storage, now), now)
+    const allMembers = storage.clusters.getMembers(patternId) // started_at ASC
+    const info = buildClusterInfo(cluster, allMembers, countObservedDays(storage, now), now)
     const header = formatClusterLine(info)
+
+    // Same window as the header stats, so "seen Nx" matches the run count.
+    const windowStart = statsWindowStart(now)
+    const members = allMembers.filter((m) => m.startedAt >= windowStart)
+    const windowStr = `last ${CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS} days`
 
     let runsSection = ''
     if (members.length > 0) {
@@ -780,9 +777,11 @@ async function handleGetPatternDetails(
         .slice(0, limit ?? 20)
       const runsHeader =
         shown.length < members.length
-          ? `Runs (showing ${shown.length} of ${members.length}, newest first):`
-          : `Runs (${members.length}, newest first):`
+          ? `Runs (showing ${shown.length} of ${members.length} in the ${windowStr}, newest first):`
+          : `Runs (${members.length} in the ${windowStr}, newest first):`
       runsSection = `\n\n${runsHeader}\n\n${shown.map(formatClusterSightingLine).join('\n\n')}`
+    } else if (allMembers.length > 0) {
+      runsSection = `\n\nNo runs in the ${windowStr}.`
     } else {
       runsSection = '\n\nNo runs recorded yet.'
     }

--- a/src/main/ui/cluster-view.ts
+++ b/src/main/ui/cluster-view.ts
@@ -18,6 +18,11 @@ const DAY_MS = 24 * 60 * 60 * 1000
 // 1970-01-05 (day index 4) was a Monday; anchor week buckets to it.
 const EPOCH_MONDAY_DAY = 4
 
+/** Start of the window all cluster stats (and run listings) are computed over. */
+export function statsWindowStart(now: number): number {
+  return now - CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS * DAY_MS
+}
+
 /**
  * Days since epoch of the timestamp's LOCAL calendar day — buckets must match
  * the local days the rest of the stats (observedDays, day headings) use.
@@ -128,7 +133,7 @@ export function buildClusterInfo(
 ): ClusterInfo {
   // Window the numerator to the same period as observedDays — pruning only
   // runs during mining runs, so stored members can outlive the stats window.
-  const windowStart = now - CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS * DAY_MS
+  const windowStart = statsWindowStart(now)
   const members = allMembers.filter((m) => m.startedAt >= windowStart)
   const startedAts = members.map((m) => m.startedAt)
   const spansMin = members.map((m) => Math.max(0, m.endedAt - m.startedAt) / 60_000)
@@ -181,8 +186,29 @@ export interface ClusterViewStore {
 
 /** Frequency denominator: distinct captured days in the same window sightings are retained for. */
 export function countObservedDays(store: ClusterViewStore, now: number): number {
-  const windowStart = now - CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS * DAY_MS
-  return store.activities.countDistinctActiveDays(windowStart, now)
+  return store.activities.countDistinctActiveDays(statsWindowStart(now), now)
+}
+
+/** Case-insensitive keyword filter over the fields shown in the clusters view. */
+export function filterClusters(clusters: ClusterInfo[], query: string): ClusterInfo[] {
+  const q = query.toLowerCase()
+  return clusters.filter((c) =>
+    [c.title, c.description, c.mechanism, c.apps.join(' ')].some((field) =>
+      field.toLowerCase().includes(q),
+    ),
+  )
+}
+
+export const MISSING_TABLES_TEXT =
+  'Task-mining tables not found in this database. Launch the MemoryLane app once ' +
+  '(it creates them on startup) and let task mining run, then retry.'
+
+/** The cluster tables are created by the app, not by consumers that open the DB read-only. */
+export function isMissingClusterTables(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /no such table: (clusters|cluster_sightings|sightings|mining_days)/.test(error.message)
+  )
 }
 
 /**

--- a/src/main/ui/cluster-view.ts
+++ b/src/main/ui/cluster-view.ts
@@ -6,7 +6,13 @@
  */
 
 import { CLUSTER_VIEW_CONFIG } from '@/shared/constants'
-import type { ClusterInfo, ClusterKind, RecurrenceBucket, RecurrenceUnit } from '@types'
+import type {
+  ClusterInfo,
+  ClustersView,
+  ClusterKind,
+  RecurrenceBucket,
+  RecurrenceUnit,
+} from '@types'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 // 1970-01-05 (day index 4) was a Monday; anchor week buckets to it.
@@ -154,6 +160,60 @@ export function buildClusterInfo(
     recurrence: recurrence.buckets,
     recurrenceUnit: recurrence.unit,
   }
+}
+
+/** The storage surface the clusters view reads from (satisfied by StorageService). */
+export interface ClusterViewStore {
+  clusters: {
+    getAll(): {
+      id: string
+      label: string
+      description: string
+      kind: ClusterKind
+      mechanism: string
+    }[]
+    getMemberDigest(): ({ clusterId: string } & ClusterMember)[]
+  }
+  activities: {
+    countDistinctActiveDays(windowStart: number, windowEnd: number): number
+  }
+}
+
+/** Frequency denominator: distinct captured days in the same window sightings are retained for. */
+export function countObservedDays(store: ClusterViewStore, now: number): number {
+  const windowStart = now - CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS * DAY_MS
+  return store.activities.countDistinctActiveDays(windowStart, now)
+}
+
+/**
+ * The clusters view served to both the Patterns UI and the MCP pattern tools:
+ * visible clusters (most frequent first) plus the noise-floor hidden count.
+ * One digest query for all members → stats, recurrence, title fallback (no N+1).
+ */
+export function computeClustersView(
+  store: ClusterViewStore,
+  now: number,
+): ClustersView & { observedDays: number } {
+  const membersByCluster = new Map<string, ClusterMember[]>()
+  for (const { clusterId, ...member } of store.clusters.getMemberDigest()) {
+    let list = membersByCluster.get(clusterId)
+    if (!list) {
+      list = []
+      membersByCluster.set(clusterId, list)
+    }
+    list.push(member)
+  }
+  const observedDays = countObservedDays(store, now)
+  const infos = store.clusters
+    .getAll()
+    .map((c) => buildClusterInfo(c, membersByCluster.get(c.id) ?? [], observedDays, now))
+    // Clusters with no in-window members are dead rows awaiting cleanup, not
+    // "hidden noise" — exclude them from the view and the hidden count.
+    .filter((c) => c.timesSeen > 0)
+  const visible = infos
+    .filter((c) => !isBelowNoiseFloor(c.timesSeen, c.totalActiveMin))
+    .sort((a, b) => b.timesSeen - a.timesSeen || (b.lastSeenAt ?? 0) - (a.lastSeenAt ?? 0))
+  return { clusters: visible, hiddenCount: infos.length - visible.length, observedDays }
 }
 
 /**

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -10,7 +10,7 @@ import { showOpenDialog, showSaveDialog } from '@main/ui/dialogs'
 import path from 'node:path'
 import { syncAutoStartSetting } from '@main/system/auto-start'
 import { DEFAULT_EDITION, type AppEditionConfig } from '../../shared/edition'
-import { CLUSTER_VIEW_CONFIG, PURGE_CONFIRMATION_PHRASE } from '../../shared/constants'
+import { PURGE_CONFIRMATION_PHRASE } from '../../shared/constants'
 import log from '@main/utils/logger'
 import { updateTrayMenu } from './tray'
 import { getUpdateInfo, quitAndInstall } from '@main/system/updater'
@@ -27,7 +27,7 @@ import { integrations } from '../integrations'
 import { listInstalledApps } from '../apps/installed-apps'
 import type { VendorCredentialsManager } from '../settings/vendor-credentials-manager'
 import { VENDORS } from '../../shared/types'
-import { buildClusterInfo, isBelowNoiseFloor, type ClusterMember } from './cluster-view'
+import { computeClustersView } from './cluster-view'
 import { VENDOR_PRESETS, getVendorDefaults } from '../../shared/vendor-defaults'
 import { applyVendorSwitch } from './vendor-switch'
 import { applyModelSettings } from './model-settings'
@@ -750,37 +750,11 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     return deps.accessProvider.getAccessState().customerSubscriptionStatus ?? 'idle'
   })
 
-  // Frequency denominator: distinct captured days in the same window sightings
-  // are retained for, so timesSeen and observedDays cover the same period.
-  const countObservedDays = (now: number): number => {
-    if (!deps) return 0
-    const windowStart = now - CLUSTER_VIEW_CONFIG.STATS_WINDOW_DAYS * 24 * 60 * 60 * 1000
-    return deps.storage.activities.countDistinctActiveDays(windowStart, now)
-  }
-
   // Patterns (task clusters)
   handle('main-window:getClusters', (): ClustersView => {
     if (!deps) return { clusters: [], hiddenCount: 0 }
-    // One digest query for all members → stats, recurrence, title fallback (no N+1).
-    const membersByCluster = new Map<string, ClusterMember[]>()
-    for (const { clusterId, ...member } of deps.storage.clusters.getMemberDigest()) {
-      let list = membersByCluster.get(clusterId)
-      if (!list) {
-        list = []
-        membersByCluster.set(clusterId, list)
-      }
-      list.push(member)
-    }
-    const now = Date.now()
-    const observedDays = countObservedDays(now)
-    const infos = deps.storage.clusters
-      .getAll()
-      .map((c) => buildClusterInfo(c, membersByCluster.get(c.id) ?? [], observedDays, now))
-      // Clusters with no in-window members are dead rows awaiting cleanup, not
-      // "hidden noise" — exclude them from the view and the hidden count.
-      .filter((c) => c.timesSeen > 0)
-    const visible = infos.filter((c) => !isBelowNoiseFloor(c.timesSeen, c.totalActiveMin))
-    return { clusters: visible, hiddenCount: infos.length - visible.length }
+    const { clusters, hiddenCount } = computeClustersView(deps.storage, Date.now())
+    return { clusters, hiddenCount }
   })
 
   handle('main-window:getMiningStatus', (): MiningStatus => {


### PR DESCRIPTION
## Summary

`list_patterns`, `search_patterns`, and `get_pattern_details` still read the legacy `patterns`/`pattern_sightings` tables, which stopped being written when the PatternDetector was removed in the clusters cutover — MCP clients only saw stale data. This repoints all three at the cluster read path, reusing `buildClusterInfo`/`isBelowNoiseFloor` from `cluster-view.ts` so MCP and the Patterns UI always agree.

- Tool names unchanged (no client break); descriptions rewritten for mined recurring tasks (times seen, ~runs/week, avg active min, kind, "Replace with" recommendation)
- `search_patterns`: in-memory filter over title/description/apps/mechanism (cluster counts are small)
- `get_pattern_details`: `runId` param dropped (no cluster equivalent), optional `limit` added (default 20, newest first)
- Friendly missing-tables error — the MCP process opens the DB without running migrations; cluster tables are queried before `activities` so the guard matches
- `packages/cli` gains the `@` alias: `cluster-view.ts` imports `@/shared/constants` at runtime, which the CLI bundle couldn't resolve before
- `SERVER_INSTRUCTIONS` and the (disabled) `automate_patterns` prompt updated to the new vocabulary

## Testing

- 14 new tests in `tools.test.ts` over a real temp-DB `StorageService`: empty state, title fallback, noise-floor hiding, kind/mechanism rendering, case-insensitive search on all four fields, newest-first runs with `limit` truncation, missing-tables path
- Lint, typecheck, and `packages/cli` build green
- Exercised live over stdio against the dev DB: all three tools return current mining data matching the app's Patterns page

Follow-up (separate plugin-only commit): `plugins/memorylane/skills/process-analyst-new/SKILL.md` still references the removed `durationEstimateMin` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)