### PR TITLE
feat(llm): remote model config (DEU-202)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ The `enode.sh` wrapper sets `ELECTRON_RUN_AS_NODE=1` and executes the command th
 ## UI Guidelines
 
 - Prefer React UI components (modals, toasts, inline messages) over browser-native dialogs (`alert()`, `confirm()`, `prompt()`).
+- Styling comes from the shadcn design preset <https://ui.shadcn.com/create?preset=bJMTbSgy>. Never edit the preset tokens in `src/renderer/index.css` (`:root`/`.dark`); adjust looks via component `className`s.
 
 ## Findings
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -41,10 +41,7 @@ import { readRemoteBlacklist, writeRemoteBlacklist } from './services/remote-bla
 import { RemoteModelConfigService } from './services/remote-model-config-service'
 import { readRemoteModelConfig, writeRemoteModelConfig } from './services/remote-model-config-store'
 import type { RemoteModelConfig } from '../shared/remote-model-config'
-import {
-  resolveClusterModelOverride,
-  resolveTextTaskModels,
-} from './settings/effective-model-presets'
+import { pushModelSelections } from './ui/apply-models'
 import { applyRemoteModelConfig } from './ui/remote-model-apply'
 import { DeviceReportSync } from './services/device-report-sync'
 import { readDeviceReportState, writeDeviceReportState } from './services/device-report-store'
