### PR TITLE
ci: auto-merge Dependabot patch/minor PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+# Enable GitHub auto-merge on Dependabot PRs. Patch and minor bumps only;
+# majors wait for manual review. No PR CI exists yet, so a qualifying PR
+# merges once mergeable; if required checks are added later, auto-merge
+# will wait for them automatically.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Fetch metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/dependabot-automerge.yml` to enable GitHub auto-merge on Dependabot PRs — patch and minor bumps only; majors still wait for manual review.

Mirrors the pattern used in our other repo, adapted for this repo:
- Runner `ubuntu-24.04` (repo convention; no Blacksmith runners here)
- `dependabot/fetch-metadata` SHA-pinned per repo convention (`21025c7` # v2.5.0)

Also enabled `allow_auto_merge` on the repo (was off), which `gh pr merge --auto` requires.

**Note:** no PR CI exists yet, so a qualifying PR merges once mergeable. If required checks are added later, `--auto` will wait for them automatically with no change to this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)