@@ -233,31 +230,28 @@ app.on('ready', async () => {
       ? ENTERPRISE_BACKEND_CONFIG.BACKEND_URL
       : MANAGED_KEY_CONFIG.BACKEND_URL
 
+  const isEnterpriseActivated = (): boolean =>
+    runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false
+
   // Remote model config (DEU-202): constructed before the runtime so chain
-  // building can already see the disk cache; onChange is late-bound below once
-  // the miners exist, and start() only runs after that binding. Managed-key
-  // installs only — BYOK and custom endpoints keep full model control.
+  // building can already see the disk cache (loaded in the constructor);
+  // onChange is late-bound below once the miners exist, and start() only runs
+  // after that binding. Managed-key installs only — BYOK and custom endpoints
+  // keep full model control.
   const isOpenRouterManaged = (): boolean =>
     vendorCredentialsManager.getStatus('openrouter').source === 'managed'
   let applyRemoteModel: ((config: RemoteModelConfig) => void) | null = null
-  const cachedModelConfig = readRemoteModelConfig()
   remoteModelConfig = new RemoteModelConfigService({
     getDeviceId: () => deviceIdentity.getDeviceId(),
-    isActivated:
-      editionConfig.edition === 'enterprise'
-        ? () =>
-            isOpenRouterManaged() &&
-            (runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false)
-        : isOpenRouterManaged,
+    isActivated: () =>
+      isOpenRouterManaged() && (editionConfig.edition !== 'enterprise' || isEnterpriseActivated()),
     getBackendUrl: () => backendBaseUrl,
     onChange: (config) => applyRemoteModel?.(config),
     readStored: () => readRemoteModelConfig(),
     writeStored: (config) => writeRemoteModelConfig(config),
   })
-  const getRemoteModelConfig = (): RemoteModelConfig | null => {
-    if (!isOpenRouterManaged()) return null
-    return remoteModelConfig?.getConfig() ?? cachedModelConfig
-  }
+  const getRemoteModelConfig = (): RemoteModelConfig | null =>
+    isOpenRouterManaged() ? (remoteModelConfig?.getConfig() ?? null) : null
 
   runtime = await createMainRuntime({
     edition: editionConfig.edition,
@@ -293,10 +287,7 @@ app.on('ready', async () => {
   // distribution is visible server-side.
   deviceReportSync = new DeviceReportSync({
     getDeviceId: () => deviceIdentity.getDeviceId(),
-    isActivated:
-      editionConfig.edition === 'enterprise'
-        ? () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false
-        : () => true,
+    isActivated: editionConfig.edition === 'enterprise' ? isEnterpriseActivated : () => true,
     getBackendUrl: () => backendBaseUrl,
     getVersion: () => app.getVersion(),
     edition: editionConfig.edition,
@@ -309,7 +300,7 @@ app.on('ready', async () => {
     databaseUploadSync = new DatabaseUploadSync({
       storage: runtime.storage,
       getDeviceId: () => deviceIdentity.getDeviceId(),
-      isActivated: () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false,
+      isActivated: isEnterpriseActivated,
       isSyncEnabled: () => captureSettingsManager.get().uploadDetailLevel !== 'off',
       getStripOptions: () => {
         const level = captureSettingsManager.get().uploadDetailLevel
@@ -323,7 +314,7 @@ app.on('ready', async () => {
 
     logUploadSync = new LogUploadSync({
       getDeviceId: () => deviceIdentity.getDeviceId(),
-      isActivated: () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false,
+      isActivated: isEnterpriseActivated,
       isSyncEnabled: () => captureSettingsManager.get().uploadDetailLevel !== 'off',
       getBackendUrl: () => ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
       readState: () => readLogUploadState(),
@@ -333,7 +324,7 @@ app.on('ready', async () => {
 
     remoteBlacklist = new RemoteBlacklistService({
       getDeviceId: () => deviceIdentity.getDeviceId(),
-      isActivated: () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false,
+      isActivated: isEnterpriseActivated,
       getBackendUrl: () => ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
       onChange: (blacklist) => {
         runtime?.setManagedExclusions(blacklist)
@@ -346,13 +337,7 @@ app.on('ready', async () => {
   }
 
   const settings = captureSettingsManager.get()
-  const initialTextModels = resolveTextTaskModels(
-    settings.patternDetectionModel,
-    settings.activeVendor,
-    getRemoteModelConfig(),
-  )
   userContextBuilder = new UserContextBuilder(runtime.storage, runtime.inferenceProvider)
-  userContextBuilder.updateModel(initialTextModels.userContext)
   // The scheduled analyzer. The newTaskMinerEnabled developer toggle (default
   // off) picks the new TaskMiner (mining + clustering) over the legacy
   // PatternDetector. Read once here — flipping the toggle takes effect on the
@@ -361,16 +346,21 @@ app.on('ready', async () => {
   if (settings.newTaskMinerEnabled) {
     taskMiner = new TaskMiner(runtime.storage, runtime.inferenceProvider, runtime.mlWorker)
     taskMiner.setEnabled(settings.patternDetectionEnabled)
-    taskMiner.updateModel(initialTextModels.taskMining)
-    taskMiner.updateClusterModel(
-      resolveClusterModelOverride(settings.activeVendor, getRemoteModelConfig()),
-    )
   } else {
     patternDetector = new PatternDetector(runtime.storage, runtime.inferenceProvider)
     patternDetector.setEnabled(settings.patternDetectionEnabled)
-    patternDetector.updateModel(initialTextModels.taskMining)
   }
   const scheduledMiner = taskMiner ?? patternDetector
+  pushModelSelections(
+    {
+      semanticService: runtime.semanticService,
+      patternDetector: scheduledMiner ?? undefined,
+      userContextBuilder,
+      taskMiner: taskMiner ?? undefined,
+    },
+    settings,
+    getRemoteModelConfig(),
+  )
 
   // Miners exist now — bind the apply step and start syncing. The cached-load
   // notification re-applies idempotently; the first network sync follows.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,11 @@ import { LogUploadSync } from './services/log-upload-sync'
 import { readLogUploadState, writeLogUploadState } from './services/log-upload-store'
 import { RemoteBlacklistService } from './services/remote-blacklist-service'
 import { readRemoteBlacklist, writeRemoteBlacklist } from './services/remote-blacklist-store'
+import { RemoteModelConfigService } from './services/remote-model-config-service'
+import { readRemoteModelConfig, writeRemoteModelConfig } from './services/remote-model-config-store'
+import type { RemoteModelConfig } from '../shared/remote-model-config'
+import { resolveTextTaskModels } from './settings/effective-model-presets'
+import { applyRemoteModelConfig } from './ui/remote-model-apply'
 import { DeviceReportSync } from './services/device-report-sync'
 import { readDeviceReportState, writeDeviceReportState } from './services/device-report-store'
 import { createMainRuntime, type MainRuntime } from './runtime'
@@ -129,6 +134,7 @@ let rawDatabaseExportSync: RawDatabaseExportSync | null = null
 let databaseUploadSync: DatabaseUploadSync | null = null
 let logUploadSync: LogUploadSync | null = null
 let remoteBlacklist: RemoteBlacklistService | null = null
+let remoteModelConfig: RemoteModelConfigService | null = null
 let deviceReportSync: DeviceReportSync | null = null
 let observation: ObservationController | null = null
 
@@ -146,6 +152,7 @@ app.on('before-quit', (event) => {
 
   runtime?.accessProvider.stopPeriodicRefresh()
   remoteBlacklist?.stop()
+  remoteModelConfig?.stop()
   deviceReportSync?.stop()
   observation?.dispose()
 
@@ -217,6 +224,31 @@ app.on('ready', async () => {
   const { initMainWindowIPC, openMainWindow, sendStatusToRenderer, sendManagedExclusionsUpdate } =
     await import('./ui/main-window')
 
+  // Per-edition backend base URL, shared by device reporting and remote config.
+  const backendBaseUrl =
+    editionConfig.edition === 'enterprise'
+      ? ENTERPRISE_BACKEND_CONFIG.BACKEND_URL
+      : MANAGED_KEY_CONFIG.BACKEND_URL
+
+  // Remote model config (DEU-202): constructed before the runtime so chain
+  // building can already see the disk cache; onChange is late-bound below once
+  // the miners exist, and start() only runs after that binding.
+  let applyRemoteModel: ((config: RemoteModelConfig) => void) | null = null
+  const cachedModelConfig = readRemoteModelConfig()
+  remoteModelConfig = new RemoteModelConfigService({
+    getDeviceId: () => deviceIdentity.getDeviceId(),
+    isActivated:
+      editionConfig.edition === 'enterprise'
+        ? () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false
+        : () => true,
+    getBackendUrl: () => backendBaseUrl,
+    onChange: (config) => applyRemoteModel?.(config),
+    readStored: () => readRemoteModelConfig(),
+    writeStored: (config) => writeRemoteModelConfig(config),
+  })
+  const getRemoteModelConfig = (): RemoteModelConfig | null =>
+    remoteModelConfig?.getConfig() ?? cachedModelConfig
+
   runtime = await createMainRuntime({
     edition: editionConfig.edition,
     onCaptureStateChanged: () => {
@@ -232,6 +264,7 @@ app.on('ready', async () => {
     deviceIdentity,
     vendorCredentials: vendorCredentialsManager,
     getActiveVendor: () => captureSettingsManager.get().activeVendor,
+    getRemoteModelConfig,
     initialVideoModel: initialCaptureSettings.semanticVideoModel,
     initialSnapshotModel: initialCaptureSettings.semanticSnapshotModel,
   })
@@ -247,18 +280,14 @@ app.on('ready', async () => {
   rawDatabaseExportSync.start()
 
   // Report the running app version in both editions so the fleet's version
-  // distribution is visible server-side. Picks the per-edition backend base URL.
-  const reportBackendUrl =
-    editionConfig.edition === 'enterprise'
-      ? ENTERPRISE_BACKEND_CONFIG.BACKEND_URL
-      : MANAGED_KEY_CONFIG.BACKEND_URL
+  // distribution is visible server-side.
   deviceReportSync = new DeviceReportSync({
     getDeviceId: () => deviceIdentity.getDeviceId(),
     isActivated:
       editionConfig.edition === 'enterprise'
         ? () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false
         : () => true,
-    getBackendUrl: () => reportBackendUrl,
+    getBackendUrl: () => backendBaseUrl,
     getVersion: () => app.getVersion(),
     edition: editionConfig.edition,
     readStored: () => readDeviceReportState(),
@@ -306,24 +335,48 @@ app.on('ready', async () => {
     remoteBlacklist.start()
   }
 
+  const settings = captureSettingsManager.get()
+  const initialTextModels = resolveTextTaskModels(
+    settings.patternDetectionModel,
+    settings.activeVendor,
+    getRemoteModelConfig(),
+  )
   userContextBuilder = new UserContextBuilder(runtime.storage, runtime.inferenceProvider)
-  userContextBuilder.updateModel(captureSettingsManager.get().patternDetectionModel)
+  userContextBuilder.updateModel(initialTextModels.userContext)
   // The scheduled analyzer. The newTaskMinerEnabled developer toggle (default
   // off) picks the new TaskMiner (mining + clustering) over the legacy
   // PatternDetector. Read once here — flipping the toggle takes effect on the
   // next launch. Both use the patternDetection* capture settings for enable
   // state and model.
-  const settings = captureSettingsManager.get()
   if (settings.newTaskMinerEnabled) {
     taskMiner = new TaskMiner(runtime.storage, runtime.inferenceProvider, runtime.mlWorker)
     taskMiner.setEnabled(settings.patternDetectionEnabled)
-    taskMiner.updateModel(settings.patternDetectionModel)
+    taskMiner.updateModel(initialTextModels.taskMining)
+    taskMiner.updateClusterModel(getRemoteModelConfig()?.models.clusterReview?.[0] ?? null)
   } else {
     patternDetector = new PatternDetector(runtime.storage, runtime.inferenceProvider)
     patternDetector.setEnabled(settings.patternDetectionEnabled)
-    patternDetector.updateModel(settings.patternDetectionModel)
+    patternDetector.updateModel(initialTextModels.taskMining)
   }
   const scheduledMiner = taskMiner ?? patternDetector
+
+  // Miners exist now — bind the apply step and start syncing. The cached-load
+  // notification re-applies idempotently; the first network sync follows.
+  applyRemoteModel = (config) => {
+    if (!runtime) return
+    applyRemoteModelConfig(
+      {
+        semanticService: runtime.semanticService,
+        patternDetector: scheduledMiner ?? undefined,
+        userContextBuilder: userContextBuilder ?? undefined,
+        taskMiner: taskMiner ?? undefined,
+      },
+      captureSettingsManager,
+      config,
+    )
+  }
+  remoteModelConfig.start()
+
   const captureCoordinator = createCaptureCoordinator({
     capture: runtime.capture,
     captureStateManager,
@@ -428,6 +481,7 @@ app.on('ready', async () => {
     captureSettingsManager,
     patternDetector: scheduledMiner ?? undefined,
     userContextBuilder: userContextBuilder ?? undefined,
+    getRemoteModelConfig,
     getCaptureHotkeyLabel: hotkeyManager.getLabel,
     reconfigureCaptureHotkey,
     updateExclusions: (exclusions) => runtime?.updateExclusions(exclusions),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -41,7 +41,10 @@ import { readRemoteBlacklist, writeRemoteBlacklist } from './services/remote-bla
 import { RemoteModelConfigService } from './services/remote-model-config-service'
 import { readRemoteModelConfig, writeRemoteModelConfig } from './services/remote-model-config-store'
 import type { RemoteModelConfig } from '../shared/remote-model-config'
-import { resolveTextTaskModels } from './settings/effective-model-presets'
+import {
+  resolveClusterModelOverride,
+  resolveTextTaskModels,
+} from './settings/effective-model-presets'
 import { applyRemoteModelConfig } from './ui/remote-model-apply'
 import { DeviceReportSync } from './services/device-report-sync'
 import { readDeviceReportState, writeDeviceReportState } from './services/device-report-store'
@@ -232,22 +235,29 @@ app.on('ready', async () => {
 
   // Remote model config (DEU-202): constructed before the runtime so chain
   // building can already see the disk cache; onChange is late-bound below once
-  // the miners exist, and start() only runs after that binding.
+  // the miners exist, and start() only runs after that binding. Managed-key
+  // installs only — BYOK and custom endpoints keep full model control.
+  const isOpenRouterManaged = (): boolean =>
+    vendorCredentialsManager.getStatus('openrouter').source === 'managed'
   let applyRemoteModel: ((config: RemoteModelConfig) => void) | null = null
   const cachedModelConfig = readRemoteModelConfig()
   remoteModelConfig = new RemoteModelConfigService({
     getDeviceId: () => deviceIdentity.getDeviceId(),
     isActivated:
       editionConfig.edition === 'enterprise'
-        ? () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false
-        : () => true,
+        ? () =>
+            isOpenRouterManaged() &&
+            (runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false)
+        : isOpenRouterManaged,
     getBackendUrl: () => backendBaseUrl,
     onChange: (config) => applyRemoteModel?.(config),
     readStored: () => readRemoteModelConfig(),
     writeStored: (config) => writeRemoteModelConfig(config),
   })
-  const getRemoteModelConfig = (): RemoteModelConfig | null =>
-    remoteModelConfig?.getConfig() ?? cachedModelConfig
+  const getRemoteModelConfig = (): RemoteModelConfig | null => {
+    if (!isOpenRouterManaged()) return null
+    return remoteModelConfig?.getConfig() ?? cachedModelConfig
+  }
 
   runtime = await createMainRuntime({
     edition: editionConfig.edition,
@@ -352,7 +362,9 @@ app.on('ready', async () => {
     taskMiner = new TaskMiner(runtime.storage, runtime.inferenceProvider, runtime.mlWorker)
     taskMiner.setEnabled(settings.patternDetectionEnabled)
     taskMiner.updateModel(initialTextModels.taskMining)
-    taskMiner.updateClusterModel(getRemoteModelConfig()?.models.clusterReview?.[0] ?? null)
+    taskMiner.updateClusterModel(
+      resolveClusterModelOverride(settings.activeVendor, getRemoteModelConfig()),
+    )
   } else {
     patternDetector = new PatternDetector(runtime.storage, runtime.inferenceProvider)
     patternDetector.setEnabled(settings.patternDetectionEnabled)
@@ -363,7 +375,7 @@ app.on('ready', async () => {
   // Miners exist now — bind the apply step and start syncing. The cached-load
   // notification re-applies idempotently; the first network sync follows.
   applyRemoteModel = (config) => {
-    if (!runtime) return
+    if (!runtime || !isOpenRouterManaged()) return
     applyRemoteModelConfig(
       {
         semanticService: runtime.semanticService,
@@ -481,6 +493,7 @@ app.on('ready', async () => {
     captureSettingsManager,
     patternDetector: scheduledMiner ?? undefined,
     userContextBuilder: userContextBuilder ?? undefined,
+    taskMiner: taskMiner ?? undefined,
     getRemoteModelConfig,
     getCaptureHotkeyLabel: hotkeyManager.getLabel,
     reconfigureCaptureHotkey,

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -24,7 +24,9 @@ import type { SemanticPipelinePreference } from '@main/semantic/activity-semanti
 import { InteractionEventDebugDumper } from '@main/debug/interaction-event-debug-dump'
 import { InferenceProviderImpl, type InferenceProvider } from './llm'
 import type { Vendor } from '../shared/types'
-import { VENDOR_PRESETS, buildModelChain } from '../shared/vendor-defaults'
+import type { RemoteModelConfig } from '../shared/remote-model-config'
+import { buildModelChain } from '../shared/vendor-defaults'
+import { getEffectivePresets } from '@main/settings/effective-model-presets'
 import { createCaptureBlacklistCoordinator } from '@main/capture/capture-blacklist-coordinator'
 import {
   createCaptureController,
@@ -74,6 +76,7 @@ export async function createMainRuntime(params: {
   edition: AppEdition
   vendorCredentials: VendorCredentialsManager
   getActiveVendor: () => Vendor
+  getRemoteModelConfig?: () => RemoteModelConfig | null
   initialVideoModel?: string
   initialSnapshotModel?: string
 }): Promise<MainRuntime> {
@@ -121,7 +124,10 @@ export async function createMainRuntime(params: {
     )
   }
 
-  const presets = VENDOR_PRESETS[params.getActiveVendor()]
+  const presets = getEffectivePresets(
+    params.getActiveVendor(),
+    params.getRemoteModelConfig?.() ?? null,
+  )
   const initialVideoModels = buildModelChain(params.initialVideoModel ?? '', presets.semanticVideo)
   const initialSnapshotModels = buildModelChain(
     params.initialSnapshotModel ?? '',

--- a/src/main/services/remote-blacklist-service.ts
+++ b/src/main/services/remote-blacklist-service.ts
@@ -1,7 +1,7 @@
-import log from '@main/utils/logger'
 import { backendPlatformToken } from '@main/utils/platform'
 import type { ManagedExclusions } from '../../shared/types'
 import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
+import { RemoteSyncService, type RemoteSyncServiceParams } from './remote-sync-service'
 import { coerceManagedExclusions } from './remote-blacklist-store'
 
 const EMPTY: ManagedExclusions = { apps: [], urlPatterns: [] }
@@ -11,133 +11,36 @@ const EMPTY: ManagedExclusions = { apps: [], urlPatterns: [] }
 // the policy rarely, so there's no need to poll more often.
 const DEFAULT_SYNC_INTERVAL_MS = ENTERPRISE_BACKEND_CONFIG.STATUS_REFRESH_INTERVAL_MS
 
-function serialize(blacklist: ManagedExclusions): string {
-  return JSON.stringify([blacklist.apps, blacklist.urlPatterns])
-}
-
-export interface RemoteBlacklistServiceParams {
-  getDeviceId: () => string
-  isActivated: () => boolean
-  getBackendUrl: () => string
-  /** Fired when the blacklist changes (including the first fetch); the
-   * coordinator unions it with the user's list. */
-  onChange: (blacklist: ManagedExclusions) => void
-  /** Last-known blacklist cached on disk, or null. Loaded on start() so a
-   * restart enforces before the first network sync. */
-  readStored?: () => ManagedExclusions | null
-  /** Persists the latest blacklist so it survives restarts and backend outages. */
-  writeStored?: (blacklist: ManagedExclusions) => void
-  intervalMs?: number
-}
-
 /**
- * Polls the tenant's centralized blacklist on a timer and caches it to a
- * dedicated file (never the user's settings). The coordinator unions it with the
+ * Polls the tenant's centralized blacklist. The coordinator unions it with the
  * user's exclusions, so managed entries are always enforced and not removable.
- *
- * The cache is durable: loaded on start() and replaced only by a clean HTTP 200.
- * Any failure (4xx/5xx, network, even 401) is logged and keeps the cache, so a
- * backend blip never drops the blacklist. Only a 200 with an empty list clears it.
+ * A backend blip never drops the blacklist — only a clean 200 with an empty
+ * list clears it.
  */
-export class RemoteBlacklistService {
-  private readonly getDeviceId: () => string
-  private readonly isActivated: () => boolean
-  private readonly getBackendUrl: () => string
-  private readonly onChange: (blacklist: ManagedExclusions) => void
-  private readonly readStored?: () => ManagedExclusions | null
-  private readonly writeStored?: (blacklist: ManagedExclusions) => void
-  private readonly intervalMs: number
-
-  private blacklist: ManagedExclusions = EMPTY
-  private serialized = serialize(EMPTY)
-  private timer: ReturnType<typeof setInterval> | null = null
-  private syncing = false
-
-  constructor(params: RemoteBlacklistServiceParams) {
-    this.getDeviceId = params.getDeviceId
-    this.isActivated = params.isActivated
-    this.getBackendUrl = params.getBackendUrl
-    this.onChange = params.onChange
-    this.readStored = params.readStored
-    this.writeStored = params.writeStored
-    this.intervalMs = params.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS
+export class RemoteBlacklistService extends RemoteSyncService<ManagedExclusions> {
+  constructor(params: RemoteSyncServiceParams<ManagedExclusions>) {
+    super('RemoteBlacklist', params, DEFAULT_SYNC_INTERVAL_MS)
   }
 
   getBlacklist(): ManagedExclusions {
-    return this.blacklist
+    return this.getValue() ?? EMPTY
   }
 
-  start(): void {
-    if (this.timer !== null) return
-    this.loadCached()
-    this.timer = setInterval(() => void this.sync(), this.intervalMs)
-    this.timer.unref?.()
-    void this.sync()
+  protected describe(blacklist: ManagedExclusions): string {
+    return `blacklist: ${blacklist.apps.length} apps, ${blacklist.urlPatterns.length} url patterns`
   }
 
-  /** Enforces the on-disk blacklist ahead of the first sync, so a restart has no
-   * blacklist-free window. Missing/empty cache is a no-op. */
-  private loadCached(): void {
-    const cached = this.readStored?.()
-    if (!cached) return
-    const serialized = serialize(cached)
-    if (serialized === this.serialized) return
-    this.blacklist = cached
-    this.serialized = serialized
-    log.info(
-      `[RemoteBlacklist] Loaded cached blacklist: ${cached.apps.length} apps, ` +
-        `${cached.urlPatterns.length} url patterns`,
-    )
-    this.onChange(cached)
+  protected serialize(blacklist: ManagedExclusions): string {
+    return JSON.stringify([blacklist.apps, blacklist.urlPatterns])
   }
 
-  stop(): void {
-    if (this.timer !== null) {
-      clearInterval(this.timer)
-      this.timer = null
-    }
-  }
-
-  /** One sync pass. Skips while a prior pass is in flight or the device isn't
-   * activated; updates the held blacklist and notifies only on a real change. */
-  async sync(): Promise<void> {
-    if (this.syncing || !this.isActivated()) return
-    this.syncing = true
-    try {
-      const next = await this.fetchBlacklist()
-      const serialized = serialize(next)
-      if (serialized === this.serialized) return
-      this.blacklist = next
-      this.serialized = serialized
-      this.writeStored?.(next)
-      log.info(
-        `[RemoteBlacklist] Synced centralized blacklist: ${next.apps.length} apps, ` +
-          `${next.urlPatterns.length} url patterns`,
-      )
-      this.onChange(next)
-    } catch (error) {
-      log.warn('[RemoteBlacklist] Sync failed:', error)
-    } finally {
-      this.syncing = false
-    }
-  }
-
-  private async fetchBlacklist(): Promise<ManagedExclusions> {
-    const base = this.getBackendUrl().replace(/\/?$/, '/')
-    const url = new URL('api/license/blacklist', base)
+  protected async fetchRemote(base: string): Promise<ManagedExclusions> {
+    const url = this.endpoint(base, 'api/license/blacklist')
     // Narrow app tokens to this platform's identifiers (macOS bundle ids vs.
     // Windows process names); the device can't match the other's.
     const platform = backendPlatformToken()
     if (platform) url.searchParams.set('platform', platform)
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${this.getDeviceId()}` },
-    })
-    // Any non-200 (including 401) is a failure: the sync loop swallows the throw
-    // and keeps the last-known blacklist. Only a clean 200 replaces it.
-    if (!response.ok) {
-      throw new Error(`Remote blacklist request failed (${response.status})`)
-    }
-    const data = (await response.json()) as {
+    const data = (await this.fetchJson(url)) as {
       excludedApps?: unknown
       excludedUrlPatterns?: unknown
     }

--- a/src/main/services/remote-blacklist-store.ts
+++ b/src/main/services/remote-blacklist-store.ts
@@ -1,9 +1,5 @@
-import * as fs from 'fs'
-import * as path from 'path'
-import log from '@main/utils/logger'
+import { createUserDataJsonStore } from '@main/utils/json-file-store'
 import type { ManagedExclusions } from '../../shared/types'
-
-const FILE_NAME = 'remote-blacklist.json'
 
 function toStringArray(value: unknown): string[] {
   return Array.isArray(value)
@@ -20,39 +16,12 @@ export function coerceManagedExclusions(apps: unknown, urlPatterns: unknown): Ma
   return { apps: toStringArray(apps), urlPatterns: toStringArray(urlPatterns) }
 }
 
-function defaultPath(): string {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const electron = require('electron') as typeof import('electron')
-  return path.join(electron.app.getPath('userData'), FILE_NAME)
-}
+// Entries are sanitized to string arrays in case the file was hand-edited or
+// written by an older build.
+const store = createUserDataJsonStore('remote-blacklist.json', 'RemoteBlacklist', (data) => {
+  const { apps, urlPatterns } = data as { apps?: unknown; urlPatterns?: unknown }
+  return coerceManagedExclusions(apps, urlPatterns)
+})
 
-/**
- * Reads the last-known remote blacklist cached on disk. Returns null when the
- * file is missing or unreadable/corrupt, so callers treat it as "no cached
- * blacklist" and fall back to waiting for a fresh sync. Entries are sanitized to
- * string arrays in case the file was hand-edited or written by an older build.
- */
-export function readRemoteBlacklist(filePath: string = defaultPath()): ManagedExclusions | null {
-  try {
-    const raw = fs.readFileSync(filePath, 'utf-8')
-    const data = JSON.parse(raw) as { apps?: unknown; urlPatterns?: unknown }
-    return coerceManagedExclusions(data.apps, data.urlPatterns)
-  } catch {
-    return null
-  }
-}
-
-/**
- * Persists the latest remote blacklist. Failures are swallowed (logged) — a disk
- * hiccup must never break the sync loop.
- */
-export function writeRemoteBlacklist(
-  blacklist: ManagedExclusions,
-  filePath: string = defaultPath(),
-): void {
-  try {
-    fs.writeFileSync(filePath, JSON.stringify(blacklist, null, 2))
-  } catch (error) {
-    log.warn('[RemoteBlacklist] Failed to persist blacklist:', error)
-  }
-}
+export const readRemoteBlacklist = store.read
+export const writeRemoteBlacklist = store.write

--- a/src/main/services/remote-model-config-service.test.ts
+++ b/src/main/services/remote-model-config-service.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@main/utils/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import { RemoteModelConfigService } from './remote-model-config-service'
+import { jsonResponse } from '@main/utils/test-utils'
+
+const CONFIG_V1: RemoteModelConfig = {
+  version: 1,
+  models: { taskMining: ['minimax/minimax-m3'] },
+}
+
+describe('RemoteModelConfigService', () => {
+  const originalFetch = globalThis.fetch
+
+  function makeService(
+    overrides: Partial<{
+      isActivated: () => boolean
+      onChange: (config: RemoteModelConfig) => void
+      readStored: () => RemoteModelConfig | null
+      writeStored: (config: RemoteModelConfig) => void
+    }> = {},
+  ) {
+    const onChange = overrides.onChange ?? vi.fn()
+    const service = new RemoteModelConfigService({
+      getDeviceId: () => 'device-123',
+      isActivated: overrides.isActivated ?? (() => true),
+      getBackendUrl: () => 'https://backend.test',
+      onChange,
+      readStored: overrides.readStored,
+      writeStored: overrides.writeStored,
+    })
+    return { service, onChange }
+  }
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('fetches with the device bearer and exposes the synced config', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse(CONFIG_V1))
+    globalThis.fetch = fetchMock
+
+    const { service, onChange } = makeService()
+    await service.sync()
+
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+    expect(String(url)).toBe('https://backend.test/api/config/models')
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer device-123')
+    expect(service.getConfig()).toEqual(CONFIG_V1)
+    expect(onChange).toHaveBeenCalledWith(CONFIG_V1)
+  })
+
+  it('does not fetch or notify when the device is not activated', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    globalThis.fetch = fetchMock
+
+    const { service, onChange } = makeService({ isActivated: () => false })
+    await service.sync()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
+    expect(service.getConfig()).toBeNull()
+  })
+
+  it('notifies and persists only when the config actually changes', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(async () => jsonResponse(CONFIG_V1))
+
+    const writeStored = vi.fn()
+    const { service, onChange } = makeService({ writeStored })
+    await service.sync()
+    await service.sync()
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(writeStored).toHaveBeenCalledTimes(1)
+    expect(writeStored).toHaveBeenCalledWith(CONFIG_V1)
+  })
+
+  it('keeps the last config on a non-200 (endpoint not yet deployed)', async () => {
+    const responses: Response[] = [jsonResponse(CONFIG_V1), jsonResponse({}, false, 404)]
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
+
+    const { service, onChange } = makeService()
+    await service.sync()
+    await expect(service.sync()).resolves.toBeUndefined()
+
+    expect(service.getConfig()).toEqual(CONFIG_V1)
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the last config on a malformed body', async () => {
+    const responses: Response[] = [
+      jsonResponse(CONFIG_V1),
+      jsonResponse({ version: 'not-a-number', models: {} }),
+    ]
+    globalThis.fetch = vi.fn<typeof fetch>(async () => responses.shift() as Response)
+
+    const { service, onChange } = makeService()
+    await service.sync()
+    await service.sync()
+
+    expect(service.getConfig()).toEqual(CONFIG_V1)
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('loads the cached config on start() and applies it before any fetch', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(async () => jsonResponse(CONFIG_V1))
+
+    const { service, onChange } = makeService({ readStored: () => CONFIG_V1 })
+    service.start()
+    service.stop()
+
+    // Applied and broadcast synchronously, before the async first sync resolves.
+    expect(service.getConfig()).toEqual(CONFIG_V1)
+    expect(onChange).toHaveBeenCalledWith(CONFIG_V1)
+  })
+
+  it('treats a missing cache on start() as a no-op', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(async () => jsonResponse(CONFIG_V1))
+
+    const { service, onChange } = makeService({ readStored: () => null })
+    service.start()
+    service.stop()
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/services/remote-model-config-service.ts
+++ b/src/main/services/remote-model-config-service.ts
@@ -1,0 +1,131 @@
+import log from '@main/utils/logger'
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import { coerceRemoteModelConfig } from './remote-model-config-store'
+
+// Poll cadence for the model pipeline config. The point of remote config is
+// that a degraded/repriced model can be swapped out within minutes, not on the
+// next app update — 5 minutes bounds that lag while a no-change sync stays a
+// cheap GET of a tiny static payload.
+const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000
+
+export interface RemoteModelConfigServiceParams {
+  getDeviceId: () => string
+  /** Enterprise gates on activation; customer always syncs. */
+  isActivated: () => boolean
+  getBackendUrl: () => string
+  /** Fired when the config changes (including the cached load on start()). */
+  onChange: (config: RemoteModelConfig) => void
+  /** Last-known config cached on disk, or null. Loaded on start() so a restart
+   * applies before the first network sync. */
+  readStored?: () => RemoteModelConfig | null
+  /** Persists the latest config so it survives restarts and backend outages. */
+  writeStored?: (config: RemoteModelConfig) => void
+  intervalMs?: number
+}
+
+/**
+ * Polls the backend's model pipeline config (`GET api/config/models`) on a
+ * timer and caches it to a dedicated file (never the user's settings). The
+ * apply layer decides what to overwrite based on the config's version.
+ *
+ * The cache is durable: loaded on start() and replaced only by a clean HTTP 200
+ * with a valid body. Any failure (4xx/5xx incl. a not-yet-deployed 404, network
+ * error, malformed JSON) is logged and keeps the cache.
+ */
+export class RemoteModelConfigService {
+  private readonly getDeviceId: () => string
+  private readonly isActivated: () => boolean
+  private readonly getBackendUrl: () => string
+  private readonly onChange: (config: RemoteModelConfig) => void
+  private readonly readStored?: () => RemoteModelConfig | null
+  private readonly writeStored?: (config: RemoteModelConfig) => void
+  private readonly intervalMs: number
+
+  private config: RemoteModelConfig | null = null
+  private serialized = ''
+  private timer: ReturnType<typeof setInterval> | null = null
+  private syncing = false
+
+  constructor(params: RemoteModelConfigServiceParams) {
+    this.getDeviceId = params.getDeviceId
+    this.isActivated = params.isActivated
+    this.getBackendUrl = params.getBackendUrl
+    this.onChange = params.onChange
+    this.readStored = params.readStored
+    this.writeStored = params.writeStored
+    this.intervalMs = params.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS
+  }
+
+  getConfig(): RemoteModelConfig | null {
+    return this.config
+  }
+
+  start(): void {
+    if (this.timer !== null) return
+    this.loadCached()
+    this.timer = setInterval(() => void this.sync(), this.intervalMs)
+    this.timer.unref?.()
+    void this.sync()
+  }
+
+  /** Applies the on-disk config ahead of the first sync, so a restart doesn't
+   * wait on the network. Missing/corrupt cache is a no-op. */
+  private loadCached(): void {
+    const cached = this.readStored?.()
+    if (!cached) return
+    this.config = cached
+    this.serialized = JSON.stringify(cached)
+    log.info(`[RemoteModelConfig] Loaded cached config v${cached.version}`)
+    this.onChange(cached)
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  /** One sync pass. Skips while a prior pass is in flight or the device isn't
+   * activated; updates the held config and notifies only on a real change. */
+  async sync(): Promise<void> {
+    if (this.syncing || !this.isActivated()) return
+    const base = this.getBackendUrl()
+    if (!base) return
+    this.syncing = true
+    try {
+      const next = await this.fetchConfig(base)
+      const serialized = JSON.stringify(next)
+      if (serialized === this.serialized) return
+      this.config = next
+      this.serialized = serialized
+      this.writeStored?.(next)
+      log.info(
+        `[RemoteModelConfig] Synced config v${next.version} ` +
+          `(${Object.keys(next.models).length} slots)`,
+      )
+      this.onChange(next)
+    } catch (error) {
+      log.warn('[RemoteModelConfig] Sync failed:', error)
+    } finally {
+      this.syncing = false
+    }
+  }
+
+  private async fetchConfig(base: string): Promise<RemoteModelConfig> {
+    const url = new URL('api/config/models', base.replace(/\/?$/, '/'))
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${this.getDeviceId()}` },
+    })
+    // Any non-200 is a failure: the sync loop swallows the throw and keeps the
+    // last-known config. Only a clean 200 with a valid body replaces it.
+    if (!response.ok) {
+      throw new Error(`Remote model config request failed (${response.status})`)
+    }
+    const config = coerceRemoteModelConfig(await response.json())
+    if (config === null) {
+      throw new Error('Remote model config response is malformed')
+    }
+    return config
+  }
+}

--- a/src/main/services/remote-model-config-service.ts
+++ b/src/main/services/remote-model-config-service.ts
@@ -10,7 +10,8 @@ const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000
 
 export interface RemoteModelConfigServiceParams {
   getDeviceId: () => string
-  /** Enterprise gates on activation; customer always syncs. */
+  /** Gates syncing entirely: requires a managed OpenRouter key (plus
+   * enterprise activation in that edition). BYOK/custom installs never poll. */
   isActivated: () => boolean
   getBackendUrl: () => string
   /** Fired when the config changes (including the cached load on start()). */

--- a/src/main/services/remote-model-config-service.ts
+++ b/src/main/services/remote-model-config-service.ts
@@ -1,5 +1,5 @@
-import log from '@main/utils/logger'
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import { RemoteSyncService, type RemoteSyncServiceParams } from './remote-sync-service'
 import { coerceRemoteModelConfig } from './remote-model-config-store'
 
 // Poll cadence for the model pipeline config. The point of remote config is
@@ -8,122 +8,30 @@ import { coerceRemoteModelConfig } from './remote-model-config-store'
 // cheap GET of a tiny static payload.
 const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000
 
-export interface RemoteModelConfigServiceParams {
-  getDeviceId: () => string
-  /** Gates syncing entirely: requires a managed OpenRouter key (plus
-   * enterprise activation in that edition). BYOK/custom installs never poll. */
-  isActivated: () => boolean
-  getBackendUrl: () => string
-  /** Fired when the config changes (including the cached load on start()). */
-  onChange: (config: RemoteModelConfig) => void
-  /** Last-known config cached on disk, or null. Loaded on start() so a restart
-   * applies before the first network sync. */
-  readStored?: () => RemoteModelConfig | null
-  /** Persists the latest config so it survives restarts and backend outages. */
-  writeStored?: (config: RemoteModelConfig) => void
-  intervalMs?: number
-}
-
 /**
- * Polls the backend's model pipeline config (`GET api/config/models`) on a
- * timer and caches it to a dedicated file (never the user's settings). The
+ * Polls the backend's model pipeline config (`GET api/config/models`). The
  * apply layer decides what to overwrite based on the config's version.
- *
- * The cache is durable: loaded on start() and replaced only by a clean HTTP 200
- * with a valid body. Any failure (4xx/5xx incl. a not-yet-deployed 404, network
- * error, malformed JSON) is logged and keeps the cache.
+ * `isActivated` gates syncing entirely: it requires a managed OpenRouter key
+ * (plus enterprise activation in that edition) — BYOK/custom installs never
+ * poll.
  */
-export class RemoteModelConfigService {
-  private readonly getDeviceId: () => string
-  private readonly isActivated: () => boolean
-  private readonly getBackendUrl: () => string
-  private readonly onChange: (config: RemoteModelConfig) => void
-  private readonly readStored?: () => RemoteModelConfig | null
-  private readonly writeStored?: (config: RemoteModelConfig) => void
-  private readonly intervalMs: number
-
-  private config: RemoteModelConfig | null = null
-  private serialized = ''
-  private timer: ReturnType<typeof setInterval> | null = null
-  private syncing = false
-
-  constructor(params: RemoteModelConfigServiceParams) {
-    this.getDeviceId = params.getDeviceId
-    this.isActivated = params.isActivated
-    this.getBackendUrl = params.getBackendUrl
-    this.onChange = params.onChange
-    this.readStored = params.readStored
-    this.writeStored = params.writeStored
-    this.intervalMs = params.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS
+export class RemoteModelConfigService extends RemoteSyncService<RemoteModelConfig> {
+  constructor(params: RemoteSyncServiceParams<RemoteModelConfig>) {
+    super('RemoteModelConfig', params, DEFAULT_SYNC_INTERVAL_MS)
   }
 
   getConfig(): RemoteModelConfig | null {
-    return this.config
+    return this.getValue()
   }
 
-  start(): void {
-    if (this.timer !== null) return
-    this.loadCached()
-    this.timer = setInterval(() => void this.sync(), this.intervalMs)
-    this.timer.unref?.()
-    void this.sync()
+  protected describe(config: RemoteModelConfig): string {
+    return `config v${config.version} (${Object.keys(config.models).length} slots)`
   }
 
-  /** Applies the on-disk config ahead of the first sync, so a restart doesn't
-   * wait on the network. Missing/corrupt cache is a no-op. */
-  private loadCached(): void {
-    const cached = this.readStored?.()
-    if (!cached) return
-    this.config = cached
-    this.serialized = JSON.stringify(cached)
-    log.info(`[RemoteModelConfig] Loaded cached config v${cached.version}`)
-    this.onChange(cached)
-  }
-
-  stop(): void {
-    if (this.timer !== null) {
-      clearInterval(this.timer)
-      this.timer = null
-    }
-  }
-
-  /** One sync pass. Skips while a prior pass is in flight or the device isn't
-   * activated; updates the held config and notifies only on a real change. */
-  async sync(): Promise<void> {
-    if (this.syncing || !this.isActivated()) return
-    const base = this.getBackendUrl()
-    if (!base) return
-    this.syncing = true
-    try {
-      const next = await this.fetchConfig(base)
-      const serialized = JSON.stringify(next)
-      if (serialized === this.serialized) return
-      this.config = next
-      this.serialized = serialized
-      this.writeStored?.(next)
-      log.info(
-        `[RemoteModelConfig] Synced config v${next.version} ` +
-          `(${Object.keys(next.models).length} slots)`,
-      )
-      this.onChange(next)
-    } catch (error) {
-      log.warn('[RemoteModelConfig] Sync failed:', error)
-    } finally {
-      this.syncing = false
-    }
-  }
-
-  private async fetchConfig(base: string): Promise<RemoteModelConfig> {
-    const url = new URL('api/config/models', base.replace(/\/?$/, '/'))
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${this.getDeviceId()}` },
-    })
-    // Any non-200 is a failure: the sync loop swallows the throw and keeps the
-    // last-known config. Only a clean 200 with a valid body replaces it.
-    if (!response.ok) {
-      throw new Error(`Remote model config request failed (${response.status})`)
-    }
-    const config = coerceRemoteModelConfig(await response.json())
+  protected async fetchRemote(base: string): Promise<RemoteModelConfig> {
+    const config = coerceRemoteModelConfig(
+      await this.fetchJson(this.endpoint(base, 'api/config/models')),
+    )
     if (config === null) {
       throw new Error('Remote model config response is malformed')
     }

--- a/src/main/services/remote-model-config-store.test.ts
+++ b/src/main/services/remote-model-config-store.test.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@main/utils/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import {
+  coerceRemoteModelConfig,
+  readRemoteModelConfig,
+  writeRemoteModelConfig,
+} from './remote-model-config-store'
+
+const TMP_FILE = path.join(os.tmpdir(), 'memorylane-remote-model-config.test.json')
+
+describe('coerceRemoteModelConfig', () => {
+  it('accepts a valid payload and keeps chain order', () => {
+    expect(
+      coerceRemoteModelConfig({
+        version: 3,
+        models: {
+          semanticVideo: ['google/gemini-3.1-flash-lite', 'google/gemini-2.5-flash'],
+          taskMining: ['minimax/minimax-m3'],
+        },
+      }),
+    ).toEqual({
+      version: 3,
+      models: {
+        semanticVideo: ['google/gemini-3.1-flash-lite', 'google/gemini-2.5-flash'],
+        taskMining: ['minimax/minimax-m3'],
+      },
+    })
+  })
+
+  it('rejects the whole payload on a bad version', () => {
+    expect(coerceRemoteModelConfig({ version: -1, models: {} })).toBeNull()
+    expect(coerceRemoteModelConfig({ version: 1.5, models: {} })).toBeNull()
+    expect(coerceRemoteModelConfig({ version: '3', models: {} })).toBeNull()
+    expect(coerceRemoteModelConfig({ models: {} })).toBeNull()
+    expect(coerceRemoteModelConfig(null)).toBeNull()
+    expect(coerceRemoteModelConfig('nope')).toBeNull()
+  })
+
+  it('accepts version 0 with no models as the no-opinion bootstrap', () => {
+    expect(coerceRemoteModelConfig({ version: 0 })).toEqual({ version: 0, models: {} })
+  })
+
+  it('drops invalid chain entries, dedupes, and caps at 8', () => {
+    const config = coerceRemoteModelConfig({
+      version: 1,
+      models: {
+        semanticVideo: [
+          '  google/gemini-2.5-flash  ',
+          'google/gemini-2.5-flash',
+          42,
+          '',
+          'bad id with spaces',
+          '-leading-dash',
+          'x'.repeat(129),
+          ...Array.from({ length: 10 }, (_, i) => `vendor/model-${i}`),
+        ],
+      },
+    })
+    expect(config?.models.semanticVideo).toEqual([
+      'google/gemini-2.5-flash',
+      ...Array.from({ length: 7 }, (_, i) => `vendor/model-${i}`),
+    ])
+  })
+
+  it('omits empty slots and ignores unknown keys', () => {
+    const config = coerceRemoteModelConfig({
+      version: 2,
+      models: {
+        semanticVideo: [],
+        embeddings: ['some/model'],
+        userContext: ['minimax/minimax-m3'],
+      },
+    })
+    expect(config).toEqual({ version: 2, models: { userContext: ['minimax/minimax-m3'] } })
+  })
+})
+
+describe('remote-model-config-store', () => {
+  afterEach(() => {
+    try {
+      fs.unlinkSync(TMP_FILE)
+    } catch {
+      // already gone
+    }
+  })
+
+  it('round-trips a config through write then read', () => {
+    const config = { version: 4, models: { taskMining: ['minimax/minimax-m3'] } }
+    writeRemoteModelConfig(config, TMP_FILE)
+    expect(readRemoteModelConfig(TMP_FILE)).toEqual(config)
+  })
+
+  it('returns null when the file is missing', () => {
+    expect(readRemoteModelConfig(TMP_FILE)).toBeNull()
+  })
+
+  it('returns null on corrupt JSON', () => {
+    fs.writeFileSync(TMP_FILE, '{ not valid json')
+    expect(readRemoteModelConfig(TMP_FILE)).toBeNull()
+  })
+
+  it('returns null on a hand-edited file with an invalid version', () => {
+    fs.writeFileSync(TMP_FILE, JSON.stringify({ version: 'latest', models: {} }))
+    expect(readRemoteModelConfig(TMP_FILE)).toBeNull()
+  })
+})

--- a/src/main/services/remote-model-config-store.ts
+++ b/src/main/services/remote-model-config-store.ts
@@ -1,13 +1,9 @@
-import * as fs from 'fs'
-import * as path from 'path'
-import log from '@main/utils/logger'
+import { createUserDataJsonStore } from '@main/utils/json-file-store'
 import {
   REMOTE_MODEL_SLOTS,
   type RemoteModelConfig,
   type RemoteModelSlot,
 } from '../../shared/remote-model-config'
-
-const FILE_NAME = 'remote-model-config.json'
 
 const MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/
 const MAX_MODEL_ID_LENGTH = 128
@@ -49,37 +45,11 @@ export function coerceRemoteModelConfig(data: unknown): RemoteModelConfig | null
   return { version, models: result }
 }
 
-function defaultPath(): string {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const electron = require('electron') as typeof import('electron')
-  return path.join(electron.app.getPath('userData'), FILE_NAME)
-}
+const store = createUserDataJsonStore(
+  'remote-model-config.json',
+  'RemoteModelConfig',
+  coerceRemoteModelConfig,
+)
 
-/**
- * Reads the last-known remote model config cached on disk. Returns null when
- * the file is missing or unreadable/corrupt, so callers fall back to baked
- * presets until the first successful sync.
- */
-export function readRemoteModelConfig(filePath: string = defaultPath()): RemoteModelConfig | null {
-  try {
-    const raw = fs.readFileSync(filePath, 'utf-8')
-    return coerceRemoteModelConfig(JSON.parse(raw))
-  } catch {
-    return null
-  }
-}
-
-/**
- * Persists the latest remote model config. Failures are swallowed (logged) — a
- * disk hiccup must never break the sync loop.
- */
-export function writeRemoteModelConfig(
-  config: RemoteModelConfig,
-  filePath: string = defaultPath(),
-): void {
-  try {
-    fs.writeFileSync(filePath, JSON.stringify(config, null, 2))
-  } catch (error) {
-    log.warn('[RemoteModelConfig] Failed to persist config:', error)
-  }
-}
+export const readRemoteModelConfig = store.read
+export const writeRemoteModelConfig = store.write

--- a/src/main/services/remote-model-config-store.ts
+++ b/src/main/services/remote-model-config-store.ts
@@ -1,0 +1,85 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import log from '@main/utils/logger'
+import {
+  REMOTE_MODEL_SLOTS,
+  type RemoteModelConfig,
+  type RemoteModelSlot,
+} from '../../shared/remote-model-config'
+
+const FILE_NAME = 'remote-model-config.json'
+
+const MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/
+const MAX_MODEL_ID_LENGTH = 128
+const MAX_CHAIN_LENGTH = 8
+
+function coerceChain(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const chain: string[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue
+    const id = entry.trim()
+    if (id.length === 0 || id.length > MAX_MODEL_ID_LENGTH) continue
+    if (!MODEL_ID_PATTERN.test(id)) continue
+    if (chain.includes(id)) continue
+    chain.push(id)
+    if (chain.length >= MAX_CHAIN_LENGTH) break
+  }
+  return chain
+}
+
+/**
+ * Coerces an untrusted payload (network response or disk cache) into a
+ * sanitized {@link RemoteModelConfig}, or null when the payload is unusable.
+ * The single chokepoint for both inputs: a non-integer/negative version rejects
+ * the whole payload; invalid chain entries are dropped, unknown keys ignored.
+ */
+export function coerceRemoteModelConfig(data: unknown): RemoteModelConfig | null {
+  if (typeof data !== 'object' || data === null) return null
+  const { version, models } = data as { version?: unknown; models?: unknown }
+  if (typeof version !== 'number' || !Number.isSafeInteger(version) || version < 0) return null
+
+  const result: Partial<Record<RemoteModelSlot, string[]>> = {}
+  if (typeof models === 'object' && models !== null) {
+    for (const slot of REMOTE_MODEL_SLOTS) {
+      const chain = coerceChain((models as Record<string, unknown>)[slot])
+      if (chain.length > 0) result[slot] = chain
+    }
+  }
+  return { version, models: result }
+}
+
+function defaultPath(): string {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const electron = require('electron') as typeof import('electron')
+  return path.join(electron.app.getPath('userData'), FILE_NAME)
+}
+
+/**
+ * Reads the last-known remote model config cached on disk. Returns null when
+ * the file is missing or unreadable/corrupt, so callers fall back to baked
+ * presets until the first successful sync.
+ */
+export function readRemoteModelConfig(filePath: string = defaultPath()): RemoteModelConfig | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8')
+    return coerceRemoteModelConfig(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Persists the latest remote model config. Failures are swallowed (logged) — a
+ * disk hiccup must never break the sync loop.
+ */
+export function writeRemoteModelConfig(
+  config: RemoteModelConfig,
+  filePath: string = defaultPath(),
+): void {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify(config, null, 2))
+  } catch (error) {
+    log.warn('[RemoteModelConfig] Failed to persist config:', error)
+  }
+}

--- a/src/main/services/remote-sync-service.ts
+++ b/src/main/services/remote-sync-service.ts
@@ -1,0 +1,123 @@
+import log from '@main/utils/logger'
+
+export interface RemoteSyncServiceParams<T> {
+  getDeviceId: () => string
+  /** Gates syncing entirely; polling is skipped while it returns false. */
+  isActivated: () => boolean
+  getBackendUrl: () => string
+  /** Fired when the value changes (including the cached load on start()). */
+  onChange: (value: T) => void
+  /** Last-known value cached on disk, or null. Read in the constructor so the
+   * value is available before start(); start() broadcasts it ahead of the
+   * first network sync. */
+  readStored?: () => T | null
+  /** Persists the latest value so it survives restarts and backend outages. */
+  writeStored?: (value: T) => void
+  intervalMs?: number
+}
+
+/**
+ * Base for services that poll a backend endpoint on a timer and cache the last
+ * good value to a dedicated file (never the user's settings).
+ *
+ * The cache is durable: replaced only by a clean HTTP 200 with a valid body.
+ * Any failure (4xx/5xx, network error, malformed JSON) is logged and keeps the
+ * cache. Change detection is by serialized comparison, so onChange fires only
+ * on a real change.
+ */
+export abstract class RemoteSyncService<T> {
+  private value: T | null = null
+  private serialized = ''
+  private cachePending = false
+  private timer: ReturnType<typeof setInterval> | null = null
+  private syncing = false
+  private readonly intervalMs: number
+
+  protected constructor(
+    private readonly tag: string,
+    private readonly params: RemoteSyncServiceParams<T>,
+    defaultIntervalMs: number,
+  ) {
+    this.intervalMs = params.intervalMs ?? defaultIntervalMs
+    const cached = params.readStored?.()
+    if (cached) {
+      this.value = cached
+      this.serialized = this.serialize(cached)
+      this.cachePending = true
+      log.info(`[${tag}] Loaded cached ${this.describe(cached)}`)
+    }
+  }
+
+  /** Fetch and parse the remote value; throw on anything but a clean result. */
+  protected abstract fetchRemote(base: string): Promise<T>
+  /** Short human description of a value, for log lines. */
+  protected abstract describe(value: T): string
+  /** Canonical form used for change detection. */
+  protected serialize(value: T): string {
+    return JSON.stringify(value)
+  }
+
+  protected getValue(): T | null {
+    return this.value
+  }
+
+  start(): void {
+    if (this.timer !== null) return
+    // Broadcast the cached value ahead of the first network sync, so a restart
+    // doesn't wait on the network.
+    if (this.cachePending && this.value !== null) {
+      this.cachePending = false
+      this.params.onChange(this.value)
+    }
+    this.timer = setInterval(() => void this.sync(), this.intervalMs)
+    this.timer.unref?.()
+    void this.sync()
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  /** One sync pass. Skips while a prior pass is in flight or the device isn't
+   * activated; updates the held value and notifies only on a real change. */
+  async sync(): Promise<void> {
+    if (this.syncing || !this.params.isActivated()) return
+    const base = this.params.getBackendUrl()
+    if (!base) return
+    this.syncing = true
+    try {
+      const next = await this.fetchRemote(base)
+      const serialized = this.serialize(next)
+      if (serialized === this.serialized) return
+      this.value = next
+      this.serialized = serialized
+      this.params.writeStored?.(next)
+      log.info(`[${this.tag}] Synced ${this.describe(next)}`)
+      this.params.onChange(next)
+    } catch (error) {
+      log.warn(`[${this.tag}] Sync failed:`, error)
+    } finally {
+      this.syncing = false
+    }
+  }
+
+  /** Resolves an endpoint path against the backend base URL. */
+  protected endpoint(base: string, path: string): URL {
+    return new URL(path, base.replace(/\/?$/, '/'))
+  }
+
+  /** GET with the device bearer. Any non-200 throws, so the sync loop swallows
+   * it and keeps the last-known value; only a clean 200 replaces it. */
+  protected async fetchJson(url: URL): Promise<unknown> {
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${this.params.getDeviceId()}` },
+    })
+    if (!response.ok) {
+      throw new Error(`Request failed (${response.status})`)
+    }
+    return response.json()
+  }
+}

--- a/src/main/services/task-miner/index.ts
+++ b/src/main/services/task-miner/index.ts
@@ -50,6 +50,8 @@ export class TaskMiner {
   private sweepBaseline: { completed: number; failed: number } | null = null
   private settleTimer: ReturnType<typeof setTimeout> | null = null
   private model: string = DEFAULT_MINER_CONFIG.model
+  /** Remote override for the clustering (label/merge/split) passes; null = follow `model`. */
+  private clusterModel: string | null = null
   private enabled = true
   private statusListener?: () => void
 
@@ -71,6 +73,11 @@ export class TaskMiner {
   updateModel(model: string): void {
     this.model = model && model.trim().length > 0 ? model.trim() : DEFAULT_MINER_CONFIG.model
     log.info(`[TaskMiner] Model updated to: ${this.model}`)
+  }
+
+  updateClusterModel(model: string | null): void {
+    this.clusterModel = model && model.trim().length > 0 ? model.trim() : null
+    log.info(`[TaskMiner] Cluster model updated to: ${this.clusterModel ?? '(follow miner model)'}`)
   }
 
   /** True while a run is executing or its settle timer is armed. */
@@ -318,7 +325,7 @@ export class TaskMiner {
         embedder: this.embedder,
         clusterVectors: this.embedder.clusterVectors?.bind(this.embedder),
         provider: this.enabled && this.provider?.isConfigured() ? this.provider : undefined,
-        model: this.model,
+        model: this.clusterModel ?? this.model,
       })
     } catch (error) {
       log.error('[TaskMiner] Cluster rebuild failed:', formatApiError(error))
@@ -475,7 +482,7 @@ export class TaskMiner {
         embedder: this.embedder,
         clusterVectors: this.embedder.clusterVectors?.bind(this.embedder),
         provider,
-        model: cfg.model,
+        model: this.clusterModel ?? cfg.model,
         onProgress,
       })
     } catch (error) {

--- a/src/main/services/task-miner/task-miner.test.ts
+++ b/src/main/services/task-miner/task-miner.test.ts
@@ -218,6 +218,30 @@ describe('TaskMiner sweep', () => {
     expect(mockedRunClustering).toHaveBeenCalledTimes(2)
   })
 
+  it('clusters with the remote cluster-model override when one is set', async () => {
+    seedDays(1)
+    miner.updateModel('mining/model')
+    miner.updateClusterModel('cluster/model')
+
+    await miner.sweepNow(configuredProvider)
+
+    expect(mockedRunClustering).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'cluster/model' }),
+    )
+  })
+
+  it('clusters with the mining model when no cluster override is set', async () => {
+    seedDays(1)
+    miner.updateModel('mining/model')
+    miner.updateClusterModel(null)
+
+    await miner.sweepNow(configuredProvider)
+
+    expect(mockedRunClustering).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'mining/model' }),
+    )
+  })
+
   it('scheduleRun arms nothing when every day is already settled', async () => {
     seedDays(2)
     // Enough activities to pass the MIN_ACTIVITIES guard, all inside days the

--- a/src/main/settings/capture-settings-manager.test.ts
+++ b/src/main/settings/capture-settings-manager.test.ts
@@ -407,6 +407,34 @@ describe('CaptureSettingsManager', () => {
       expect(manager.get().patternDetectionModel).toBe(expected)
     })
 
+    it('resets the remote config stamp on a defaults version bump', () => {
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          activeVendor: 'openrouter',
+          modelDefaultsVersion: MODEL_DEFAULTS_VERSION - 1,
+          remoteModelConfigVersion: 7,
+        }),
+      )
+      const manager = new CaptureSettingsManager(configPath)
+      // The wipe clears the stamp so the next remote sync re-applies on top of
+      // the fresh defaults.
+      expect(manager.get().remoteModelConfigVersion).toBe(0)
+    })
+
+    it('preserves the remote config stamp when defaults version is current', () => {
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          activeVendor: 'openrouter',
+          modelDefaultsVersion: MODEL_DEFAULTS_VERSION,
+          remoteModelConfigVersion: 7,
+        }),
+      )
+      const manager = new CaptureSettingsManager(configPath)
+      expect(manager.get().remoteModelConfigVersion).toBe(7)
+    })
+
     it('persists the version bump so the override runs only once', () => {
       fs.writeFileSync(
         configPath,

--- a/src/main/settings/capture-settings-manager.ts
+++ b/src/main/settings/capture-settings-manager.ts
@@ -315,6 +315,8 @@ export class CaptureSettingsManager {
         let finalSnapshotModel = semanticSnapshotModel
         let finalPatternModel = patternDetectionModel
         let finalModelsByVendor = modelsByVendor
+        let remoteModelConfigVersion =
+          typeof data.remoteModelConfigVersion === 'number' ? data.remoteModelConfigVersion : 0
         if ((data.modelDefaultsVersion ?? 0) < MODEL_DEFAULTS_VERSION) {
           finalModelsByVendor = { ...modelsByVendor }
           for (const vendor of VENDORS) {
@@ -327,6 +329,9 @@ export class CaptureSettingsManager {
             finalSnapshotModel = active.semanticSnapshotModel
             finalPatternModel = active.patternDetectionModel
           }
+          // A baked-defaults wipe also clears the remote stamp so the next sync
+          // re-applies the remote config on top of the fresh defaults.
+          remoteModelConfigVersion = 0
           this.modelDefaultsUpgraded = true
           log.info(
             `[CaptureSettings] Model defaults v${data.modelDefaultsVersion ?? 0} → v${MODEL_DEFAULTS_VERSION}: overriding stored model picks with vendor defaults`,
@@ -361,6 +366,7 @@ export class CaptureSettingsManager {
           ),
           databaseExportDirectory: normalizeDatabaseExportDirectory(data.databaseExportDirectory),
           modelDefaultsVersion: MODEL_DEFAULTS_VERSION,
+          remoteModelConfigVersion,
           activeVendor,
           semanticVideoModel: finalVideoModel,
           semanticSnapshotModel: finalSnapshotModel,

--- a/src/main/settings/effective-model-presets.test.ts
+++ b/src/main/settings/effective-model-presets.test.ts
@@ -5,7 +5,7 @@ import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
 import {
   getEffectivePresets,
   resolveClusterModelOverride,
-  resolveTextTaskModels,
+  resolveUserContextModel,
 } from './effective-model-presets'
 
 const REMOTE: RemoteModelConfig = {
@@ -42,29 +42,21 @@ describe('getEffectivePresets', () => {
   })
 })
 
-describe('resolveTextTaskModels', () => {
-  it('follows the stored pick for all tasks without remote config', () => {
-    expect(resolveTextTaskModels('minimax/minimax-m3', 'openrouter', null)).toEqual({
-      taskMining: 'minimax/minimax-m3',
-      userContext: 'minimax/minimax-m3',
-      clusterReview: 'minimax/minimax-m3',
-    })
+describe('resolveUserContextModel', () => {
+  it('follows the stored pick without remote config', () => {
+    expect(resolveUserContextModel('minimax/minimax-m3', 'openrouter', null)).toBe(
+      'minimax/minimax-m3',
+    )
   })
 
   it('follows the stored pick for non-openrouter vendors', () => {
-    expect(resolveTextTaskModels('gemini-2.5-flash', 'google', REMOTE)).toEqual({
-      taskMining: 'gemini-2.5-flash',
-      userContext: 'gemini-2.5-flash',
-      clusterReview: 'gemini-2.5-flash',
-    })
+    expect(resolveUserContextModel('gemini-2.5-flash', 'google', REMOTE)).toBe('gemini-2.5-flash')
   })
 
-  it('diverges tasks with a remote opinion and defaults the rest to the pick', () => {
-    expect(resolveTextTaskModels('xiaomi/mimo-v2.5', 'openrouter', REMOTE)).toEqual({
-      taskMining: 'xiaomi/mimo-v2.5',
-      userContext: 'minimax/minimax-m3',
-      clusterReview: 'xiaomi/mimo-v2.5',
-    })
+  it('diverges to the remote opinion when present', () => {
+    expect(resolveUserContextModel('xiaomi/mimo-v2.5', 'openrouter', REMOTE)).toBe(
+      'minimax/minimax-m3',
+    )
   })
 })
 

--- a/src/main/settings/effective-model-presets.test.ts
+++ b/src/main/settings/effective-model-presets.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
+import { getEffectivePresets, resolveTextTaskModels } from './effective-model-presets'
+
+const REMOTE: RemoteModelConfig = {
+  version: 3,
+  models: {
+    semanticVideo: ['google/gemini-2.5-flash', 'some/new-model'],
+    taskMining: ['xiaomi/mimo-v2.5'],
+    userContext: ['minimax/minimax-m3'],
+  },
+}
+
+describe('getEffectivePresets', () => {
+  it('returns baked presets when there is no remote config', () => {
+    expect(getEffectivePresets('openrouter', null)).toBe(VENDOR_PRESETS.openrouter)
+  })
+
+  it('returns baked presets for non-openrouter vendors regardless of remote config', () => {
+    expect(getEffectivePresets('google', REMOTE)).toBe(VENDOR_PRESETS.google)
+  })
+
+  it('replaces remotely-configured slots and keeps baked labels for known ids', () => {
+    const presets = getEffectivePresets('openrouter', REMOTE)
+    expect(presets.semanticVideo).toEqual([
+      { id: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+      { id: 'some/new-model', label: 'some/new-model' },
+    ])
+    // taskMining maps onto the stored patternDetection slot.
+    expect(presets.patternDetection).toEqual([{ id: 'xiaomi/mimo-v2.5', label: 'MiMo V2.5' }])
+  })
+
+  it('falls through to baked presets for empty or missing slots', () => {
+    const presets = getEffectivePresets('openrouter', REMOTE)
+    expect(presets.semanticSnapshot).toBe(VENDOR_PRESETS.openrouter.semanticSnapshot)
+  })
+})
+
+describe('resolveTextTaskModels', () => {
+  it('follows the stored pick for all tasks without remote config', () => {
+    expect(resolveTextTaskModels('minimax/minimax-m3', 'openrouter', null)).toEqual({
+      taskMining: 'minimax/minimax-m3',
+      userContext: 'minimax/minimax-m3',
+      clusterReview: 'minimax/minimax-m3',
+    })
+  })
+
+  it('follows the stored pick for non-openrouter vendors', () => {
+    expect(resolveTextTaskModels('gemini-2.5-flash', 'google', REMOTE)).toEqual({
+      taskMining: 'gemini-2.5-flash',
+      userContext: 'gemini-2.5-flash',
+      clusterReview: 'gemini-2.5-flash',
+    })
+  })
+
+  it('diverges tasks with a remote opinion and defaults the rest to the pick', () => {
+    expect(resolveTextTaskModels('xiaomi/mimo-v2.5', 'openrouter', REMOTE)).toEqual({
+      taskMining: 'xiaomi/mimo-v2.5',
+      userContext: 'minimax/minimax-m3',
+      clusterReview: 'xiaomi/mimo-v2.5',
+    })
+  })
+})

--- a/src/main/settings/effective-model-presets.test.ts
+++ b/src/main/settings/effective-model-presets.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
-import { getEffectivePresets, resolveTextTaskModels } from './effective-model-presets'
+import {
+  getEffectivePresets,
+  resolveClusterModelOverride,
+  resolveTextTaskModels,
+} from './effective-model-presets'
 
 const REMOTE: RemoteModelConfig = {
   version: 3,
@@ -61,5 +65,23 @@ describe('resolveTextTaskModels', () => {
       userContext: 'minimax/minimax-m3',
       clusterReview: 'xiaomi/mimo-v2.5',
     })
+  })
+})
+
+describe('resolveClusterModelOverride', () => {
+  const WITH_CLUSTER: RemoteModelConfig = {
+    version: 1,
+    models: { clusterReview: ['remote/cluster-model'] },
+  }
+
+  it('returns the remote head for openrouter and null without an opinion', () => {
+    expect(resolveClusterModelOverride('openrouter', WITH_CLUSTER)).toBe('remote/cluster-model')
+    expect(resolveClusterModelOverride('openrouter', REMOTE)).toBeNull()
+    expect(resolveClusterModelOverride('openrouter', null)).toBeNull()
+  })
+
+  it('never returns an override for other vendors', () => {
+    expect(resolveClusterModelOverride('google', WITH_CLUSTER)).toBeNull()
+    expect(resolveClusterModelOverride('openai-compatible', WITH_CLUSTER)).toBeNull()
   })
 })

--- a/src/main/settings/effective-model-presets.ts
+++ b/src/main/settings/effective-model-presets.ts
@@ -1,0 +1,64 @@
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import type { Vendor } from '../../shared/types'
+import { VENDOR_PRESETS, type ModelPreset, type VendorPresets } from '../../shared/vendor-defaults'
+
+function toPresets(chain: string[], baked: ModelPreset[]): ModelPreset[] {
+  return chain.map((id) => ({ id, label: baked.find((p) => p.id === id)?.label ?? id }))
+}
+
+/**
+ * The vendor's preset lists with the remote model config layered on top.
+ * Remote config is OpenRouter-only: for that vendor a non-empty remote slot
+ * replaces the baked list (first entry = the remotely-enforced default), an
+ * empty/missing slot falls through to the baked presets. Other vendors — and a
+ * null config — return the baked presets untouched.
+ */
+export function getEffectivePresets(
+  vendor: Vendor,
+  remote: RemoteModelConfig | null,
+): VendorPresets {
+  const baked = VENDOR_PRESETS[vendor]
+  if (vendor !== 'openrouter' || remote === null) return baked
+  const { semanticVideo, semanticSnapshot, taskMining } = remote.models
+  return {
+    semanticVideo: semanticVideo?.length
+      ? toPresets(semanticVideo, baked.semanticVideo)
+      : baked.semanticVideo,
+    semanticSnapshot: semanticSnapshot?.length
+      ? toPresets(semanticSnapshot, baked.semanticSnapshot)
+      : baked.semanticSnapshot,
+    patternDetection: taskMining?.length
+      ? toPresets(taskMining, baked.patternDetection)
+      : baked.patternDetection,
+  }
+}
+
+export interface TextTaskModels {
+  taskMining: string
+  userContext: string
+  clusterReview: string
+}
+
+/**
+ * Splits the single stored `patternDetectionModel` pick into the three text
+ * tasks. Remote config (OpenRouter only) can point each task at its own model;
+ * without a remote opinion all three follow the stored pick.
+ */
+export function resolveTextTaskModels(
+  patternDetectionPick: string,
+  vendor: Vendor,
+  remote: RemoteModelConfig | null,
+): TextTaskModels {
+  if (vendor !== 'openrouter' || remote === null) {
+    return {
+      taskMining: patternDetectionPick,
+      userContext: patternDetectionPick,
+      clusterReview: patternDetectionPick,
+    }
+  }
+  return {
+    taskMining: patternDetectionPick,
+    userContext: remote.models.userContext?.[0] ?? patternDetectionPick,
+    clusterReview: remote.models.clusterReview?.[0] ?? patternDetectionPick,
+  }
+}

--- a/src/main/settings/effective-model-presets.ts
+++ b/src/main/settings/effective-model-presets.ts
@@ -62,3 +62,15 @@ export function resolveTextTaskModels(
     clusterReview: remote.models.clusterReview?.[0] ?? patternDetectionPick,
   }
 }
+
+/**
+ * The TaskMiner clustering-pass override; null = follow the miner model.
+ * OpenRouter only — any other vendor must never run a remote OpenRouter id.
+ */
+export function resolveClusterModelOverride(
+  vendor: Vendor,
+  remote: RemoteModelConfig | null,
+): string | null {
+  if (vendor !== 'openrouter') return null
+  return remote?.models.clusterReview?.[0] ?? null
+}

--- a/src/main/settings/effective-model-presets.ts
+++ b/src/main/settings/effective-model-presets.ts
@@ -33,34 +33,17 @@ export function getEffectivePresets(
   }
 }
 
-export interface TextTaskModels {
-  taskMining: string
-  userContext: string
-  clusterReview: string
-}
-
 /**
- * Splits the single stored `patternDetectionModel` pick into the three text
- * tasks. Remote config (OpenRouter only) can point each task at its own model;
- * without a remote opinion all three follow the stored pick.
+ * The user-context builder follows the stored `patternDetectionModel` pick
+ * unless remote config (OpenRouter only) points it at its own model.
  */
-export function resolveTextTaskModels(
+export function resolveUserContextModel(
   patternDetectionPick: string,
   vendor: Vendor,
   remote: RemoteModelConfig | null,
-): TextTaskModels {
-  if (vendor !== 'openrouter' || remote === null) {
-    return {
-      taskMining: patternDetectionPick,
-      userContext: patternDetectionPick,
-      clusterReview: patternDetectionPick,
-    }
-  }
-  return {
-    taskMining: patternDetectionPick,
-    userContext: remote.models.userContext?.[0] ?? patternDetectionPick,
-    clusterReview: remote.models.clusterReview?.[0] ?? patternDetectionPick,
-  }
+): string {
+  if (vendor !== 'openrouter') return patternDetectionPick
+  return remote?.models.userContext?.[0] ?? patternDetectionPick
 }
 
 /**

--- a/src/main/ui/apply-models.ts
+++ b/src/main/ui/apply-models.ts
@@ -1,0 +1,45 @@
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import type { CaptureSettings } from '../../shared/types'
+import { buildModelChain } from '../../shared/vendor-defaults'
+import {
+  getEffectivePresets,
+  resolveClusterModelOverride,
+  resolveUserContextModel,
+} from '@main/settings/effective-model-presets'
+
+/** Structural shape of every live service that consumes a model selection. */
+export interface ModelPushDeps {
+  semanticService: {
+    updateModels(videoModels: string[], snapshotModels: string[]): void
+  }
+  patternDetector?: { updateModel(model: string): void }
+  userContextBuilder?: { updateModel(model: string): void }
+  taskMiner?: { updateClusterModel(model: string | null): void }
+}
+
+type ModelSelection = Pick<
+  CaptureSettings,
+  'activeVendor' | 'semanticVideoModel' | 'semanticSnapshotModel' | 'patternDetectionModel'
+>
+
+/**
+ * Push the effective model selections (stored picks + remote config) into the
+ * live services. Idempotent — the single choke point shared by startup seeding,
+ * vendor switches, settings saves, and remote-config notifications.
+ */
+export function pushModelSelections(
+  d: ModelPushDeps,
+  s: ModelSelection,
+  remote: RemoteModelConfig | null,
+): void {
+  const presets = getEffectivePresets(s.activeVendor, remote)
+  d.semanticService.updateModels(
+    buildModelChain(s.semanticVideoModel, presets.semanticVideo),
+    buildModelChain(s.semanticSnapshotModel, presets.semanticSnapshot),
+  )
+  d.patternDetector?.updateModel(s.patternDetectionModel)
+  d.userContextBuilder?.updateModel(
+    resolveUserContextModel(s.patternDetectionModel, s.activeVendor, remote),
+  )
+  d.taskMiner?.updateClusterModel(resolveClusterModelOverride(s.activeVendor, remote))
+}

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -29,6 +29,7 @@ import type { VendorCredentialsManager } from '../settings/vendor-credentials-ma
 import { VENDORS } from '../../shared/types'
 import { computeClustersView } from './cluster-view'
 import { getEffectivePresets } from '@main/settings/effective-model-presets'
+import { getPresetDefaults } from '../../shared/vendor-defaults'
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import { applyVendorSwitch } from './vendor-switch'
 import { applyModelSettings } from './model-settings'
@@ -174,11 +175,7 @@ function reconcileManagedModelSelections(
   // would flag remote-applied models as stale and reset them.
   const presets = getEffectivePresets(vendor, remote)
   const settings = captureSettings.get()
-  const defaults = {
-    semanticVideoModel: presets.semanticVideo[0]?.id ?? '',
-    semanticSnapshotModel: presets.semanticSnapshot[0]?.id ?? '',
-    patternDetectionModel: presets.patternDetection[0]?.id ?? '',
-  }
+  const defaults = getPresetDefaults(presets)
   const updates: Partial<{
     semanticVideoModel: string
     semanticSnapshotModel: string

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -112,7 +112,9 @@ interface MainWindowDependencies {
   captureSettingsManager: CaptureSettingsManager
   patternDetector?: PatternDetectorService
   userContextBuilder?: UserContextBuilderService
-  /** Latest remote model config (cached or synced); null when none is known. */
+  taskMiner?: { updateClusterModel(model: string | null): void }
+  /** Latest remote model config (cached or synced); null when the OpenRouter
+   * key isn't managed or none is known. */
   getRemoteModelConfig?: () => RemoteModelConfig | null
   getCaptureHotkeyLabel: () => string
   reconfigureCaptureHotkey: (accelerator: string) => { success: boolean; error?: string }
@@ -1082,15 +1084,6 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
   ipcMain.handle('main-window:getCaptureSettings', () => {
     if (!deps) return null
     return deps.captureSettingsManager.get()
-  })
-
-  // Preset lists with the remote model config layered in, so the managed-mode
-  // grid can display remotely-swapped models the baked presets don't know.
-  ipcMain.handle('main-window:getModelPresets', () => {
-    const remote = deps?.getRemoteModelConfig?.() ?? null
-    return Object.fromEntries(
-      VENDORS.map((vendor) => [vendor, getEffectivePresets(vendor, remote)]),
-    )
   })
 
   ipcMain.handle(

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -28,7 +28,8 @@ import { listInstalledApps } from '../apps/installed-apps'
 import type { VendorCredentialsManager } from '../settings/vendor-credentials-manager'
 import { VENDORS } from '../../shared/types'
 import { computeClustersView } from './cluster-view'
-import { VENDOR_PRESETS, getVendorDefaults } from '../../shared/vendor-defaults'
+import { getEffectivePresets } from '@main/settings/effective-model-presets'
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import { applyVendorSwitch } from './vendor-switch'
 import { applyModelSettings } from './model-settings'
 import type { EvalRecorder } from '../eval/eval-recorder'
@@ -111,6 +112,8 @@ interface MainWindowDependencies {
   captureSettingsManager: CaptureSettingsManager
   patternDetector?: PatternDetectorService
   userContextBuilder?: UserContextBuilderService
+  /** Latest remote model config (cached or synced); null when none is known. */
+  getRemoteModelConfig?: () => RemoteModelConfig | null
   getCaptureHotkeyLabel: () => string
   reconfigureCaptureHotkey: (accelerator: string) => { success: boolean; error?: string }
   updateExclusions: (exclusions: {
@@ -163,10 +166,17 @@ app.on('before-quit', () => {
 function reconcileManagedModelSelections(
   captureSettings: CaptureSettingsManager,
   vendor: Vendor,
+  remote: RemoteModelConfig | null,
 ): boolean {
-  const presets = VENDOR_PRESETS[vendor]
+  // Validate against the effective (remote-aware) presets — the baked lists
+  // would flag remote-applied models as stale and reset them.
+  const presets = getEffectivePresets(vendor, remote)
   const settings = captureSettings.get()
-  const defaults = getVendorDefaults(vendor)
+  const defaults = {
+    semanticVideoModel: presets.semanticVideo[0]?.id ?? '',
+    semanticSnapshotModel: presets.semanticSnapshot[0]?.id ?? '',
+    patternDetectionModel: presets.patternDetection[0]?.id ?? '',
+  }
   const updates: Partial<{
     semanticVideoModel: string
     semanticSnapshotModel: string
@@ -707,7 +717,11 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
       // prior BYOK session with a freetext model id) is unreachable and stale.
       // Reset such slots to the vendor's preset default; valid preset picks
       // are preserved.
-      const reconciled = reconcileManagedModelSelections(deps.captureSettingsManager, vendor)
+      const reconciled = reconcileManagedModelSelections(
+        deps.captureSettingsManager,
+        vendor,
+        deps.getRemoteModelConfig?.() ?? null,
+      )
       if (switching || reconciled) {
         applyVendorSwitch(deps, deps.captureSettingsManager.get())
       } else if (changed) {
@@ -1068,6 +1082,15 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
   ipcMain.handle('main-window:getCaptureSettings', () => {
     if (!deps) return null
     return deps.captureSettingsManager.get()
+  })
+
+  // Preset lists with the remote model config layered in, so the managed-mode
+  // grid can display remotely-swapped models the baked presets don't know.
+  ipcMain.handle('main-window:getModelPresets', () => {
+    const remote = deps?.getRemoteModelConfig?.() ?? null
+    return Object.fromEntries(
+      VENDORS.map((vendor) => [vendor, getEffectivePresets(vendor, remote)]),
+    )
   })
 
   ipcMain.handle(

--- a/src/main/ui/model-settings.test.ts
+++ b/src/main/ui/model-settings.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { applyModelSettings, type ModelSettingsDeps } from './model-settings'
 import type { CaptureSettings } from '../../shared/types'
 import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
+import { makeCaptureSettings } from '@main/utils/test-utils'
 
 function makeDeps(): {
   deps: ModelSettingsDeps
@@ -20,32 +21,7 @@ function makeDeps(): {
 }
 
 function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
-  return {
-    autoStartEnabled: true,
-    visualThreshold: 8,
-    typingDebounceMs: 2000,
-    scrollDebounceMs: 2000,
-    clickDebounceMs: 3000,
-    minActivityDurationMs: 3000,
-    maxActivityDurationMs: 300000,
-    maxScreenshotsForLlm: 6,
-    semanticRequestTimeoutMs: 120000,
-    semanticPipelineMode: 'image',
-    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
-    databaseExportDirectory: '',
-    excludePrivateBrowsing: true,
-    excludedApps: [],
-    excludedUrlPatterns: [],
-    activeVendor: 'openrouter',
-    modelsByVendor: {},
-    newTaskMinerEnabled: true,
-    semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
-    semanticSnapshotModel: VENDOR_PRESETS.openrouter.semanticSnapshot[0].id,
-    patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,
-    patternDetectionEnabled: true,
-    uploadDetailLevel: 'off',
-    ...overrides,
-  }
+  return makeCaptureSettings({ semanticPipelineMode: 'image', ...overrides })
 }
 
 describe('applyModelSettings', () => {

--- a/src/main/ui/model-settings.test.ts
+++ b/src/main/ui/model-settings.test.ts
@@ -113,4 +113,30 @@ describe('applyModelSettings', () => {
 
     expect(semanticService.updateModels).not.toHaveBeenCalled()
   })
+
+  it('uses remote chains for the tail and diverges the user-context model', () => {
+    const { deps, semanticService, patternDetector, userContextBuilder } = makeDeps()
+    deps.getRemoteModelConfig = () => ({
+      version: 2,
+      models: {
+        semanticVideo: ['remote/video-a', 'remote/video-b'],
+        userContext: ['remote/context-model'],
+      },
+    })
+    const previous = makeSettings({
+      semanticVideoModel: 'remote/video-a',
+      patternDetectionModel: 'old/model',
+    })
+    const updated = makeSettings({
+      semanticVideoModel: 'remote/video-b',
+      patternDetectionModel: 'new/model',
+    })
+
+    applyModelSettings(deps, updated, previous)
+
+    const [videoModels] = semanticService.updateModels.mock.calls[0] as [string[], string[]]
+    expect(videoModels).toEqual(['remote/video-b', 'remote/video-a'])
+    expect(patternDetector.updateModel).toHaveBeenCalledWith('new/model')
+    expect(userContextBuilder.updateModel).toHaveBeenCalledWith('remote/context-model')
+  })
 })

--- a/src/main/ui/model-settings.ts
+++ b/src/main/ui/model-settings.ts
@@ -1,47 +1,33 @@
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings } from '../../shared/types'
-import { buildModelChain } from '../../shared/vendor-defaults'
-import { getEffectivePresets, resolveTextTaskModels } from '@main/settings/effective-model-presets'
+import { pushModelSelections, type ModelPushDeps } from './apply-models'
 
 /**
  * Structural shape of the dependencies that `applyModelSettings` touches.
  * Defined separately so the helper is unit-testable without a full
  * `MainWindowDependencies` mock.
  */
-export interface ModelSettingsDeps {
-  semanticService: {
-    updateModels(videoModels: string[], snapshotModels: string[]): void
-  }
+export interface ModelSettingsDeps extends ModelPushDeps {
   patternDetector?: { updateModel(model: string): void; setEnabled(enabled: boolean): void }
-  userContextBuilder?: { updateModel(model: string): void }
   getRemoteModelConfig?: () => RemoteModelConfig | null
 }
 
 /**
- * Diff `updated` vs `previous` capture settings and push only the changed
- * model-related fields into the live runtime services.
+ * Diff `updated` vs `previous` capture settings and push model-related changes
+ * into the live runtime services.
  */
 export function applyModelSettings(
   d: ModelSettingsDeps,
   updated: CaptureSettings,
   previous: CaptureSettings,
 ): void {
-  const remote = d.getRemoteModelConfig?.() ?? null
   if (
+    updated.activeVendor !== previous.activeVendor ||
     updated.semanticVideoModel !== previous.semanticVideoModel ||
     updated.semanticSnapshotModel !== previous.semanticSnapshotModel ||
-    updated.activeVendor !== previous.activeVendor
+    updated.patternDetectionModel !== previous.patternDetectionModel
   ) {
-    const presets = getEffectivePresets(updated.activeVendor, remote)
-    d.semanticService.updateModels(
-      buildModelChain(updated.semanticVideoModel, presets.semanticVideo),
-      buildModelChain(updated.semanticSnapshotModel, presets.semanticSnapshot),
-    )
-  }
-  if (updated.patternDetectionModel !== previous.patternDetectionModel) {
-    const text = resolveTextTaskModels(updated.patternDetectionModel, updated.activeVendor, remote)
-    d.patternDetector?.updateModel(text.taskMining)
-    d.userContextBuilder?.updateModel(text.userContext)
+    pushModelSelections(d, updated, d.getRemoteModelConfig?.() ?? null)
   }
   if (updated.patternDetectionEnabled !== previous.patternDetectionEnabled) {
     d.patternDetector?.setEnabled(updated.patternDetectionEnabled)

--- a/src/main/ui/model-settings.ts
+++ b/src/main/ui/model-settings.ts
@@ -1,5 +1,7 @@
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings } from '../../shared/types'
-import { VENDOR_PRESETS, buildModelChain } from '../../shared/vendor-defaults'
+import { buildModelChain } from '../../shared/vendor-defaults'
+import { getEffectivePresets, resolveTextTaskModels } from '@main/settings/effective-model-presets'
 
 /**
  * Structural shape of the dependencies that `applyModelSettings` touches.
@@ -12,6 +14,7 @@ export interface ModelSettingsDeps {
   }
   patternDetector?: { updateModel(model: string): void; setEnabled(enabled: boolean): void }
   userContextBuilder?: { updateModel(model: string): void }
+  getRemoteModelConfig?: () => RemoteModelConfig | null
 }
 
 /**
@@ -23,20 +26,22 @@ export function applyModelSettings(
   updated: CaptureSettings,
   previous: CaptureSettings,
 ): void {
+  const remote = d.getRemoteModelConfig?.() ?? null
   if (
     updated.semanticVideoModel !== previous.semanticVideoModel ||
     updated.semanticSnapshotModel !== previous.semanticSnapshotModel ||
     updated.activeVendor !== previous.activeVendor
   ) {
-    const presets = VENDOR_PRESETS[updated.activeVendor]
+    const presets = getEffectivePresets(updated.activeVendor, remote)
     d.semanticService.updateModels(
       buildModelChain(updated.semanticVideoModel, presets.semanticVideo),
       buildModelChain(updated.semanticSnapshotModel, presets.semanticSnapshot),
     )
   }
   if (updated.patternDetectionModel !== previous.patternDetectionModel) {
-    d.patternDetector?.updateModel(updated.patternDetectionModel)
-    d.userContextBuilder?.updateModel(updated.patternDetectionModel)
+    const text = resolveTextTaskModels(updated.patternDetectionModel, updated.activeVendor, remote)
+    d.patternDetector?.updateModel(text.taskMining)
+    d.userContextBuilder?.updateModel(text.userContext)
   }
   if (updated.patternDetectionEnabled !== previous.patternDetectionEnabled) {
     d.patternDetector?.setEnabled(updated.patternDetectionEnabled)

--- a/src/main/ui/remote-model-apply.test.ts
+++ b/src/main/ui/remote-model-apply.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@main/utils/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import type { CaptureSettings } from '../../shared/types'
+import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
+import {
+  applyRemoteModelConfig,
+  type RemoteModelApplyDeps,
+  type RemoteModelSettingsManager,
+} from './remote-model-apply'
+
+const REMOTE: RemoteModelConfig = {
+  version: 3,
+  models: {
+    semanticVideo: ['remote/video-model', 'google/gemini-2.5-flash'],
+    semanticSnapshot: ['remote/snapshot-model'],
+    taskMining: ['remote/mining-model'],
+    userContext: ['remote/context-model'],
+    clusterReview: ['remote/cluster-model'],
+  },
+}
+
+function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
+  return {
+    autoStartEnabled: true,
+    visualThreshold: 8,
+    typingDebounceMs: 2000,
+    scrollDebounceMs: 2000,
+    clickDebounceMs: 3000,
+    minActivityDurationMs: 3000,
+    maxActivityDurationMs: 300000,
+    maxScreenshotsForLlm: 6,
+    semanticRequestTimeoutMs: 120000,
+    semanticPipelineMode: 'auto',
+    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
+    databaseExportDirectory: '',
+    excludePrivateBrowsing: true,
+    excludedApps: [],
+    excludedUrlPatterns: [],
+    activeVendor: 'openrouter',
+    modelsByVendor: {},
+    newTaskMinerEnabled: true,
+    semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
+    semanticSnapshotModel: VENDOR_PRESETS.openrouter.semanticSnapshot[0].id,
+    patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,
+    patternDetectionEnabled: true,
+    remoteModelConfigVersion: 0,
+    uploadDetailLevel: 'off',
+    ...overrides,
+  }
+}
+
+function makeManager(initial: CaptureSettings): RemoteModelSettingsManager & {
+  save: ReturnType<typeof vi.fn>
+} {
+  let settings = initial
+  const save = vi.fn((partial: Partial<CaptureSettings>) => {
+    settings = { ...settings, ...partial }
+    // Mirror of CaptureSettingsManager.save: flat picks land in the active
+    // vendor's map entry unless an explicit map was passed.
+    if (partial.modelsByVendor === undefined) {
+      settings.modelsByVendor = {
+        ...settings.modelsByVendor,
+        [settings.activeVendor]: {
+          semanticVideoModel: settings.semanticVideoModel,
+          semanticSnapshotModel: settings.semanticSnapshotModel,
+          patternDetectionModel: settings.patternDetectionModel,
+          semanticPipelineMode: settings.semanticPipelineMode,
+        },
+      }
+    }
+  })
+  return { get: () => ({ ...settings }), save }
+}
+
+function makeDeps(): {
+  deps: RemoteModelApplyDeps
+  semanticService: { updateModels: ReturnType<typeof vi.fn> }
+  patternDetector: { updateModel: ReturnType<typeof vi.fn> }
+  userContextBuilder: { updateModel: ReturnType<typeof vi.fn> }
+  taskMiner: { updateClusterModel: ReturnType<typeof vi.fn> }
+} {
+  const semanticService = { updateModels: vi.fn() }
+  const patternDetector = { updateModel: vi.fn() }
+  const userContextBuilder = { updateModel: vi.fn() }
+  const taskMiner = { updateClusterModel: vi.fn() }
+  return {
+    deps: { semanticService, patternDetector, userContextBuilder, taskMiner },
+    semanticService,
+    patternDetector,
+    userContextBuilder,
+    taskMiner,
+  }
+}
+
+describe('applyRemoteModelConfig', () => {
+  it('overwrites picks and records the version when it advances', () => {
+    const manager = makeManager(makeSettings())
+    const { deps } = makeDeps()
+
+    applyRemoteModelConfig(deps, manager, REMOTE)
+
+    const settings = manager.get()
+    expect(settings.semanticVideoModel).toBe('remote/video-model')
+    expect(settings.semanticSnapshotModel).toBe('remote/snapshot-model')
+    expect(settings.patternDetectionModel).toBe('remote/mining-model')
+    expect(settings.remoteModelConfigVersion).toBe(3)
+  })
+
+  it('does not overwrite picks at an equal or lower version but still pushes live chains', () => {
+    const manager = makeManager(
+      makeSettings({ remoteModelConfigVersion: 3, semanticVideoModel: 'user/custom-pick' }),
+    )
+    const { deps, semanticService } = makeDeps()
+
+    applyRemoteModelConfig(deps, manager, REMOTE)
+
+    expect(manager.save).not.toHaveBeenCalled()
+    expect(manager.get().semanticVideoModel).toBe('user/custom-pick')
+    // The live chain still reflects the remote presets under the user's pick.
+    const [videoModels] = semanticService.updateModels.mock.calls[0] as [string[], string[]]
+    expect(videoModels).toEqual([
+      'user/custom-pick',
+      'remote/video-model',
+      'google/gemini-2.5-flash',
+    ])
+  })
+
+  it('reverts a slot to the baked default when a newer config leaves it empty', () => {
+    const manager = makeManager(
+      makeSettings({ remoteModelConfigVersion: 1, semanticVideoModel: 'old-remote/model' }),
+    )
+    const { deps } = makeDeps()
+
+    applyRemoteModelConfig(deps, manager, {
+      version: 2,
+      models: { taskMining: ['remote/mining-model'] },
+    })
+
+    expect(manager.get().semanticVideoModel).toBe(VENDOR_PRESETS.openrouter.semanticVideo[0].id)
+    expect(manager.get().patternDetectionModel).toBe('remote/mining-model')
+  })
+
+  it('writes the openrouter map entry when another vendor is active, without live pushes', () => {
+    const manager = makeManager(
+      makeSettings({
+        activeVendor: 'google',
+        semanticVideoModel: 'gemini-2.5-flash',
+        modelsByVendor: {
+          openrouter: {
+            semanticVideoModel: 'user/old-pick',
+            semanticSnapshotModel: 'user/old-pick',
+            patternDetectionModel: 'user/old-pick',
+            semanticPipelineMode: 'image',
+          },
+        },
+      }),
+    )
+    const { deps, semanticService, taskMiner } = makeDeps()
+
+    applyRemoteModelConfig(deps, manager, REMOTE)
+
+    const settings = manager.get()
+    // The active vendor's flat picks are untouched…
+    expect(settings.semanticVideoModel).toBe('gemini-2.5-flash')
+    // …while the remembered openrouter selection is overwritten, mode preserved.
+    expect(settings.modelsByVendor.openrouter).toEqual({
+      semanticVideoModel: 'remote/video-model',
+      semanticSnapshotModel: 'remote/snapshot-model',
+      patternDetectionModel: 'remote/mining-model',
+      semanticPipelineMode: 'image',
+    })
+    expect(settings.remoteModelConfigVersion).toBe(3)
+    expect(semanticService.updateModels).not.toHaveBeenCalled()
+    expect(taskMiner.updateClusterModel).not.toHaveBeenCalled()
+  })
+
+  it('pushes diverged text-task models and the cluster override live', () => {
+    const manager = makeManager(makeSettings())
+    const { deps, patternDetector, userContextBuilder, taskMiner } = makeDeps()
+
+    applyRemoteModelConfig(deps, manager, REMOTE)
+
+    expect(patternDetector.updateModel).toHaveBeenCalledWith('remote/mining-model')
+    expect(userContextBuilder.updateModel).toHaveBeenCalledWith('remote/context-model')
+    expect(taskMiner.updateClusterModel).toHaveBeenCalledWith('remote/cluster-model')
+  })
+
+  it('clears the cluster override when the config has no clusterReview slot', () => {
+    const manager = makeManager(makeSettings())
+    const { deps, taskMiner } = makeDeps()
+
+    applyRemoteModelConfig(deps, manager, { version: 4, models: {} })
+
+    expect(taskMiner.updateClusterModel).toHaveBeenCalledWith(null)
+  })
+
+  it('is idempotent across repeated notifications of the same config', () => {
+    const manager = makeManager(makeSettings())
+    const { deps } = makeDeps()
+
+    applyRemoteModelConfig(deps, manager, REMOTE)
+    applyRemoteModelConfig(deps, manager, REMOTE)
+
+    expect(manager.save).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ui/remote-model-apply.test.ts
+++ b/src/main/ui/remote-model-apply.test.ts
@@ -7,11 +7,9 @@ vi.mock('@main/utils/logger', () => ({
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings } from '../../shared/types'
 import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
-import {
-  applyRemoteModelConfig,
-  type RemoteModelApplyDeps,
-  type RemoteModelSettingsManager,
-} from './remote-model-apply'
+import { makeCaptureSettings as makeSettings } from '@main/utils/test-utils'
+import type { ModelPushDeps } from './apply-models'
+import { applyRemoteModelConfig, type RemoteModelSettingsManager } from './remote-model-apply'
 
 const REMOTE: RemoteModelConfig = {
   version: 3,
@@ -22,36 +20,6 @@ const REMOTE: RemoteModelConfig = {
     userContext: ['remote/context-model'],
     clusterReview: ['remote/cluster-model'],
   },
-}
-
-function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
-  return {
-    autoStartEnabled: true,
-    visualThreshold: 8,
-    typingDebounceMs: 2000,
-    scrollDebounceMs: 2000,
-    clickDebounceMs: 3000,
-    minActivityDurationMs: 3000,
-    maxActivityDurationMs: 300000,
-    maxScreenshotsForLlm: 6,
-    semanticRequestTimeoutMs: 120000,
-    semanticPipelineMode: 'auto',
-    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
-    databaseExportDirectory: '',
-    excludePrivateBrowsing: true,
-    excludedApps: [],
-    excludedUrlPatterns: [],
-    activeVendor: 'openrouter',
-    modelsByVendor: {},
-    newTaskMinerEnabled: true,
-    semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
-    semanticSnapshotModel: VENDOR_PRESETS.openrouter.semanticSnapshot[0].id,
-    patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,
-    patternDetectionEnabled: true,
-    remoteModelConfigVersion: 0,
-    uploadDetailLevel: 'off',
-    ...overrides,
-  }
 }
 
 function makeManager(initial: CaptureSettings): RemoteModelSettingsManager & {
@@ -78,7 +46,7 @@ function makeManager(initial: CaptureSettings): RemoteModelSettingsManager & {
 }
 
 function makeDeps(): {
-  deps: RemoteModelApplyDeps
+  deps: ModelPushDeps
   semanticService: { updateModels: ReturnType<typeof vi.fn> }
   patternDetector: { updateModel: ReturnType<typeof vi.fn> }
   userContextBuilder: { updateModel: ReturnType<typeof vi.fn> }

--- a/src/main/ui/remote-model-apply.ts
+++ b/src/main/ui/remote-model-apply.ts
@@ -1,17 +1,9 @@
 import log from '@main/utils/logger'
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings } from '../../shared/types'
-import { buildModelChain } from '../../shared/vendor-defaults'
-import { getEffectivePresets, resolveTextTaskModels } from '@main/settings/effective-model-presets'
-
-export interface RemoteModelApplyDeps {
-  semanticService: {
-    updateModels(videoModels: string[], snapshotModels: string[]): void
-  }
-  patternDetector?: { updateModel(model: string): void }
-  userContextBuilder?: { updateModel(model: string): void }
-  taskMiner?: { updateClusterModel(model: string | null): void }
-}
+import { getPresetDefaults } from '../../shared/vendor-defaults'
+import { getEffectivePresets } from '@main/settings/effective-model-presets'
+import { pushModelSelections, type ModelPushDeps } from './apply-models'
 
 export interface RemoteModelSettingsManager {
   get(): CaptureSettings
@@ -26,19 +18,14 @@ export interface RemoteModelSettingsManager {
  * call on every config notification, including the cached load at startup.
  */
 export function applyRemoteModelConfig(
-  deps: RemoteModelApplyDeps,
+  deps: ModelPushDeps,
   settingsManager: RemoteModelSettingsManager,
   config: RemoteModelConfig,
 ): void {
   const settings = settingsManager.get()
-  const presets = getEffectivePresets('openrouter', config)
   // Empty remote slots resolve to the baked heads, so a version bump that
   // clears a slot cleanly reverts that pick to the baked default.
-  const heads = {
-    semanticVideoModel: presets.semanticVideo[0]?.id ?? '',
-    semanticSnapshotModel: presets.semanticSnapshot[0]?.id ?? '',
-    patternDetectionModel: presets.patternDetection[0]?.id ?? '',
-  }
+  const heads = getPresetDefaults(getEffectivePresets('openrouter', config))
 
   const appliedVersion = settings.remoteModelConfigVersion ?? 0
   if (config.version > appliedVersion) {
@@ -66,12 +53,5 @@ export function applyRemoteModelConfig(
 
   const current = settingsManager.get()
   if (current.activeVendor !== 'openrouter') return
-  deps.semanticService.updateModels(
-    buildModelChain(current.semanticVideoModel, presets.semanticVideo),
-    buildModelChain(current.semanticSnapshotModel, presets.semanticSnapshot),
-  )
-  const text = resolveTextTaskModels(current.patternDetectionModel, 'openrouter', config)
-  deps.patternDetector?.updateModel(text.taskMining)
-  deps.userContextBuilder?.updateModel(text.userContext)
-  deps.taskMiner?.updateClusterModel(config.models.clusterReview?.[0] ?? null)
+  pushModelSelections(deps, current, config)
 }

--- a/src/main/ui/remote-model-apply.ts
+++ b/src/main/ui/remote-model-apply.ts
@@ -1,0 +1,77 @@
+import log from '@main/utils/logger'
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import type { CaptureSettings } from '../../shared/types'
+import { buildModelChain } from '../../shared/vendor-defaults'
+import { getEffectivePresets, resolveTextTaskModels } from '@main/settings/effective-model-presets'
+
+export interface RemoteModelApplyDeps {
+  semanticService: {
+    updateModels(videoModels: string[], snapshotModels: string[]): void
+  }
+  patternDetector?: { updateModel(model: string): void }
+  userContextBuilder?: { updateModel(model: string): void }
+  taskMiner?: { updateClusterModel(model: string | null): void }
+}
+
+export interface RemoteModelSettingsManager {
+  get(): CaptureSettings
+  save(partial: Partial<CaptureSettings>): void
+}
+
+/**
+ * Applies a remote model config: overwrites the stored OpenRouter picks when
+ * the config's version advances past the last-applied one (same authoritative
+ * semantics as MODEL_DEFAULTS_VERSION), then pushes the effective chains into
+ * the live services when OpenRouter is the active vendor. Idempotent — safe to
+ * call on every config notification, including the cached load at startup.
+ */
+export function applyRemoteModelConfig(
+  deps: RemoteModelApplyDeps,
+  settingsManager: RemoteModelSettingsManager,
+  config: RemoteModelConfig,
+): void {
+  const settings = settingsManager.get()
+  const presets = getEffectivePresets('openrouter', config)
+  // Empty remote slots resolve to the baked heads, so a version bump that
+  // clears a slot cleanly reverts that pick to the baked default.
+  const heads = {
+    semanticVideoModel: presets.semanticVideo[0]?.id ?? '',
+    semanticSnapshotModel: presets.semanticSnapshot[0]?.id ?? '',
+    patternDetectionModel: presets.patternDetection[0]?.id ?? '',
+  }
+
+  const appliedVersion = settings.remoteModelConfigVersion ?? 0
+  if (config.version > appliedVersion) {
+    if (settings.activeVendor === 'openrouter') {
+      // save() mirrors the flat picks into modelsByVendor.openrouter.
+      settingsManager.save({ ...heads, remoteModelConfigVersion: config.version })
+    } else {
+      const remembered = settings.modelsByVendor.openrouter
+      settingsManager.save({
+        modelsByVendor: {
+          ...settings.modelsByVendor,
+          openrouter: {
+            ...heads,
+            semanticPipelineMode: remembered?.semanticPipelineMode ?? settings.semanticPipelineMode,
+          },
+        },
+        remoteModelConfigVersion: config.version,
+      })
+    }
+    log.info(
+      `[RemoteModelConfig] Applied config v${config.version} (was v${appliedVersion}), ` +
+        `overwrote OpenRouter model picks`,
+    )
+  }
+
+  const current = settingsManager.get()
+  if (current.activeVendor !== 'openrouter') return
+  deps.semanticService.updateModels(
+    buildModelChain(current.semanticVideoModel, presets.semanticVideo),
+    buildModelChain(current.semanticSnapshotModel, presets.semanticSnapshot),
+  )
+  const text = resolveTextTaskModels(current.patternDetectionModel, 'openrouter', config)
+  deps.patternDetector?.updateModel(text.taskMining)
+  deps.userContextBuilder?.updateModel(text.userContext)
+  deps.taskMiner?.updateClusterModel(config.models.clusterReview?.[0] ?? null)
+}

--- a/src/main/ui/vendor-switch.test.ts
+++ b/src/main/ui/vendor-switch.test.ts
@@ -12,6 +12,7 @@ function makeDeps(): {
   }
   patternDetector: { updateModel: ReturnType<typeof vi.fn> }
   userContextBuilder: { updateModel: ReturnType<typeof vi.fn> }
+  taskMiner: { updateClusterModel: ReturnType<typeof vi.fn> }
   inferenceProvider: { notifyConfigChanged: ReturnType<typeof vi.fn> }
 } {
   const semanticService = {
@@ -21,14 +22,23 @@ function makeDeps(): {
   }
   const patternDetector = { updateModel: vi.fn() }
   const userContextBuilder = { updateModel: vi.fn() }
+  const taskMiner = { updateClusterModel: vi.fn() }
   const inferenceProvider = { notifyConfigChanged: vi.fn() }
   const deps: VendorSwitchDeps = {
     semanticService,
     patternDetector,
     userContextBuilder,
+    taskMiner,
     inferenceProvider,
   }
-  return { deps, semanticService, patternDetector, userContextBuilder, inferenceProvider }
+  return {
+    deps,
+    semanticService,
+    patternDetector,
+    userContextBuilder,
+    taskMiner,
+    inferenceProvider,
+  }
 }
 
 function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
@@ -190,5 +200,19 @@ describe('applyVendorSwitch', () => {
     expect(videoModels).toEqual(['remote/video-model'])
     expect(patternDetector.updateModel).toHaveBeenCalledWith('minimax/minimax-m3')
     expect(userContextBuilder.updateModel).toHaveBeenCalledWith('remote/context-model')
+  })
+
+  it('sets the cluster override on openrouter and clears it on other vendors', () => {
+    const { deps, taskMiner } = makeDeps()
+    deps.getRemoteModelConfig = () => ({
+      version: 2,
+      models: { clusterReview: ['remote/cluster-model'] },
+    })
+
+    applyVendorSwitch(deps, makeSettings({ activeVendor: 'openrouter' }))
+    expect(taskMiner.updateClusterModel).toHaveBeenLastCalledWith('remote/cluster-model')
+
+    applyVendorSwitch(deps, makeSettings({ activeVendor: 'openai-compatible' }))
+    expect(taskMiner.updateClusterModel).toHaveBeenLastCalledWith(null)
   })
 })

--- a/src/main/ui/vendor-switch.test.ts
+++ b/src/main/ui/vendor-switch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { applyVendorSwitch, type VendorSwitchDeps } from './vendor-switch'
 import type { CaptureSettings, Vendor } from '../../shared/types'
 import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
+import { makeCaptureSettings } from '@main/utils/test-utils'
 
 function makeDeps(): {
   deps: VendorSwitchDeps
@@ -42,32 +43,13 @@ function makeDeps(): {
 }
 
 function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
-  return {
-    autoStartEnabled: true,
-    visualThreshold: 8,
-    typingDebounceMs: 2000,
-    scrollDebounceMs: 2000,
-    clickDebounceMs: 3000,
-    minActivityDurationMs: 3000,
-    maxActivityDurationMs: 300000,
-    maxScreenshotsForLlm: 6,
-    semanticRequestTimeoutMs: 120000,
+  return makeCaptureSettings({
     semanticPipelineMode: 'image',
-    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
-    databaseExportDirectory: '',
-    excludePrivateBrowsing: true,
-    excludedApps: [],
-    excludedUrlPatterns: [],
-    activeVendor: 'openrouter',
-    modelsByVendor: {},
-    newTaskMinerEnabled: true,
     semanticVideoModel: '',
     semanticSnapshotModel: '',
     patternDetectionModel: '',
-    patternDetectionEnabled: true,
-    uploadDetailLevel: 'off',
     ...overrides,
-  }
+  })
 }
 
 describe('applyVendorSwitch', () => {

--- a/src/main/ui/vendor-switch.test.ts
+++ b/src/main/ui/vendor-switch.test.ts
@@ -167,4 +167,28 @@ describe('applyVendorSwitch', () => {
     applyVendorSwitch(deps, makeSettings({ activeVendor: 'openrouter' }))
     expect(semanticService.testConnection).toHaveBeenCalledTimes(1)
   })
+
+  it('builds chains from the remote config and diverges the user-context model', () => {
+    const { deps, semanticService, patternDetector, userContextBuilder } = makeDeps()
+    deps.getRemoteModelConfig = () => ({
+      version: 2,
+      models: {
+        semanticVideo: ['remote/video-model'],
+        userContext: ['remote/context-model'],
+      },
+    })
+    const next = makeSettings({
+      activeVendor: 'openrouter',
+      semanticVideoModel: 'remote/video-model',
+      patternDetectionModel: 'minimax/minimax-m3',
+      semanticPipelineMode: 'auto',
+    })
+
+    applyVendorSwitch(deps, next)
+
+    const [videoModels] = semanticService.updateModels.mock.calls[0] as [string[], string[]]
+    expect(videoModels).toEqual(['remote/video-model'])
+    expect(patternDetector.updateModel).toHaveBeenCalledWith('minimax/minimax-m3')
+    expect(userContextBuilder.updateModel).toHaveBeenCalledWith('remote/context-model')
+  })
 })

--- a/src/main/ui/vendor-switch.ts
+++ b/src/main/ui/vendor-switch.ts
@@ -1,7 +1,11 @@
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings, SemanticPipelineMode } from '../../shared/types'
 import { buildModelChain } from '../../shared/vendor-defaults'
-import { getEffectivePresets, resolveTextTaskModels } from '@main/settings/effective-model-presets'
+import {
+  getEffectivePresets,
+  resolveClusterModelOverride,
+  resolveTextTaskModels,
+} from '@main/settings/effective-model-presets'
 
 /**
  * Structural shape of the dependencies that `applyVendorSwitch` touches.
@@ -16,6 +20,7 @@ export interface VendorSwitchDeps {
   }
   patternDetector?: { updateModel(model: string): void }
   userContextBuilder?: { updateModel(model: string): void }
+  taskMiner?: { updateClusterModel(model: string | null): void }
   inferenceProvider: { notifyConfigChanged(): void }
   getRemoteModelConfig?: () => RemoteModelConfig | null
 }
@@ -40,6 +45,7 @@ export function applyVendorSwitch(d: VendorSwitchDeps, next: CaptureSettings): v
   const text = resolveTextTaskModels(next.patternDetectionModel, next.activeVendor, remote)
   d.patternDetector?.updateModel(text.taskMining)
   d.userContextBuilder?.updateModel(text.userContext)
+  d.taskMiner?.updateClusterModel(resolveClusterModelOverride(next.activeVendor, remote))
   d.inferenceProvider.notifyConfigChanged()
   void d.semanticService.testConnection()
 }

--- a/src/main/ui/vendor-switch.ts
+++ b/src/main/ui/vendor-switch.ts
@@ -1,5 +1,7 @@
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings, SemanticPipelineMode } from '../../shared/types'
-import { VENDOR_PRESETS, buildModelChain } from '../../shared/vendor-defaults'
+import { buildModelChain } from '../../shared/vendor-defaults'
+import { getEffectivePresets, resolveTextTaskModels } from '@main/settings/effective-model-presets'
 
 /**
  * Structural shape of the dependencies that `applyVendorSwitch` touches.
@@ -15,6 +17,7 @@ export interface VendorSwitchDeps {
   patternDetector?: { updateModel(model: string): void }
   userContextBuilder?: { updateModel(model: string): void }
   inferenceProvider: { notifyConfigChanged(): void }
+  getRemoteModelConfig?: () => RemoteModelConfig | null
 }
 
 /**
@@ -27,14 +30,16 @@ export interface VendorSwitchDeps {
  * with.
  */
 export function applyVendorSwitch(d: VendorSwitchDeps, next: CaptureSettings): void {
-  const presets = VENDOR_PRESETS[next.activeVendor]
+  const remote = d.getRemoteModelConfig?.() ?? null
+  const presets = getEffectivePresets(next.activeVendor, remote)
   d.semanticService.updateModels(
     buildModelChain(next.semanticVideoModel, presets.semanticVideo),
     buildModelChain(next.semanticSnapshotModel, presets.semanticSnapshot),
   )
   d.semanticService.updatePipelinePreference(next.semanticPipelineMode)
-  d.patternDetector?.updateModel(next.patternDetectionModel)
-  d.userContextBuilder?.updateModel(next.patternDetectionModel)
+  const text = resolveTextTaskModels(next.patternDetectionModel, next.activeVendor, remote)
+  d.patternDetector?.updateModel(text.taskMining)
+  d.userContextBuilder?.updateModel(text.userContext)
   d.inferenceProvider.notifyConfigChanged()
   void d.semanticService.testConnection()
 }

--- a/src/main/ui/vendor-switch.ts
+++ b/src/main/ui/vendor-switch.ts
@@ -1,26 +1,17 @@
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings, SemanticPipelineMode } from '../../shared/types'
-import { buildModelChain } from '../../shared/vendor-defaults'
-import {
-  getEffectivePresets,
-  resolveClusterModelOverride,
-  resolveTextTaskModels,
-} from '@main/settings/effective-model-presets'
+import { pushModelSelections, type ModelPushDeps } from './apply-models'
 
 /**
  * Structural shape of the dependencies that `applyVendorSwitch` touches.
  * Defined separately so the helper is unit-testable without a full
  * `MainWindowDependencies` mock.
  */
-export interface VendorSwitchDeps {
-  semanticService: {
-    updateModels(videoModels: string[], snapshotModels: string[]): void
+export interface VendorSwitchDeps extends ModelPushDeps {
+  semanticService: ModelPushDeps['semanticService'] & {
     updatePipelinePreference(mode: SemanticPipelineMode): void
     testConnection(): Promise<void>
   }
-  patternDetector?: { updateModel(model: string): void }
-  userContextBuilder?: { updateModel(model: string): void }
-  taskMiner?: { updateClusterModel(model: string | null): void }
   inferenceProvider: { notifyConfigChanged(): void }
   getRemoteModelConfig?: () => RemoteModelConfig | null
 }
@@ -35,17 +26,8 @@ export interface VendorSwitchDeps {
  * with.
  */
 export function applyVendorSwitch(d: VendorSwitchDeps, next: CaptureSettings): void {
-  const remote = d.getRemoteModelConfig?.() ?? null
-  const presets = getEffectivePresets(next.activeVendor, remote)
-  d.semanticService.updateModels(
-    buildModelChain(next.semanticVideoModel, presets.semanticVideo),
-    buildModelChain(next.semanticSnapshotModel, presets.semanticSnapshot),
-  )
+  pushModelSelections(d, next, d.getRemoteModelConfig?.() ?? null)
   d.semanticService.updatePipelinePreference(next.semanticPipelineMode)
-  const text = resolveTextTaskModels(next.patternDetectionModel, next.activeVendor, remote)
-  d.patternDetector?.updateModel(text.taskMining)
-  d.userContextBuilder?.updateModel(text.userContext)
-  d.taskMiner?.updateClusterModel(resolveClusterModelOverride(next.activeVendor, remote))
   d.inferenceProvider.notifyConfigChanged()
   void d.semanticService.testConnection()
 }

--- a/src/main/utils/json-file-store.ts
+++ b/src/main/utils/json-file-store.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import log from '@main/utils/logger'
+
+export interface JsonFileStore<T> {
+  read: (filePath?: string) => T | null
+  write: (value: T, filePath?: string) => void
+}
+
+/**
+ * Read/write helpers for a JSON cache file in the app's userData directory.
+ * `read` returns null when the file is missing or unreadable/corrupt, so
+ * callers fall back to their defaults; `write` failures are swallowed (logged)
+ * — a disk hiccup must never break a sync loop.
+ */
+export function createUserDataJsonStore<T>(
+  fileName: string,
+  tag: string,
+  coerce: (data: unknown) => T | null,
+): JsonFileStore<T> {
+  const defaultPath = (): string => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const electron = require('electron') as typeof import('electron')
+    return path.join(electron.app.getPath('userData'), fileName)
+  }
+  return {
+    read(filePath = defaultPath()) {
+      try {
+        return coerce(JSON.parse(fs.readFileSync(filePath, 'utf-8')))
+      } catch {
+        return null
+      }
+    },
+    write(value, filePath = defaultPath()) {
+      try {
+        fs.writeFileSync(filePath, JSON.stringify(value, null, 2))
+      } catch (error) {
+        log.warn(`[${tag}] Failed to persist ${fileName}:`, error)
+      }
+    },
+  }
+}

--- a/src/main/utils/test-utils.ts
+++ b/src/main/utils/test-utils.ts
@@ -1,3 +1,6 @@
+import type { CaptureSettings } from '../../shared/types'
+import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
+
 export function jsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
     ok,
@@ -5,4 +8,34 @@ export function jsonResponse(body: unknown, ok = true, status = 200): Response {
     json: async () => body,
     text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
   } as Response
+}
+
+export function makeCaptureSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
+  return {
+    autoStartEnabled: true,
+    visualThreshold: 8,
+    typingDebounceMs: 2000,
+    scrollDebounceMs: 2000,
+    clickDebounceMs: 3000,
+    minActivityDurationMs: 3000,
+    maxActivityDurationMs: 300000,
+    maxScreenshotsForLlm: 6,
+    semanticRequestTimeoutMs: 120000,
+    semanticPipelineMode: 'auto',
+    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
+    databaseExportDirectory: '',
+    excludePrivateBrowsing: true,
+    excludedApps: [],
+    excludedUrlPatterns: [],
+    activeVendor: 'openrouter',
+    modelsByVendor: {},
+    newTaskMinerEnabled: true,
+    semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
+    semanticSnapshotModel: VENDOR_PRESETS.openrouter.semanticSnapshot[0].id,
+    patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,
+    patternDetectionEnabled: true,
+    remoteModelConfigVersion: 0,
+    uploadDetailLevel: 'off',
+    ...overrides,
+  }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -65,6 +65,7 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
   listSeenDomains: () => ipcRenderer.invoke('main-window:listSeenDomains'),
   // Capture settings
   getCaptureSettings: () => ipcRenderer.invoke('main-window:getCaptureSettings'),
+  getModelPresets: () => ipcRenderer.invoke('main-window:getModelPresets'),
   saveCaptureSettings: (settings: Record<string, unknown>) =>
     ipcRenderer.invoke('main-window:saveCaptureSettings', settings),
   resetCaptureSettings: () => ipcRenderer.invoke('main-window:resetCaptureSettings'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -65,7 +65,6 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
   listSeenDomains: () => ipcRenderer.invoke('main-window:listSeenDomains'),
   // Capture settings
   getCaptureSettings: () => ipcRenderer.invoke('main-window:getCaptureSettings'),
-  getModelPresets: () => ipcRenderer.invoke('main-window:getModelPresets'),
   saveCaptureSettings: (settings: Record<string, unknown>) =>
     ipcRenderer.invoke('main-window:saveCaptureSettings', settings),
   resetCaptureSettings: () => ipcRenderer.invoke('main-window:resetCaptureSettings'),

--- a/src/renderer/pages/main-window/components/advanced-settings/AiModelsSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/AiModelsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { toast } from 'sonner'
 import { Cpu, Sparkles } from 'lucide-react'
 import { Button } from '@components/ui/button'
@@ -18,7 +18,7 @@ import type {
   VendorStatus,
 } from '@types'
 import { VENDORS } from '@types'
-import { VENDOR_PRESETS, type VendorPresets } from '@/shared/vendor-defaults'
+import { VENDOR_PRESETS, getVendorDefaults } from '@/shared/vendor-defaults'
 import { ManageKeySection } from '../ManageKeySection'
 import { ModelSelector } from './ModelSelector'
 import { SegmentedControl } from './SegmentedControl'
@@ -70,27 +70,10 @@ export function AiModelsSection({
   const activeVendor = form.activeVendor
   const activeStatus = credentialStatuses?.[activeVendor] ?? null
   const hasLlmAccess = activeStatus?.hasKey === true
-  const selectorMode: 'preset' | 'freetext' =
-    activeStatus?.source === 'managed' ? 'preset' : 'freetext'
-  // Baked presets render immediately; the effective (remote-aware) lists
-  // replace them once fetched so managed-mode pickers can show remote models.
-  const [presetsByVendor, setPresetsByVendor] =
-    useState<Record<Vendor, VendorPresets>>(VENDOR_PRESETS)
-  useEffect(() => {
-    let cancelled = false
-    void api.getModelPresets().then((presets) => {
-      if (!cancelled && presets) setPresetsByVendor(presets)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [api])
-  const presets = presetsByVendor[activeVendor]
-  const vendorDefaults = {
-    semanticVideoModel: presets.semanticVideo[0]?.id ?? '',
-    semanticSnapshotModel: presets.semanticSnapshot[0]?.id ?? '',
-    patternDetectionModel: presets.patternDetection[0]?.id ?? '',
-  }
+  // Managed keys hide the advanced options below: models are chosen remotely
+  // (DEU-202) and the tuning knobs aren't meant for managed installs.
+  const isManagedKey = activeStatus?.source === 'managed'
+  const vendorDefaults = getVendorDefaults(activeVendor)
   const videoSupported = vendorDefaults.semanticVideoModel.length > 0
   const visibleVendors = isEnterprise ? VENDORS : VENDORS.filter((v) => v !== 'google')
 
@@ -163,159 +146,163 @@ export function AiModelsSection({
               />
             }
           />
-          <div className="py-3 first:pt-0 last:pb-0">
-            <SettingsDisclosure label="Advanced options">
-              <div className="space-y-2">
-                <p className="text-xs font-medium text-muted-foreground">Semantic media pipeline</p>
-                <SegmentedControl
-                  ariaLabel="Semantic media pipeline"
-                  value={form.semanticPipelineMode}
-                  onChange={onSemanticPipelineModeChange}
-                  options={[
-                    { value: 'auto', label: 'Auto', disabled: !videoSupported },
-                    { value: 'video', label: 'Video only', disabled: !videoSupported },
-                    { value: 'image', label: 'Image only' },
-                  ]}
-                />
-                <p className="text-xs text-muted-foreground">
-                  {!videoSupported
-                    ? `${VENDOR_LABELS[activeVendor]} has no default video model — using image snapshots only.`
-                    : form.semanticPipelineMode === 'auto'
-                      ? 'Tries video first, then falls back to images when needed.'
-                      : form.semanticPipelineMode === 'video'
-                        ? 'Uses only the video pipeline and never falls back to images.'
-                        : 'Uses only image snapshots and skips video requests.'}
-                </p>
-                <SliderRow
-                  label="LLM request timeout"
-                  value={form.semanticRequestTimeoutMs}
-                  min={15_000}
-                  max={300_000}
-                  step={5_000}
-                  format={formatMinSec}
-                  onChange={(v) => onSettingChange('semanticRequestTimeoutMs', v)}
-                  onCommit={(v) => onSettingCommit('semanticRequestTimeoutMs', v)}
-                />
-              </div>
-              <div className="space-y-3">
-                <p className="text-xs font-medium text-muted-foreground">Model selection</p>
-                {form.semanticPipelineMode !== 'image' && (
-                  <ModelSelector
-                    mode={selectorMode}
-                    presets={presets.semanticVideo}
-                    value={form.semanticVideoModel}
-                    defaultValue={vendorDefaults.semanticVideoModel}
-                    onChange={(v) => onModelChange('semanticVideoModel', v)}
-                    label="Video analysis model"
+          {!isManagedKey && (
+            <div className="py-3 first:pt-0 last:pb-0">
+              <SettingsDisclosure label="Advanced options">
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Semantic media pipeline
+                  </p>
+                  <SegmentedControl
+                    ariaLabel="Semantic media pipeline"
+                    value={form.semanticPipelineMode}
+                    onChange={onSemanticPipelineModeChange}
+                    options={[
+                      { value: 'auto', label: 'Auto', disabled: !videoSupported },
+                      { value: 'video', label: 'Video only', disabled: !videoSupported },
+                      { value: 'image', label: 'Image only' },
+                    ]}
                   />
-                )}
-                {form.semanticPipelineMode !== 'video' && (
-                  <ModelSelector
-                    mode={selectorMode}
-                    presets={presets.semanticSnapshot}
-                    value={form.semanticSnapshotModel}
-                    defaultValue={vendorDefaults.semanticSnapshotModel}
-                    onChange={(v) => onModelChange('semanticSnapshotModel', v)}
-                    label="Snapshot analysis model"
+                  <p className="text-xs text-muted-foreground">
+                    {!videoSupported
+                      ? `${VENDOR_LABELS[activeVendor]} has no default video model — using image snapshots only.`
+                      : form.semanticPipelineMode === 'auto'
+                        ? 'Tries video first, then falls back to images when needed.'
+                        : form.semanticPipelineMode === 'video'
+                          ? 'Uses only the video pipeline and never falls back to images.'
+                          : 'Uses only image snapshots and skips video requests.'}
+                  </p>
+                  <SliderRow
+                    label="LLM request timeout"
+                    value={form.semanticRequestTimeoutMs}
+                    min={15_000}
+                    max={300_000}
+                    step={5_000}
+                    format={formatMinSec}
+                    onChange={(v) => onSettingChange('semanticRequestTimeoutMs', v)}
+                    onCommit={(v) => onSettingCommit('semanticRequestTimeoutMs', v)}
                   />
-                )}
-                <ModelSelector
-                  mode={selectorMode}
-                  presets={presets.patternDetection}
-                  value={form.patternDetectionModel}
-                  defaultValue={vendorDefaults.patternDetectionModel}
-                  onChange={(v) => onModelChange('patternDetectionModel', v)}
-                  label="Automation opportunities model"
-                />
-              </div>
-              <div className="space-y-2">
-                <p className="text-xs font-medium text-muted-foreground">Capture sensitivity</p>
-                <SliderRow
-                  label="Visual change sensitivity"
-                  value={form.visualThreshold}
-                  min={1}
-                  max={20}
-                  step={1}
-                  format={(v) =>
-                    `${v}% — ${v <= 5 ? 'more captures' : v >= 15 ? 'fewer captures' : 'balanced'}`
-                  }
-                  onChange={(v) => onSettingChange('visualThreshold', v)}
-                  onCommit={(v) => onSettingCommit('visualThreshold', v)}
-                />
-              </div>
-              <div className="space-y-2">
-                <p className="text-xs font-medium text-muted-foreground">Interaction timeouts</p>
-                <SliderRow
-                  label="Typing debounce"
-                  value={form.typingDebounceMs}
-                  min={500}
-                  max={10_000}
-                  step={100}
-                  format={formatMs}
-                  onChange={(v) => onSettingChange('typingDebounceMs', v)}
-                  onCommit={(v) => onSettingCommit('typingDebounceMs', v)}
-                />
-                <SliderRow
-                  label="Scroll debounce"
-                  value={form.scrollDebounceMs}
-                  min={200}
-                  max={5_000}
-                  step={100}
-                  format={formatMs}
-                  onChange={(v) => onSettingChange('scrollDebounceMs', v)}
-                  onCommit={(v) => onSettingCommit('scrollDebounceMs', v)}
-                />
-                <SliderRow
-                  label="Click debounce"
-                  value={form.clickDebounceMs}
-                  min={500}
-                  max={10_000}
-                  step={100}
-                  format={formatMs}
-                  onChange={(v) => onSettingChange('clickDebounceMs', v)}
-                  onCommit={(v) => onSettingCommit('clickDebounceMs', v)}
-                />
-              </div>
-              <div className="space-y-2">
-                <p className="text-xs font-medium text-muted-foreground">Activity windows</p>
-                <SliderRow
-                  label="Minimum activity duration"
-                  value={form.minActivityDurationMs}
-                  min={1_000}
-                  max={30_000}
-                  step={1_000}
-                  format={formatMs}
-                  onChange={(v) => onSettingChange('minActivityDurationMs', v)}
-                  onCommit={(v) => onSettingCommit('minActivityDurationMs', v)}
-                />
-                <SliderRow
-                  label="Maximum activity duration"
-                  value={form.maxActivityDurationMs}
-                  min={60_000}
-                  max={1_800_000}
-                  step={60_000}
-                  format={formatMs}
-                  onChange={(v) => onSettingChange('maxActivityDurationMs', v)}
-                  onCommit={(v) => onSettingCommit('maxActivityDurationMs', v)}
-                />
-                <SliderRow
-                  label="Max screenshots for LLM"
-                  value={form.maxScreenshotsForLlm}
-                  min={1}
-                  max={20}
-                  step={1}
-                  format={(v) => `${v}`}
-                  onChange={(v) => onSettingChange('maxScreenshotsForLlm', v)}
-                  onCommit={(v) => onSettingCommit('maxScreenshotsForLlm', v)}
-                />
-              </div>
-              <div className="flex justify-end">
-                <Button variant="ghost" size="sm" onClick={onReset}>
-                  Reset to defaults
-                </Button>
-              </div>
-            </SettingsDisclosure>
-          </div>
+                </div>
+                <div className="space-y-3">
+                  <p className="text-xs font-medium text-muted-foreground">Model selection</p>
+                  {form.semanticPipelineMode !== 'image' && (
+                    <ModelSelector
+                      mode="freetext"
+                      presets={VENDOR_PRESETS[activeVendor].semanticVideo}
+                      value={form.semanticVideoModel}
+                      defaultValue={vendorDefaults.semanticVideoModel}
+                      onChange={(v) => onModelChange('semanticVideoModel', v)}
+                      label="Video analysis model"
+                    />
+                  )}
+                  {form.semanticPipelineMode !== 'video' && (
+                    <ModelSelector
+                      mode="freetext"
+                      presets={VENDOR_PRESETS[activeVendor].semanticSnapshot}
+                      value={form.semanticSnapshotModel}
+                      defaultValue={vendorDefaults.semanticSnapshotModel}
+                      onChange={(v) => onModelChange('semanticSnapshotModel', v)}
+                      label="Snapshot analysis model"
+                    />
+                  )}
+                  <ModelSelector
+                    mode="freetext"
+                    presets={VENDOR_PRESETS[activeVendor].patternDetection}
+                    value={form.patternDetectionModel}
+                    defaultValue={vendorDefaults.patternDetectionModel}
+                    onChange={(v) => onModelChange('patternDetectionModel', v)}
+                    label="Automation opportunities model"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">Capture sensitivity</p>
+                  <SliderRow
+                    label="Visual change sensitivity"
+                    value={form.visualThreshold}
+                    min={1}
+                    max={20}
+                    step={1}
+                    format={(v) =>
+                      `${v}% — ${v <= 5 ? 'more captures' : v >= 15 ? 'fewer captures' : 'balanced'}`
+                    }
+                    onChange={(v) => onSettingChange('visualThreshold', v)}
+                    onCommit={(v) => onSettingCommit('visualThreshold', v)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">Interaction timeouts</p>
+                  <SliderRow
+                    label="Typing debounce"
+                    value={form.typingDebounceMs}
+                    min={500}
+                    max={10_000}
+                    step={100}
+                    format={formatMs}
+                    onChange={(v) => onSettingChange('typingDebounceMs', v)}
+                    onCommit={(v) => onSettingCommit('typingDebounceMs', v)}
+                  />
+                  <SliderRow
+                    label="Scroll debounce"
+                    value={form.scrollDebounceMs}
+                    min={200}
+                    max={5_000}
+                    step={100}
+                    format={formatMs}
+                    onChange={(v) => onSettingChange('scrollDebounceMs', v)}
+                    onCommit={(v) => onSettingCommit('scrollDebounceMs', v)}
+                  />
+                  <SliderRow
+                    label="Click debounce"
+                    value={form.clickDebounceMs}
+                    min={500}
+                    max={10_000}
+                    step={100}
+                    format={formatMs}
+                    onChange={(v) => onSettingChange('clickDebounceMs', v)}
+                    onCommit={(v) => onSettingCommit('clickDebounceMs', v)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">Activity windows</p>
+                  <SliderRow
+                    label="Minimum activity duration"
+                    value={form.minActivityDurationMs}
+                    min={1_000}
+                    max={30_000}
+                    step={1_000}
+                    format={formatMs}
+                    onChange={(v) => onSettingChange('minActivityDurationMs', v)}
+                    onCommit={(v) => onSettingCommit('minActivityDurationMs', v)}
+                  />
+                  <SliderRow
+                    label="Maximum activity duration"
+                    value={form.maxActivityDurationMs}
+                    min={60_000}
+                    max={1_800_000}
+                    step={60_000}
+                    format={formatMs}
+                    onChange={(v) => onSettingChange('maxActivityDurationMs', v)}
+                    onCommit={(v) => onSettingCommit('maxActivityDurationMs', v)}
+                  />
+                  <SliderRow
+                    label="Max screenshots for LLM"
+                    value={form.maxScreenshotsForLlm}
+                    min={1}
+                    max={20}
+                    step={1}
+                    format={(v) => `${v}`}
+                    onChange={(v) => onSettingChange('maxScreenshotsForLlm', v)}
+                    onCommit={(v) => onSettingCommit('maxScreenshotsForLlm', v)}
+                  />
+                </div>
+                <div className="flex justify-end">
+                  <Button variant="ghost" size="sm" onClick={onReset}>
+                    Reset to defaults
+                  </Button>
+                </div>
+              </SettingsDisclosure>
+            </div>
+          )}
         </SettingsSection>
       )}
     </div>

--- a/src/renderer/pages/main-window/components/advanced-settings/AiModelsSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/AiModelsSection.tsx
@@ -18,7 +18,7 @@ import type {
   VendorStatus,
 } from '@types'
 import { VENDORS } from '@types'
-import { VENDOR_PRESETS, getVendorDefaults } from '@/shared/vendor-defaults'
+import { getVendorDefaults } from '@/shared/vendor-defaults'
 import { ManageKeySection } from '../ManageKeySection'
 import { ModelSelector } from './ModelSelector'
 import { SegmentedControl } from './SegmentedControl'
@@ -187,8 +187,6 @@ export function AiModelsSection({
                   <p className="text-xs font-medium text-muted-foreground">Model selection</p>
                   {form.semanticPipelineMode !== 'image' && (
                     <ModelSelector
-                      mode="freetext"
-                      presets={VENDOR_PRESETS[activeVendor].semanticVideo}
                       value={form.semanticVideoModel}
                       defaultValue={vendorDefaults.semanticVideoModel}
                       onChange={(v) => onModelChange('semanticVideoModel', v)}
@@ -197,8 +195,6 @@ export function AiModelsSection({
                   )}
                   {form.semanticPipelineMode !== 'video' && (
                     <ModelSelector
-                      mode="freetext"
-                      presets={VENDOR_PRESETS[activeVendor].semanticSnapshot}
                       value={form.semanticSnapshotModel}
                       defaultValue={vendorDefaults.semanticSnapshotModel}
                       onChange={(v) => onModelChange('semanticSnapshotModel', v)}
@@ -206,8 +202,6 @@ export function AiModelsSection({
                     />
                   )}
                   <ModelSelector
-                    mode="freetext"
-                    presets={VENDOR_PRESETS[activeVendor].patternDetection}
                     value={form.patternDetectionModel}
                     defaultValue={vendorDefaults.patternDetectionModel}
                     onChange={(v) => onModelChange('patternDetectionModel', v)}

--- a/src/renderer/pages/main-window/components/advanced-settings/AiModelsSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/AiModelsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Cpu, Sparkles } from 'lucide-react'
 import { Button } from '@components/ui/button'
@@ -18,7 +18,7 @@ import type {
   VendorStatus,
 } from '@types'
 import { VENDORS } from '@types'
-import { VENDOR_PRESETS, getVendorDefaults } from '@/shared/vendor-defaults'
+import { VENDOR_PRESETS, type VendorPresets } from '@/shared/vendor-defaults'
 import { ManageKeySection } from '../ManageKeySection'
 import { ModelSelector } from './ModelSelector'
 import { SegmentedControl } from './SegmentedControl'
@@ -72,7 +72,25 @@ export function AiModelsSection({
   const hasLlmAccess = activeStatus?.hasKey === true
   const selectorMode: 'preset' | 'freetext' =
     activeStatus?.source === 'managed' ? 'preset' : 'freetext'
-  const vendorDefaults = getVendorDefaults(activeVendor)
+  // Baked presets render immediately; the effective (remote-aware) lists
+  // replace them once fetched so managed-mode pickers can show remote models.
+  const [presetsByVendor, setPresetsByVendor] =
+    useState<Record<Vendor, VendorPresets>>(VENDOR_PRESETS)
+  useEffect(() => {
+    let cancelled = false
+    void api.getModelPresets().then((presets) => {
+      if (!cancelled && presets) setPresetsByVendor(presets)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [api])
+  const presets = presetsByVendor[activeVendor]
+  const vendorDefaults = {
+    semanticVideoModel: presets.semanticVideo[0]?.id ?? '',
+    semanticSnapshotModel: presets.semanticSnapshot[0]?.id ?? '',
+    patternDetectionModel: presets.patternDetection[0]?.id ?? '',
+  }
   const videoSupported = vendorDefaults.semanticVideoModel.length > 0
   const visibleVendors = isEnterprise ? VENDORS : VENDORS.filter((v) => v !== 'google')
 
@@ -184,7 +202,7 @@ export function AiModelsSection({
                 {form.semanticPipelineMode !== 'image' && (
                   <ModelSelector
                     mode={selectorMode}
-                    presets={VENDOR_PRESETS[activeVendor].semanticVideo}
+                    presets={presets.semanticVideo}
                     value={form.semanticVideoModel}
                     defaultValue={vendorDefaults.semanticVideoModel}
                     onChange={(v) => onModelChange('semanticVideoModel', v)}
@@ -194,7 +212,7 @@ export function AiModelsSection({
                 {form.semanticPipelineMode !== 'video' && (
                   <ModelSelector
                     mode={selectorMode}
-                    presets={VENDOR_PRESETS[activeVendor].semanticSnapshot}
+                    presets={presets.semanticSnapshot}
                     value={form.semanticSnapshotModel}
                     defaultValue={vendorDefaults.semanticSnapshotModel}
                     onChange={(v) => onModelChange('semanticSnapshotModel', v)}
@@ -203,7 +221,7 @@ export function AiModelsSection({
                 )}
                 <ModelSelector
                   mode={selectorMode}
-                  presets={VENDOR_PRESETS[activeVendor].patternDetection}
+                  presets={presets.patternDetection}
                   value={form.patternDetectionModel}
                   defaultValue={vendorDefaults.patternDetectionModel}
                   onChange={(v) => onModelChange('patternDetectionModel', v)}

--- a/src/renderer/pages/main-window/components/advanced-settings/ModelSelector.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/ModelSelector.tsx
@@ -1,16 +1,8 @@
 import { useState } from 'react'
 import { Input } from '@components/ui/input'
 import { Label } from '@components/ui/label'
-import { SegmentedControl } from './SegmentedControl'
-
-export interface ModelPreset {
-  id: string
-  label: string
-}
 
 interface ModelSelectorProps {
-  mode: 'preset' | 'freetext'
-  presets: ModelPreset[]
   value: string
   defaultValue: string
   onChange: (model: string) => void
@@ -18,30 +10,12 @@ interface ModelSelectorProps {
 }
 
 export function ModelSelector({
-  mode,
-  presets,
   value,
   defaultValue,
   onChange,
   label,
 }: ModelSelectorProps): React.JSX.Element {
   const [draft, setDraft] = useState<string | null>(null)
-
-  if (mode === 'preset') {
-    const effectiveValue = value || defaultValue
-    return (
-      <div className="space-y-1.5">
-        <Label className="text-xs text-muted-foreground">{label}</Label>
-        <SegmentedControl
-          ariaLabel={label}
-          layout="wrap"
-          value={effectiveValue}
-          onChange={(id) => onChange(id === defaultValue ? '' : id)}
-          options={presets.map((preset) => ({ value: preset.id, label: preset.label }))}
-        />
-      </div>
-    )
-  }
 
   const displayed = draft ?? (value || defaultValue)
 

--- a/src/shared/remote-model-config.ts
+++ b/src/shared/remote-model-config.ts
@@ -10,7 +10,8 @@ export type RemoteModelSlot = (typeof REMOTE_MODEL_SLOTS)[number]
 
 /**
  * Backend-published model pipeline config (`GET api/config/models`). One global
- * config for all installs; OpenRouter vendor only.
+ * config; applies only to installs running a managed OpenRouter key — BYOK and
+ * custom endpoints keep full model control.
  */
 export interface RemoteModelConfig {
   /** Monotonic; 0 = no remote opinion. The backend bumps it on ANY change to `models`. */

--- a/src/shared/remote-model-config.ts
+++ b/src/shared/remote-model-config.ts
@@ -1,0 +1,20 @@
+export const REMOTE_MODEL_SLOTS = [
+  'semanticVideo',
+  'semanticSnapshot',
+  'taskMining',
+  'userContext',
+  'clusterReview',
+] as const
+
+export type RemoteModelSlot = (typeof REMOTE_MODEL_SLOTS)[number]
+
+/**
+ * Backend-published model pipeline config (`GET api/config/models`). One global
+ * config for all installs; OpenRouter vendor only.
+ */
+export interface RemoteModelConfig {
+  /** Monotonic; 0 = no remote opinion. The backend bumps it on ANY change to `models`. */
+  version: number
+  /** Ordered fallback chains of OpenRouter model ids. Empty/missing slot → baked VENDOR_PRESETS. */
+  models: Partial<Record<RemoteModelSlot, string[]>>
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,5 @@
 import type { AppEditionConfig } from './edition'
+import type { VendorPresets } from './vendor-defaults'
 import type {
   EvalFixtureLoad,
   EvalFixtureSummary,
@@ -244,6 +245,8 @@ export interface CaptureSettings {
   urlMatchSchemaVersion?: number
   appMatchSchemaVersion?: number
   modelDefaultsVersion?: number
+  /** Version of the last-applied remote model config; 0 = never applied. */
+  remoteModelConfigVersion?: number
   activeVendor: Vendor
   semanticVideoModel: string
   semanticSnapshotModel: string
@@ -484,6 +487,8 @@ export interface MainWindowAPI {
   listSeenDomains: () => Promise<SeenDomain[]>
   // Capture settings
   getCaptureSettings: () => Promise<CaptureSettings>
+  /** Preset lists per vendor with the remote model config layered in. */
+  getModelPresets: () => Promise<Record<Vendor, VendorPresets>>
   saveCaptureSettings: (settings: Partial<CaptureSettings>) => Promise<SaveResult>
   resetCaptureSettings: () => Promise<SaveResult>
   // Patterns (task clusters) — new TaskMiner view

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,4 @@
 import type { AppEditionConfig } from './edition'
-import type { VendorPresets } from './vendor-defaults'
 import type {
   EvalFixtureLoad,
   EvalFixtureSummary,
@@ -487,8 +486,6 @@ export interface MainWindowAPI {
   listSeenDomains: () => Promise<SeenDomain[]>
   // Capture settings
   getCaptureSettings: () => Promise<CaptureSettings>
-  /** Preset lists per vendor with the remote model config layered in. */
-  getModelPresets: () => Promise<Record<Vendor, VendorPresets>>
   saveCaptureSettings: (settings: Partial<CaptureSettings>) => Promise<SaveResult>
   resetCaptureSettings: () => Promise<SaveResult>
   // Patterns (task clusters) — new TaskMiner view

--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -83,13 +83,17 @@ export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
   },
 }
 
-export function getVendorDefaults(vendor: Vendor): VendorModelDefaults {
-  const p = VENDOR_PRESETS[vendor]
+/** The default pick per slot: the head of each preset list, '' when empty. */
+export function getPresetDefaults(p: VendorPresets): VendorModelDefaults {
   return {
     semanticVideoModel: p.semanticVideo[0]?.id ?? '',
     semanticSnapshotModel: p.semanticSnapshot[0]?.id ?? '',
     patternDetectionModel: p.patternDetection[0]?.id ?? '',
   }
+}
+
+export function getVendorDefaults(vendor: Vendor): VendorModelDefaults {
+  return getPresetDefaults(VENDOR_PRESETS[vendor])
 }
 
 /**

--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -15,7 +15,7 @@ export interface ModelPreset {
  */
 export const MODEL_DEFAULTS_VERSION = 2
 
-interface VendorPresets {
+export interface VendorPresets {
   /** Presets for each model slot. The first entry is the vendor's default. */
   semanticVideo: ModelPreset[]
   semanticSnapshot: ModelPreset[]


### PR DESCRIPTION
Closes DEU-202.

Makes the model pipeline remotely configurable so a degraded or repriced model can be swapped without shipping an app update.

## Contract (backend implements separately)

```
GET {BACKEND_BASE}api/config/models
Authorization: Bearer {deviceId}
```

```json
{
  "version": 3,
  "models": {
    "semanticVideo":    ["google/gemini-3.1-flash-lite", "google/gemini-2.5-flash"],
    "semanticSnapshot": ["mistralai/mistral-small-3.2-24b-instruct"],
    "taskMining":       ["minimax/minimax-m3"],
    "userContext":      ["minimax/minimax-m3"],
    "clusterReview":    ["minimax/minimax-m3"]
  }
}
```

- One global config, no query params; OpenRouter ids only. **Managed-key installs only** — BYOK and custom OpenAI-compatible endpoints never poll and are never overwritten; they keep full model control.
- `version` is monotonic; bump on any change. Overwrite of stored picks happens only when it exceeds the locally applied version (same semantics as `MODEL_DEFAULTS_VERSION`). Rollback = republish under a higher version.
- Empty/missing slot = no remote opinion → baked presets. Any non-200 or malformed body → client keeps its disk cache indefinitely.

## Client side

- `RemoteModelConfigService`: 5-min poll + immediate sync at startup, disk cache applied synchronously before the first fetch (`RemoteBlacklistService` pattern; runs in both editions). Syncing and applying are both gated on the OpenRouter credential source being `managed`.
- `coerceRemoteModelConfig`: single sanitization chokepoint for network and disk input.
- `effective-model-presets`: layers remote chains over `VENDOR_PRESETS`; `resolveTextTaskModels` splits the single stored pick into taskMining/userContext/clusterReview; `resolveClusterModelOverride` keeps the cluster override OpenRouter-only (cleared on vendor switch, so a remote id can never run against another vendor).
- `applyRemoteModelConfig`: version-gated pick overwrite (active vendor flat fields, or the remembered `modelsByVendor.openrouter` entry) + unconditional live pushes when OpenRouter is active.
- Chain call sites (`runtime`, `model-settings`, `vendor-switch`, `reconcileManagedModelSelections`) now use effective presets — the reconcile switch is what stops managed-key events from resetting remote-applied models.
- `TaskMiner.updateClusterModel`: cluster labeling can run a different model than mining.
- Settings UI: managed-key installs hide the "Advanced options" disclosure entirely (models are remote-managed); the pickers only render for BYOK/custom installs, where baked presets apply.

## Testing

- 1203 unit tests pass (new suites: store coercion, service sync, apply gating, effective presets, settings stamp reset, miner cluster model, vendor-switch cluster-override clearing).
- Stub-server E2E (real HTTP server + real settings manager on temp files): apply, user-pick survival at equal version, overwrite on bump, empty-slot revert, 500 keeps cache, restart applies cache offline — 17/17 assertions.
- `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
