### PR TITLE
refactor(llm): deduplicate remote model config machinery

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -41,10 +41,7 @@ import { readRemoteBlacklist, writeRemoteBlacklist } from './services/remote-bla
 import { RemoteModelConfigService } from './services/remote-model-config-service'
 import { readRemoteModelConfig, writeRemoteModelConfig } from './services/remote-model-config-store'
 import type { RemoteModelConfig } from '../shared/remote-model-config'
-import {
-  resolveClusterModelOverride,
-  resolveTextTaskModels,
-} from './settings/effective-model-presets'
+import { pushModelSelections } from './ui/apply-models'
 import { applyRemoteModelConfig } from './ui/remote-model-apply'
 import { DeviceReportSync } from './services/device-report-sync'
 import { readDeviceReportState, writeDeviceReportState } from './services/device-report-store'
@@ -233,31 +230,28 @@ app.on('ready', async () => {
       ? ENTERPRISE_BACKEND_CONFIG.BACKEND_URL
       : MANAGED_KEY_CONFIG.BACKEND_URL
 
+  const isEnterpriseActivated = (): boolean =>
+    runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false
+
   // Remote model config (DEU-202): constructed before the runtime so chain
-  // building can already see the disk cache; onChange is late-bound below once
-  // the miners exist, and start() only runs after that binding. Managed-key
-  // installs only — BYOK and custom endpoints keep full model control.
+  // building can already see the disk cache (loaded in the constructor);
+  // onChange is late-bound below once the miners exist, and start() only runs
+  // after that binding. Managed-key installs only — BYOK and custom endpoints
+  // keep full model control.
   const isOpenRouterManaged = (): boolean =>
     vendorCredentialsManager.getStatus('openrouter').source === 'managed'
   let applyRemoteModel: ((config: RemoteModelConfig) => void) | null = null
-  const cachedModelConfig = readRemoteModelConfig()
   remoteModelConfig = new RemoteModelConfigService({
     getDeviceId: () => deviceIdentity.getDeviceId(),
-    isActivated:
-      editionConfig.edition === 'enterprise'
-        ? () =>
-            isOpenRouterManaged() &&
-            (runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false)
-        : isOpenRouterManaged,
+    isActivated: () =>
+      isOpenRouterManaged() && (editionConfig.edition !== 'enterprise' || isEnterpriseActivated()),
     getBackendUrl: () => backendBaseUrl,
     onChange: (config) => applyRemoteModel?.(config),
     readStored: () => readRemoteModelConfig(),
     writeStored: (config) => writeRemoteModelConfig(config),
   })
-  const getRemoteModelConfig = (): RemoteModelConfig | null => {
-    if (!isOpenRouterManaged()) return null
-    return remoteModelConfig?.getConfig() ?? cachedModelConfig
-  }
+  const getRemoteModelConfig = (): RemoteModelConfig | null =>
+    isOpenRouterManaged() ? (remoteModelConfig?.getConfig() ?? null) : null
 
   runtime = await createMainRuntime({
     edition: editionConfig.edition,
@@ -293,10 +287,7 @@ app.on('ready', async () => {
   // distribution is visible server-side.
   deviceReportSync = new DeviceReportSync({
     getDeviceId: () => deviceIdentity.getDeviceId(),
-    isActivated:
-      editionConfig.edition === 'enterprise'
-        ? () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false
-        : () => true,
+    isActivated: editionConfig.edition === 'enterprise' ? isEnterpriseActivated : () => true,
     getBackendUrl: () => backendBaseUrl,
     getVersion: () => app.getVersion(),
     edition: editionConfig.edition,
@@ -309,7 +300,7 @@ app.on('ready', async () => {
     databaseUploadSync = new DatabaseUploadSync({
       storage: runtime.storage,
       getDeviceId: () => deviceIdentity.getDeviceId(),
-      isActivated: () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false,
+      isActivated: isEnterpriseActivated,
       isSyncEnabled: () => captureSettingsManager.get().uploadDetailLevel !== 'off',
       getStripOptions: () => {
         const level = captureSettingsManager.get().uploadDetailLevel
@@ -323,7 +314,7 @@ app.on('ready', async () => {
 
     logUploadSync = new LogUploadSync({
       getDeviceId: () => deviceIdentity.getDeviceId(),
-      isActivated: () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false,
+      isActivated: isEnterpriseActivated,
       isSyncEnabled: () => captureSettingsManager.get().uploadDetailLevel !== 'off',
       getBackendUrl: () => ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
       readState: () => readLogUploadState(),
@@ -333,7 +324,7 @@ app.on('ready', async () => {
 
     remoteBlacklist = new RemoteBlacklistService({
       getDeviceId: () => deviceIdentity.getDeviceId(),
-      isActivated: () => runtime?.accessProvider.getAccessState().isEnterpriseActivated ?? false,
+      isActivated: isEnterpriseActivated,
       getBackendUrl: () => ENTERPRISE_BACKEND_CONFIG.BACKEND_URL,
       onChange: (blacklist) => {
         runtime?.setManagedExclusions(blacklist)
@@ -346,13 +337,7 @@ app.on('ready', async () => {
   }
 
   const settings = captureSettingsManager.get()
-  const initialTextModels = resolveTextTaskModels(
-    settings.patternDetectionModel,
-    settings.activeVendor,
-    getRemoteModelConfig(),
-  )
   userContextBuilder = new UserContextBuilder(runtime.storage, runtime.inferenceProvider)
-  userContextBuilder.updateModel(initialTextModels.userContext)
   // The scheduled analyzer. The newTaskMinerEnabled developer toggle (default
   // off) picks the new TaskMiner (mining + clustering) over the legacy
   // PatternDetector. Read once here — flipping the toggle takes effect on the
@@ -361,16 +346,21 @@ app.on('ready', async () => {
   if (settings.newTaskMinerEnabled) {
     taskMiner = new TaskMiner(runtime.storage, runtime.inferenceProvider, runtime.mlWorker)
     taskMiner.setEnabled(settings.patternDetectionEnabled)
-    taskMiner.updateModel(initialTextModels.taskMining)
-    taskMiner.updateClusterModel(
-      resolveClusterModelOverride(settings.activeVendor, getRemoteModelConfig()),
-    )
   } else {
     patternDetector = new PatternDetector(runtime.storage, runtime.inferenceProvider)
     patternDetector.setEnabled(settings.patternDetectionEnabled)
-    patternDetector.updateModel(initialTextModels.taskMining)
   }
   const scheduledMiner = taskMiner ?? patternDetector
+  pushModelSelections(
+    {
+      semanticService: runtime.semanticService,
+      patternDetector: scheduledMiner ?? undefined,
+      userContextBuilder,
+      taskMiner: taskMiner ?? undefined,
+    },
+    settings,
+    getRemoteModelConfig(),
+  )
 
   // Miners exist now — bind the apply step and start syncing. The cached-load
   // notification re-applies idempotently; the first network sync follows.

--- a/src/main/services/remote-blacklist-service.ts
+++ b/src/main/services/remote-blacklist-service.ts
@@ -1,7 +1,7 @@
-import log from '@main/utils/logger'
 import { backendPlatformToken } from '@main/utils/platform'
 import type { ManagedExclusions } from '../../shared/types'
 import { ENTERPRISE_BACKEND_CONFIG } from '../../shared/constants'
+import { RemoteSyncService, type RemoteSyncServiceParams } from './remote-sync-service'
 import { coerceManagedExclusions } from './remote-blacklist-store'
 
 const EMPTY: ManagedExclusions = { apps: [], urlPatterns: [] }
@@ -11,133 +11,36 @@ const EMPTY: ManagedExclusions = { apps: [], urlPatterns: [] }
 // the policy rarely, so there's no need to poll more often.
 const DEFAULT_SYNC_INTERVAL_MS = ENTERPRISE_BACKEND_CONFIG.STATUS_REFRESH_INTERVAL_MS
 
-function serialize(blacklist: ManagedExclusions): string {
-  return JSON.stringify([blacklist.apps, blacklist.urlPatterns])
-}
-
-export interface RemoteBlacklistServiceParams {
-  getDeviceId: () => string
-  isActivated: () => boolean
-  getBackendUrl: () => string
-  /** Fired when the blacklist changes (including the first fetch); the
-   * coordinator unions it with the user's list. */
-  onChange: (blacklist: ManagedExclusions) => void
-  /** Last-known blacklist cached on disk, or null. Loaded on start() so a
-   * restart enforces before the first network sync. */
-  readStored?: () => ManagedExclusions | null
-  /** Persists the latest blacklist so it survives restarts and backend outages. */
-  writeStored?: (blacklist: ManagedExclusions) => void
-  intervalMs?: number
-}
-
 /**
- * Polls the tenant's centralized blacklist on a timer and caches it to a
- * dedicated file (never the user's settings). The coordinator unions it with the
+ * Polls the tenant's centralized blacklist. The coordinator unions it with the
  * user's exclusions, so managed entries are always enforced and not removable.
- *
- * The cache is durable: loaded on start() and replaced only by a clean HTTP 200.
- * Any failure (4xx/5xx, network, even 401) is logged and keeps the cache, so a
- * backend blip never drops the blacklist. Only a 200 with an empty list clears it.
+ * A backend blip never drops the blacklist — only a clean 200 with an empty
+ * list clears it.
  */
-export class RemoteBlacklistService {
-  private readonly getDeviceId: () => string
-  private readonly isActivated: () => boolean
-  private readonly getBackendUrl: () => string
-  private readonly onChange: (blacklist: ManagedExclusions) => void
-  private readonly readStored?: () => ManagedExclusions | null
-  private readonly writeStored?: (blacklist: ManagedExclusions) => void
-  private readonly intervalMs: number
-
-  private blacklist: ManagedExclusions = EMPTY
-  private serialized = serialize(EMPTY)
-  private timer: ReturnType<typeof setInterval> | null = null
-  private syncing = false
-
-  constructor(params: RemoteBlacklistServiceParams) {
-    this.getDeviceId = params.getDeviceId
-    this.isActivated = params.isActivated
-    this.getBackendUrl = params.getBackendUrl
-    this.onChange = params.onChange
-    this.readStored = params.readStored
-    this.writeStored = params.writeStored
-    this.intervalMs = params.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS
+export class RemoteBlacklistService extends RemoteSyncService<ManagedExclusions> {
+  constructor(params: RemoteSyncServiceParams<ManagedExclusions>) {
+    super('RemoteBlacklist', params, DEFAULT_SYNC_INTERVAL_MS)
   }
 
   getBlacklist(): ManagedExclusions {
-    return this.blacklist
+    return this.getValue() ?? EMPTY
   }
 
-  start(): void {
-    if (this.timer !== null) return
-    this.loadCached()
-    this.timer = setInterval(() => void this.sync(), this.intervalMs)
-    this.timer.unref?.()
-    void this.sync()
+  protected describe(blacklist: ManagedExclusions): string {
+    return `blacklist: ${blacklist.apps.length} apps, ${blacklist.urlPatterns.length} url patterns`
   }
 
-  /** Enforces the on-disk blacklist ahead of the first sync, so a restart has no
-   * blacklist-free window. Missing/empty cache is a no-op. */
-  private loadCached(): void {
-    const cached = this.readStored?.()
-    if (!cached) return
-    const serialized = serialize(cached)
-    if (serialized === this.serialized) return
-    this.blacklist = cached
-    this.serialized = serialized
-    log.info(
-      `[RemoteBlacklist] Loaded cached blacklist: ${cached.apps.length} apps, ` +
-        `${cached.urlPatterns.length} url patterns`,
-    )
-    this.onChange(cached)
+  protected serialize(blacklist: ManagedExclusions): string {
+    return JSON.stringify([blacklist.apps, blacklist.urlPatterns])
   }
 
-  stop(): void {
-    if (this.timer !== null) {
-      clearInterval(this.timer)
-      this.timer = null
-    }
-  }
-
-  /** One sync pass. Skips while a prior pass is in flight or the device isn't
-   * activated; updates the held blacklist and notifies only on a real change. */
-  async sync(): Promise<void> {
-    if (this.syncing || !this.isActivated()) return
-    this.syncing = true
-    try {
-      const next = await this.fetchBlacklist()
-      const serialized = serialize(next)
-      if (serialized === this.serialized) return
-      this.blacklist = next
-      this.serialized = serialized
-      this.writeStored?.(next)
-      log.info(
-        `[RemoteBlacklist] Synced centralized blacklist: ${next.apps.length} apps, ` +
-          `${next.urlPatterns.length} url patterns`,
-      )
-      this.onChange(next)
-    } catch (error) {
-      log.warn('[RemoteBlacklist] Sync failed:', error)
-    } finally {
-      this.syncing = false
-    }
-  }
-
-  private async fetchBlacklist(): Promise<ManagedExclusions> {
-    const base = this.getBackendUrl().replace(/\/?$/, '/')
-    const url = new URL('api/license/blacklist', base)
+  protected async fetchRemote(base: string): Promise<ManagedExclusions> {
+    const url = this.endpoint(base, 'api/license/blacklist')
     // Narrow app tokens to this platform's identifiers (macOS bundle ids vs.
     // Windows process names); the device can't match the other's.
     const platform = backendPlatformToken()
     if (platform) url.searchParams.set('platform', platform)
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${this.getDeviceId()}` },
-    })
-    // Any non-200 (including 401) is a failure: the sync loop swallows the throw
-    // and keeps the last-known blacklist. Only a clean 200 replaces it.
-    if (!response.ok) {
-      throw new Error(`Remote blacklist request failed (${response.status})`)
-    }
-    const data = (await response.json()) as {
+    const data = (await this.fetchJson(url)) as {
       excludedApps?: unknown
       excludedUrlPatterns?: unknown
     }

--- a/src/main/services/remote-blacklist-store.ts
+++ b/src/main/services/remote-blacklist-store.ts
@@ -1,9 +1,5 @@
-import * as fs from 'fs'
-import * as path from 'path'
-import log from '@main/utils/logger'
+import { createUserDataJsonStore } from '@main/utils/json-file-store'
 import type { ManagedExclusions } from '../../shared/types'
-
-const FILE_NAME = 'remote-blacklist.json'
 
 function toStringArray(value: unknown): string[] {
   return Array.isArray(value)
@@ -20,39 +16,12 @@ export function coerceManagedExclusions(apps: unknown, urlPatterns: unknown): Ma
   return { apps: toStringArray(apps), urlPatterns: toStringArray(urlPatterns) }
 }
 
-function defaultPath(): string {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const electron = require('electron') as typeof import('electron')
-  return path.join(electron.app.getPath('userData'), FILE_NAME)
-}
+// Entries are sanitized to string arrays in case the file was hand-edited or
+// written by an older build.
+const store = createUserDataJsonStore('remote-blacklist.json', 'RemoteBlacklist', (data) => {
+  const { apps, urlPatterns } = data as { apps?: unknown; urlPatterns?: unknown }
+  return coerceManagedExclusions(apps, urlPatterns)
+})
 
-/**
- * Reads the last-known remote blacklist cached on disk. Returns null when the
- * file is missing or unreadable/corrupt, so callers treat it as "no cached
- * blacklist" and fall back to waiting for a fresh sync. Entries are sanitized to
- * string arrays in case the file was hand-edited or written by an older build.
- */
-export function readRemoteBlacklist(filePath: string = defaultPath()): ManagedExclusions | null {
-  try {
-    const raw = fs.readFileSync(filePath, 'utf-8')
-    const data = JSON.parse(raw) as { apps?: unknown; urlPatterns?: unknown }
-    return coerceManagedExclusions(data.apps, data.urlPatterns)
-  } catch {
-    return null
-  }
-}
-
-/**
- * Persists the latest remote blacklist. Failures are swallowed (logged) — a disk
- * hiccup must never break the sync loop.
- */
-export function writeRemoteBlacklist(
-  blacklist: ManagedExclusions,
-  filePath: string = defaultPath(),
-): void {
-  try {
-    fs.writeFileSync(filePath, JSON.stringify(blacklist, null, 2))
-  } catch (error) {
-    log.warn('[RemoteBlacklist] Failed to persist blacklist:', error)
-  }
-}
+export const readRemoteBlacklist = store.read
+export const writeRemoteBlacklist = store.write

--- a/src/main/services/remote-model-config-service.ts
+++ b/src/main/services/remote-model-config-service.ts
@@ -1,5 +1,5 @@
-import log from '@main/utils/logger'
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import { RemoteSyncService, type RemoteSyncServiceParams } from './remote-sync-service'
 import { coerceRemoteModelConfig } from './remote-model-config-store'
 
 // Poll cadence for the model pipeline config. The point of remote config is
@@ -8,122 +8,30 @@ import { coerceRemoteModelConfig } from './remote-model-config-store'
 // cheap GET of a tiny static payload.
 const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000
 
-export interface RemoteModelConfigServiceParams {
-  getDeviceId: () => string
-  /** Gates syncing entirely: requires a managed OpenRouter key (plus
-   * enterprise activation in that edition). BYOK/custom installs never poll. */
-  isActivated: () => boolean
-  getBackendUrl: () => string
-  /** Fired when the config changes (including the cached load on start()). */
-  onChange: (config: RemoteModelConfig) => void
-  /** Last-known config cached on disk, or null. Loaded on start() so a restart
-   * applies before the first network sync. */
-  readStored?: () => RemoteModelConfig | null
-  /** Persists the latest config so it survives restarts and backend outages. */
-  writeStored?: (config: RemoteModelConfig) => void
-  intervalMs?: number
-}
-
 /**
- * Polls the backend's model pipeline config (`GET api/config/models`) on a
- * timer and caches it to a dedicated file (never the user's settings). The
+ * Polls the backend's model pipeline config (`GET api/config/models`). The
  * apply layer decides what to overwrite based on the config's version.
- *
- * The cache is durable: loaded on start() and replaced only by a clean HTTP 200
- * with a valid body. Any failure (4xx/5xx incl. a not-yet-deployed 404, network
- * error, malformed JSON) is logged and keeps the cache.
+ * `isActivated` gates syncing entirely: it requires a managed OpenRouter key
+ * (plus enterprise activation in that edition) — BYOK/custom installs never
+ * poll.
  */
-export class RemoteModelConfigService {
-  private readonly getDeviceId: () => string
-  private readonly isActivated: () => boolean
-  private readonly getBackendUrl: () => string
-  private readonly onChange: (config: RemoteModelConfig) => void
-  private readonly readStored?: () => RemoteModelConfig | null
-  private readonly writeStored?: (config: RemoteModelConfig) => void
-  private readonly intervalMs: number
-
-  private config: RemoteModelConfig | null = null
-  private serialized = ''
-  private timer: ReturnType<typeof setInterval> | null = null
-  private syncing = false
-
-  constructor(params: RemoteModelConfigServiceParams) {
-    this.getDeviceId = params.getDeviceId
-    this.isActivated = params.isActivated
-    this.getBackendUrl = params.getBackendUrl
-    this.onChange = params.onChange
-    this.readStored = params.readStored
-    this.writeStored = params.writeStored
-    this.intervalMs = params.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS
+export class RemoteModelConfigService extends RemoteSyncService<RemoteModelConfig> {
+  constructor(params: RemoteSyncServiceParams<RemoteModelConfig>) {
+    super('RemoteModelConfig', params, DEFAULT_SYNC_INTERVAL_MS)
   }
 
   getConfig(): RemoteModelConfig | null {
-    return this.config
+    return this.getValue()
   }
 
-  start(): void {
-    if (this.timer !== null) return
-    this.loadCached()
-    this.timer = setInterval(() => void this.sync(), this.intervalMs)
-    this.timer.unref?.()
-    void this.sync()
+  protected describe(config: RemoteModelConfig): string {
+    return `config v${config.version} (${Object.keys(config.models).length} slots)`
   }
 
-  /** Applies the on-disk config ahead of the first sync, so a restart doesn't
-   * wait on the network. Missing/corrupt cache is a no-op. */
-  private loadCached(): void {
-    const cached = this.readStored?.()
-    if (!cached) return
-    this.config = cached
-    this.serialized = JSON.stringify(cached)
-    log.info(`[RemoteModelConfig] Loaded cached config v${cached.version}`)
-    this.onChange(cached)
-  }
-
-  stop(): void {
-    if (this.timer !== null) {
-      clearInterval(this.timer)
-      this.timer = null
-    }
-  }
-
-  /** One sync pass. Skips while a prior pass is in flight or the device isn't
-   * activated; updates the held config and notifies only on a real change. */
-  async sync(): Promise<void> {
-    if (this.syncing || !this.isActivated()) return
-    const base = this.getBackendUrl()
-    if (!base) return
-    this.syncing = true
-    try {
-      const next = await this.fetchConfig(base)
-      const serialized = JSON.stringify(next)
-      if (serialized === this.serialized) return
-      this.config = next
-      this.serialized = serialized
-      this.writeStored?.(next)
-      log.info(
-        `[RemoteModelConfig] Synced config v${next.version} ` +
-          `(${Object.keys(next.models).length} slots)`,
-      )
-      this.onChange(next)
-    } catch (error) {
-      log.warn('[RemoteModelConfig] Sync failed:', error)
-    } finally {
-      this.syncing = false
-    }
-  }
-
-  private async fetchConfig(base: string): Promise<RemoteModelConfig> {
-    const url = new URL('api/config/models', base.replace(/\/?$/, '/'))
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${this.getDeviceId()}` },
-    })
-    // Any non-200 is a failure: the sync loop swallows the throw and keeps the
-    // last-known config. Only a clean 200 with a valid body replaces it.
-    if (!response.ok) {
-      throw new Error(`Remote model config request failed (${response.status})`)
-    }
-    const config = coerceRemoteModelConfig(await response.json())
+  protected async fetchRemote(base: string): Promise<RemoteModelConfig> {
+    const config = coerceRemoteModelConfig(
+      await this.fetchJson(this.endpoint(base, 'api/config/models')),
+    )
     if (config === null) {
       throw new Error('Remote model config response is malformed')
     }

--- a/src/main/services/remote-model-config-store.ts
+++ b/src/main/services/remote-model-config-store.ts
@@ -1,13 +1,9 @@
-import * as fs from 'fs'
-import * as path from 'path'
-import log from '@main/utils/logger'
+import { createUserDataJsonStore } from '@main/utils/json-file-store'
 import {
   REMOTE_MODEL_SLOTS,
   type RemoteModelConfig,
   type RemoteModelSlot,
 } from '../../shared/remote-model-config'
-
-const FILE_NAME = 'remote-model-config.json'
 
 const MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/
 const MAX_MODEL_ID_LENGTH = 128
@@ -49,37 +45,11 @@ export function coerceRemoteModelConfig(data: unknown): RemoteModelConfig | null
   return { version, models: result }
 }
 
-function defaultPath(): string {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const electron = require('electron') as typeof import('electron')
-  return path.join(electron.app.getPath('userData'), FILE_NAME)
-}
+const store = createUserDataJsonStore(
+  'remote-model-config.json',
+  'RemoteModelConfig',
+  coerceRemoteModelConfig,
+)
 
-/**
- * Reads the last-known remote model config cached on disk. Returns null when
- * the file is missing or unreadable/corrupt, so callers fall back to baked
- * presets until the first successful sync.
- */
-export function readRemoteModelConfig(filePath: string = defaultPath()): RemoteModelConfig | null {
-  try {
-    const raw = fs.readFileSync(filePath, 'utf-8')
-    return coerceRemoteModelConfig(JSON.parse(raw))
-  } catch {
-    return null
-  }
-}
-
-/**
- * Persists the latest remote model config. Failures are swallowed (logged) — a
- * disk hiccup must never break the sync loop.
- */
-export function writeRemoteModelConfig(
-  config: RemoteModelConfig,
-  filePath: string = defaultPath(),
-): void {
-  try {
-    fs.writeFileSync(filePath, JSON.stringify(config, null, 2))
-  } catch (error) {
-    log.warn('[RemoteModelConfig] Failed to persist config:', error)
-  }
-}
+export const readRemoteModelConfig = store.read
+export const writeRemoteModelConfig = store.write

--- a/src/main/services/remote-sync-service.ts
+++ b/src/main/services/remote-sync-service.ts
@@ -1,0 +1,123 @@
+import log from '@main/utils/logger'
+
+export interface RemoteSyncServiceParams<T> {
+  getDeviceId: () => string
+  /** Gates syncing entirely; polling is skipped while it returns false. */
+  isActivated: () => boolean
+  getBackendUrl: () => string
+  /** Fired when the value changes (including the cached load on start()). */
+  onChange: (value: T) => void
+  /** Last-known value cached on disk, or null. Read in the constructor so the
+   * value is available before start(); start() broadcasts it ahead of the
+   * first network sync. */
+  readStored?: () => T | null
+  /** Persists the latest value so it survives restarts and backend outages. */
+  writeStored?: (value: T) => void
+  intervalMs?: number
+}
+
+/**
+ * Base for services that poll a backend endpoint on a timer and cache the last
+ * good value to a dedicated file (never the user's settings).
+ *
+ * The cache is durable: replaced only by a clean HTTP 200 with a valid body.
+ * Any failure (4xx/5xx, network error, malformed JSON) is logged and keeps the
+ * cache. Change detection is by serialized comparison, so onChange fires only
+ * on a real change.
+ */
+export abstract class RemoteSyncService<T> {
+  private value: T | null = null
+  private serialized = ''
+  private cachePending = false
+  private timer: ReturnType<typeof setInterval> | null = null
+  private syncing = false
+  private readonly intervalMs: number
+
+  protected constructor(
+    private readonly tag: string,
+    private readonly params: RemoteSyncServiceParams<T>,
+    defaultIntervalMs: number,
+  ) {
+    this.intervalMs = params.intervalMs ?? defaultIntervalMs
+    const cached = params.readStored?.()
+    if (cached) {
+      this.value = cached
+      this.serialized = this.serialize(cached)
+      this.cachePending = true
+      log.info(`[${tag}] Loaded cached ${this.describe(cached)}`)
+    }
+  }
+
+  /** Fetch and parse the remote value; throw on anything but a clean result. */
+  protected abstract fetchRemote(base: string): Promise<T>
+  /** Short human description of a value, for log lines. */
+  protected abstract describe(value: T): string
+  /** Canonical form used for change detection. */
+  protected serialize(value: T): string {
+    return JSON.stringify(value)
+  }
+
+  protected getValue(): T | null {
+    return this.value
+  }
+
+  start(): void {
+    if (this.timer !== null) return
+    // Broadcast the cached value ahead of the first network sync, so a restart
+    // doesn't wait on the network.
+    if (this.cachePending && this.value !== null) {
+      this.cachePending = false
+      this.params.onChange(this.value)
+    }
+    this.timer = setInterval(() => void this.sync(), this.intervalMs)
+    this.timer.unref?.()
+    void this.sync()
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  /** One sync pass. Skips while a prior pass is in flight or the device isn't
+   * activated; updates the held value and notifies only on a real change. */
+  async sync(): Promise<void> {
+    if (this.syncing || !this.params.isActivated()) return
+    const base = this.params.getBackendUrl()
+    if (!base) return
+    this.syncing = true
+    try {
+      const next = await this.fetchRemote(base)
+      const serialized = this.serialize(next)
+      if (serialized === this.serialized) return
+      this.value = next
+      this.serialized = serialized
+      this.params.writeStored?.(next)
+      log.info(`[${this.tag}] Synced ${this.describe(next)}`)
+      this.params.onChange(next)
+    } catch (error) {
+      log.warn(`[${this.tag}] Sync failed:`, error)
+    } finally {
+      this.syncing = false
+    }
+  }
+
+  /** Resolves an endpoint path against the backend base URL. */
+  protected endpoint(base: string, path: string): URL {
+    return new URL(path, base.replace(/\/?$/, '/'))
+  }
+
+  /** GET with the device bearer. Any non-200 throws, so the sync loop swallows
+   * it and keeps the last-known value; only a clean 200 replaces it. */
+  protected async fetchJson(url: URL): Promise<unknown> {
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${this.params.getDeviceId()}` },
+    })
+    if (!response.ok) {
+      throw new Error(`Request failed (${response.status})`)
+    }
+    return response.json()
+  }
+}

--- a/src/main/settings/effective-model-presets.test.ts
+++ b/src/main/settings/effective-model-presets.test.ts
@@ -5,7 +5,7 @@ import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
 import {
   getEffectivePresets,
   resolveClusterModelOverride,
-  resolveTextTaskModels,
+  resolveUserContextModel,
 } from './effective-model-presets'
 
 const REMOTE: RemoteModelConfig = {
@@ -42,29 +42,21 @@ describe('getEffectivePresets', () => {
   })
 })
 
-describe('resolveTextTaskModels', () => {
-  it('follows the stored pick for all tasks without remote config', () => {
-    expect(resolveTextTaskModels('minimax/minimax-m3', 'openrouter', null)).toEqual({
-      taskMining: 'minimax/minimax-m3',
-      userContext: 'minimax/minimax-m3',
-      clusterReview: 'minimax/minimax-m3',
-    })
+describe('resolveUserContextModel', () => {
+  it('follows the stored pick without remote config', () => {
+    expect(resolveUserContextModel('minimax/minimax-m3', 'openrouter', null)).toBe(
+      'minimax/minimax-m3',
+    )
   })
 
   it('follows the stored pick for non-openrouter vendors', () => {
-    expect(resolveTextTaskModels('gemini-2.5-flash', 'google', REMOTE)).toEqual({
-      taskMining: 'gemini-2.5-flash',
-      userContext: 'gemini-2.5-flash',
-      clusterReview: 'gemini-2.5-flash',
-    })
+    expect(resolveUserContextModel('gemini-2.5-flash', 'google', REMOTE)).toBe('gemini-2.5-flash')
   })
 
-  it('diverges tasks with a remote opinion and defaults the rest to the pick', () => {
-    expect(resolveTextTaskModels('xiaomi/mimo-v2.5', 'openrouter', REMOTE)).toEqual({
-      taskMining: 'xiaomi/mimo-v2.5',
-      userContext: 'minimax/minimax-m3',
-      clusterReview: 'xiaomi/mimo-v2.5',
-    })
+  it('diverges to the remote opinion when present', () => {
+    expect(resolveUserContextModel('xiaomi/mimo-v2.5', 'openrouter', REMOTE)).toBe(
+      'minimax/minimax-m3',
+    )
   })
 })
 

--- a/src/main/settings/effective-model-presets.ts
+++ b/src/main/settings/effective-model-presets.ts
@@ -33,34 +33,17 @@ export function getEffectivePresets(
   }
 }
 
-export interface TextTaskModels {
-  taskMining: string
-  userContext: string
-  clusterReview: string
-}
-
 /**
- * Splits the single stored `patternDetectionModel` pick into the three text
- * tasks. Remote config (OpenRouter only) can point each task at its own model;
- * without a remote opinion all three follow the stored pick.
+ * The user-context builder follows the stored `patternDetectionModel` pick
+ * unless remote config (OpenRouter only) points it at its own model.
  */
-export function resolveTextTaskModels(
+export function resolveUserContextModel(
   patternDetectionPick: string,
   vendor: Vendor,
   remote: RemoteModelConfig | null,
-): TextTaskModels {
-  if (vendor !== 'openrouter' || remote === null) {
-    return {
-      taskMining: patternDetectionPick,
-      userContext: patternDetectionPick,
-      clusterReview: patternDetectionPick,
-    }
-  }
-  return {
-    taskMining: patternDetectionPick,
-    userContext: remote.models.userContext?.[0] ?? patternDetectionPick,
-    clusterReview: remote.models.clusterReview?.[0] ?? patternDetectionPick,
-  }
+): string {
+  if (vendor !== 'openrouter') return patternDetectionPick
+  return remote?.models.userContext?.[0] ?? patternDetectionPick
 }
 
 /**

--- a/src/main/ui/apply-models.ts
+++ b/src/main/ui/apply-models.ts
@@ -1,0 +1,45 @@
+import type { RemoteModelConfig } from '../../shared/remote-model-config'
+import type { CaptureSettings } from '../../shared/types'
+import { buildModelChain } from '../../shared/vendor-defaults'
+import {
+  getEffectivePresets,
+  resolveClusterModelOverride,
+  resolveUserContextModel,
+} from '@main/settings/effective-model-presets'
+
+/** Structural shape of every live service that consumes a model selection. */
+export interface ModelPushDeps {
+  semanticService: {
+    updateModels(videoModels: string[], snapshotModels: string[]): void
+  }
+  patternDetector?: { updateModel(model: string): void }
+  userContextBuilder?: { updateModel(model: string): void }
+  taskMiner?: { updateClusterModel(model: string | null): void }
+}
+
+type ModelSelection = Pick<
+  CaptureSettings,
+  'activeVendor' | 'semanticVideoModel' | 'semanticSnapshotModel' | 'patternDetectionModel'
+>
+
+/**
+ * Push the effective model selections (stored picks + remote config) into the
+ * live services. Idempotent — the single choke point shared by startup seeding,
+ * vendor switches, settings saves, and remote-config notifications.
+ */
+export function pushModelSelections(
+  d: ModelPushDeps,
+  s: ModelSelection,
+  remote: RemoteModelConfig | null,
+): void {
+  const presets = getEffectivePresets(s.activeVendor, remote)
+  d.semanticService.updateModels(
+    buildModelChain(s.semanticVideoModel, presets.semanticVideo),
+    buildModelChain(s.semanticSnapshotModel, presets.semanticSnapshot),
+  )
+  d.patternDetector?.updateModel(s.patternDetectionModel)
+  d.userContextBuilder?.updateModel(
+    resolveUserContextModel(s.patternDetectionModel, s.activeVendor, remote),
+  )
+  d.taskMiner?.updateClusterModel(resolveClusterModelOverride(s.activeVendor, remote))
+}

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -29,6 +29,7 @@ import type { VendorCredentialsManager } from '../settings/vendor-credentials-ma
 import { VENDORS } from '../../shared/types'
 import { computeClustersView } from './cluster-view'
 import { getEffectivePresets } from '@main/settings/effective-model-presets'
+import { getPresetDefaults } from '../../shared/vendor-defaults'
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import { applyVendorSwitch } from './vendor-switch'
 import { applyModelSettings } from './model-settings'
@@ -174,11 +175,7 @@ function reconcileManagedModelSelections(
   // would flag remote-applied models as stale and reset them.
   const presets = getEffectivePresets(vendor, remote)
   const settings = captureSettings.get()
-  const defaults = {
-    semanticVideoModel: presets.semanticVideo[0]?.id ?? '',
-    semanticSnapshotModel: presets.semanticSnapshot[0]?.id ?? '',
-    patternDetectionModel: presets.patternDetection[0]?.id ?? '',
-  }
+  const defaults = getPresetDefaults(presets)
   const updates: Partial<{
     semanticVideoModel: string
     semanticSnapshotModel: string

--- a/src/main/ui/model-settings.test.ts
+++ b/src/main/ui/model-settings.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { applyModelSettings, type ModelSettingsDeps } from './model-settings'
 import type { CaptureSettings } from '../../shared/types'
 import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
+import { makeCaptureSettings } from '@main/utils/test-utils'
 
 function makeDeps(): {
   deps: ModelSettingsDeps
@@ -20,32 +21,7 @@ function makeDeps(): {
 }
 
 function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
-  return {
-    autoStartEnabled: true,
-    visualThreshold: 8,
-    typingDebounceMs: 2000,
-    scrollDebounceMs: 2000,
-    clickDebounceMs: 3000,
-    minActivityDurationMs: 3000,
-    maxActivityDurationMs: 300000,
-    maxScreenshotsForLlm: 6,
-    semanticRequestTimeoutMs: 120000,
-    semanticPipelineMode: 'image',
-    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
-    databaseExportDirectory: '',
-    excludePrivateBrowsing: true,
-    excludedApps: [],
-    excludedUrlPatterns: [],
-    activeVendor: 'openrouter',
-    modelsByVendor: {},
-    newTaskMinerEnabled: true,
-    semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
-    semanticSnapshotModel: VENDOR_PRESETS.openrouter.semanticSnapshot[0].id,
-    patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,
-    patternDetectionEnabled: true,
-    uploadDetailLevel: 'off',
-    ...overrides,
-  }
+  return makeCaptureSettings({ semanticPipelineMode: 'image', ...overrides })
 }
 
 describe('applyModelSettings', () => {

--- a/src/main/ui/model-settings.ts
+++ b/src/main/ui/model-settings.ts
@@ -1,47 +1,33 @@
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings } from '../../shared/types'
-import { buildModelChain } from '../../shared/vendor-defaults'
-import { getEffectivePresets, resolveTextTaskModels } from '@main/settings/effective-model-presets'
+import { pushModelSelections, type ModelPushDeps } from './apply-models'
 
 /**
  * Structural shape of the dependencies that `applyModelSettings` touches.
  * Defined separately so the helper is unit-testable without a full
  * `MainWindowDependencies` mock.
  */
-export interface ModelSettingsDeps {
-  semanticService: {
-    updateModels(videoModels: string[], snapshotModels: string[]): void
-  }
+export interface ModelSettingsDeps extends ModelPushDeps {
   patternDetector?: { updateModel(model: string): void; setEnabled(enabled: boolean): void }
-  userContextBuilder?: { updateModel(model: string): void }
   getRemoteModelConfig?: () => RemoteModelConfig | null
 }
 
 /**
- * Diff `updated` vs `previous` capture settings and push only the changed
- * model-related fields into the live runtime services.
+ * Diff `updated` vs `previous` capture settings and push model-related changes
+ * into the live runtime services.
  */
 export function applyModelSettings(
   d: ModelSettingsDeps,
   updated: CaptureSettings,
   previous: CaptureSettings,
 ): void {
-  const remote = d.getRemoteModelConfig?.() ?? null
   if (
+    updated.activeVendor !== previous.activeVendor ||
     updated.semanticVideoModel !== previous.semanticVideoModel ||
     updated.semanticSnapshotModel !== previous.semanticSnapshotModel ||
-    updated.activeVendor !== previous.activeVendor
+    updated.patternDetectionModel !== previous.patternDetectionModel
   ) {
-    const presets = getEffectivePresets(updated.activeVendor, remote)
-    d.semanticService.updateModels(
-      buildModelChain(updated.semanticVideoModel, presets.semanticVideo),
-      buildModelChain(updated.semanticSnapshotModel, presets.semanticSnapshot),
-    )
-  }
-  if (updated.patternDetectionModel !== previous.patternDetectionModel) {
-    const text = resolveTextTaskModels(updated.patternDetectionModel, updated.activeVendor, remote)
-    d.patternDetector?.updateModel(text.taskMining)
-    d.userContextBuilder?.updateModel(text.userContext)
+    pushModelSelections(d, updated, d.getRemoteModelConfig?.() ?? null)
   }
   if (updated.patternDetectionEnabled !== previous.patternDetectionEnabled) {
     d.patternDetector?.setEnabled(updated.patternDetectionEnabled)

--- a/src/main/ui/remote-model-apply.test.ts
+++ b/src/main/ui/remote-model-apply.test.ts
@@ -7,11 +7,9 @@ vi.mock('@main/utils/logger', () => ({
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings } from '../../shared/types'
 import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
-import {
-  applyRemoteModelConfig,
-  type RemoteModelApplyDeps,
-  type RemoteModelSettingsManager,
-} from './remote-model-apply'
+import { makeCaptureSettings as makeSettings } from '@main/utils/test-utils'
+import type { ModelPushDeps } from './apply-models'
+import { applyRemoteModelConfig, type RemoteModelSettingsManager } from './remote-model-apply'
 
 const REMOTE: RemoteModelConfig = {
   version: 3,
@@ -22,36 +20,6 @@ const REMOTE: RemoteModelConfig = {
     userContext: ['remote/context-model'],
     clusterReview: ['remote/cluster-model'],
   },
-}
-
-function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
-  return {
-    autoStartEnabled: true,
-    visualThreshold: 8,
-    typingDebounceMs: 2000,
-    scrollDebounceMs: 2000,
-    clickDebounceMs: 3000,
-    minActivityDurationMs: 3000,
-    maxActivityDurationMs: 300000,
-    maxScreenshotsForLlm: 6,
-    semanticRequestTimeoutMs: 120000,
-    semanticPipelineMode: 'auto',
-    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
-    databaseExportDirectory: '',
-    excludePrivateBrowsing: true,
-    excludedApps: [],
-    excludedUrlPatterns: [],
-    activeVendor: 'openrouter',
-    modelsByVendor: {},
-    newTaskMinerEnabled: true,
-    semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
-    semanticSnapshotModel: VENDOR_PRESETS.openrouter.semanticSnapshot[0].id,
-    patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,
-    patternDetectionEnabled: true,
-    remoteModelConfigVersion: 0,
-    uploadDetailLevel: 'off',
-    ...overrides,
-  }
 }
 
 function makeManager(initial: CaptureSettings): RemoteModelSettingsManager & {
@@ -78,7 +46,7 @@ function makeManager(initial: CaptureSettings): RemoteModelSettingsManager & {
 }
 
 function makeDeps(): {
-  deps: RemoteModelApplyDeps
+  deps: ModelPushDeps
   semanticService: { updateModels: ReturnType<typeof vi.fn> }
   patternDetector: { updateModel: ReturnType<typeof vi.fn> }
   userContextBuilder: { updateModel: ReturnType<typeof vi.fn> }

--- a/src/main/ui/remote-model-apply.ts
+++ b/src/main/ui/remote-model-apply.ts
@@ -1,17 +1,9 @@
 import log from '@main/utils/logger'
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings } from '../../shared/types'
-import { buildModelChain } from '../../shared/vendor-defaults'
-import { getEffectivePresets, resolveTextTaskModels } from '@main/settings/effective-model-presets'
-
-export interface RemoteModelApplyDeps {
-  semanticService: {
-    updateModels(videoModels: string[], snapshotModels: string[]): void
-  }
-  patternDetector?: { updateModel(model: string): void }
-  userContextBuilder?: { updateModel(model: string): void }
-  taskMiner?: { updateClusterModel(model: string | null): void }
-}
+import { getPresetDefaults } from '../../shared/vendor-defaults'
+import { getEffectivePresets } from '@main/settings/effective-model-presets'
+import { pushModelSelections, type ModelPushDeps } from './apply-models'
 
 export interface RemoteModelSettingsManager {
   get(): CaptureSettings
@@ -26,19 +18,14 @@ export interface RemoteModelSettingsManager {
  * call on every config notification, including the cached load at startup.
  */
 export function applyRemoteModelConfig(
-  deps: RemoteModelApplyDeps,
+  deps: ModelPushDeps,
   settingsManager: RemoteModelSettingsManager,
   config: RemoteModelConfig,
 ): void {
   const settings = settingsManager.get()
-  const presets = getEffectivePresets('openrouter', config)
   // Empty remote slots resolve to the baked heads, so a version bump that
   // clears a slot cleanly reverts that pick to the baked default.
-  const heads = {
-    semanticVideoModel: presets.semanticVideo[0]?.id ?? '',
-    semanticSnapshotModel: presets.semanticSnapshot[0]?.id ?? '',
-    patternDetectionModel: presets.patternDetection[0]?.id ?? '',
-  }
+  const heads = getPresetDefaults(getEffectivePresets('openrouter', config))
 
   const appliedVersion = settings.remoteModelConfigVersion ?? 0
   if (config.version > appliedVersion) {
@@ -66,12 +53,5 @@ export function applyRemoteModelConfig(
 
   const current = settingsManager.get()
   if (current.activeVendor !== 'openrouter') return
-  deps.semanticService.updateModels(
-    buildModelChain(current.semanticVideoModel, presets.semanticVideo),
-    buildModelChain(current.semanticSnapshotModel, presets.semanticSnapshot),
-  )
-  const text = resolveTextTaskModels(current.patternDetectionModel, 'openrouter', config)
-  deps.patternDetector?.updateModel(text.taskMining)
-  deps.userContextBuilder?.updateModel(text.userContext)
-  deps.taskMiner?.updateClusterModel(config.models.clusterReview?.[0] ?? null)
+  pushModelSelections(deps, current, config)
 }

--- a/src/main/ui/vendor-switch.test.ts
+++ b/src/main/ui/vendor-switch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { applyVendorSwitch, type VendorSwitchDeps } from './vendor-switch'
 import type { CaptureSettings, Vendor } from '../../shared/types'
 import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
+import { makeCaptureSettings } from '@main/utils/test-utils'
 
 function makeDeps(): {
   deps: VendorSwitchDeps
@@ -42,32 +43,13 @@ function makeDeps(): {
 }
 
 function makeSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
-  return {
-    autoStartEnabled: true,
-    visualThreshold: 8,
-    typingDebounceMs: 2000,
-    scrollDebounceMs: 2000,
-    clickDebounceMs: 3000,
-    minActivityDurationMs: 3000,
-    maxActivityDurationMs: 300000,
-    maxScreenshotsForLlm: 6,
-    semanticRequestTimeoutMs: 120000,
+  return makeCaptureSettings({
     semanticPipelineMode: 'image',
-    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
-    databaseExportDirectory: '',
-    excludePrivateBrowsing: true,
-    excludedApps: [],
-    excludedUrlPatterns: [],
-    activeVendor: 'openrouter',
-    modelsByVendor: {},
-    newTaskMinerEnabled: true,
     semanticVideoModel: '',
     semanticSnapshotModel: '',
     patternDetectionModel: '',
-    patternDetectionEnabled: true,
-    uploadDetailLevel: 'off',
     ...overrides,
-  }
+  })
 }
 
 describe('applyVendorSwitch', () => {

--- a/src/main/ui/vendor-switch.ts
+++ b/src/main/ui/vendor-switch.ts
@@ -1,26 +1,17 @@
 import type { RemoteModelConfig } from '../../shared/remote-model-config'
 import type { CaptureSettings, SemanticPipelineMode } from '../../shared/types'
-import { buildModelChain } from '../../shared/vendor-defaults'
-import {
-  getEffectivePresets,
-  resolveClusterModelOverride,
-  resolveTextTaskModels,
-} from '@main/settings/effective-model-presets'
+import { pushModelSelections, type ModelPushDeps } from './apply-models'
 
 /**
  * Structural shape of the dependencies that `applyVendorSwitch` touches.
  * Defined separately so the helper is unit-testable without a full
  * `MainWindowDependencies` mock.
  */
-export interface VendorSwitchDeps {
-  semanticService: {
-    updateModels(videoModels: string[], snapshotModels: string[]): void
+export interface VendorSwitchDeps extends ModelPushDeps {
+  semanticService: ModelPushDeps['semanticService'] & {
     updatePipelinePreference(mode: SemanticPipelineMode): void
     testConnection(): Promise<void>
   }
-  patternDetector?: { updateModel(model: string): void }
-  userContextBuilder?: { updateModel(model: string): void }
-  taskMiner?: { updateClusterModel(model: string | null): void }
   inferenceProvider: { notifyConfigChanged(): void }
   getRemoteModelConfig?: () => RemoteModelConfig | null
 }
@@ -35,17 +26,8 @@ export interface VendorSwitchDeps {
  * with.
  */
 export function applyVendorSwitch(d: VendorSwitchDeps, next: CaptureSettings): void {
-  const remote = d.getRemoteModelConfig?.() ?? null
-  const presets = getEffectivePresets(next.activeVendor, remote)
-  d.semanticService.updateModels(
-    buildModelChain(next.semanticVideoModel, presets.semanticVideo),
-    buildModelChain(next.semanticSnapshotModel, presets.semanticSnapshot),
-  )
+  pushModelSelections(d, next, d.getRemoteModelConfig?.() ?? null)
   d.semanticService.updatePipelinePreference(next.semanticPipelineMode)
-  const text = resolveTextTaskModels(next.patternDetectionModel, next.activeVendor, remote)
-  d.patternDetector?.updateModel(text.taskMining)
-  d.userContextBuilder?.updateModel(text.userContext)
-  d.taskMiner?.updateClusterModel(resolveClusterModelOverride(next.activeVendor, remote))
   d.inferenceProvider.notifyConfigChanged()
   void d.semanticService.testConnection()
 }

--- a/src/main/utils/json-file-store.ts
+++ b/src/main/utils/json-file-store.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import log from '@main/utils/logger'
+
+export interface JsonFileStore<T> {
+  read: (filePath?: string) => T | null
+  write: (value: T, filePath?: string) => void
+}
+
+/**
+ * Read/write helpers for a JSON cache file in the app's userData directory.
+ * `read` returns null when the file is missing or unreadable/corrupt, so
+ * callers fall back to their defaults; `write` failures are swallowed (logged)
+ * — a disk hiccup must never break a sync loop.
+ */
+export function createUserDataJsonStore<T>(
+  fileName: string,
+  tag: string,
+  coerce: (data: unknown) => T | null,
+): JsonFileStore<T> {
+  const defaultPath = (): string => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const electron = require('electron') as typeof import('electron')
+    return path.join(electron.app.getPath('userData'), fileName)
+  }
+  return {
+    read(filePath = defaultPath()) {
+      try {
+        return coerce(JSON.parse(fs.readFileSync(filePath, 'utf-8')))
+      } catch {
+        return null
+      }
+    },
+    write(value, filePath = defaultPath()) {
+      try {
+        fs.writeFileSync(filePath, JSON.stringify(value, null, 2))
+      } catch (error) {
+        log.warn(`[${tag}] Failed to persist ${fileName}:`, error)
+      }
+    },
+  }
+}

--- a/src/main/utils/test-utils.ts
+++ b/src/main/utils/test-utils.ts
@@ -1,3 +1,6 @@
+import type { CaptureSettings } from '../../shared/types'
+import { VENDOR_PRESETS } from '../../shared/vendor-defaults'
+
 export function jsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
     ok,
@@ -5,4 +8,34 @@ export function jsonResponse(body: unknown, ok = true, status = 200): Response {
     json: async () => body,
     text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
   } as Response
+}
+
+export function makeCaptureSettings(overrides: Partial<CaptureSettings> = {}): CaptureSettings {
+  return {
+    autoStartEnabled: true,
+    visualThreshold: 8,
+    typingDebounceMs: 2000,
+    scrollDebounceMs: 2000,
+    clickDebounceMs: 3000,
+    minActivityDurationMs: 3000,
+    maxActivityDurationMs: 300000,
+    maxScreenshotsForLlm: 6,
+    semanticRequestTimeoutMs: 120000,
+    semanticPipelineMode: 'auto',
+    captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
+    databaseExportDirectory: '',
+    excludePrivateBrowsing: true,
+    excludedApps: [],
+    excludedUrlPatterns: [],
+    activeVendor: 'openrouter',
+    modelsByVendor: {},
+    newTaskMinerEnabled: true,
+    semanticVideoModel: VENDOR_PRESETS.openrouter.semanticVideo[0].id,
+    semanticSnapshotModel: VENDOR_PRESETS.openrouter.semanticSnapshot[0].id,
+    patternDetectionModel: VENDOR_PRESETS.openrouter.patternDetection[0].id,
+    patternDetectionEnabled: true,
+    remoteModelConfigVersion: 0,
+    uploadDetailLevel: 'off',
+    ...overrides,
+  }
 }

--- a/src/renderer/pages/main-window/components/advanced-settings/AiModelsSection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/AiModelsSection.tsx
@@ -18,7 +18,7 @@ import type {
   VendorStatus,
 } from '@types'
 import { VENDORS } from '@types'
-import { VENDOR_PRESETS, getVendorDefaults } from '@/shared/vendor-defaults'
+import { getVendorDefaults } from '@/shared/vendor-defaults'
 import { ManageKeySection } from '../ManageKeySection'
 import { ModelSelector } from './ModelSelector'
 import { SegmentedControl } from './SegmentedControl'
@@ -187,8 +187,6 @@ export function AiModelsSection({
                   <p className="text-xs font-medium text-muted-foreground">Model selection</p>
                   {form.semanticPipelineMode !== 'image' && (
                     <ModelSelector
-                      mode="freetext"
-                      presets={VENDOR_PRESETS[activeVendor].semanticVideo}
                       value={form.semanticVideoModel}
                       defaultValue={vendorDefaults.semanticVideoModel}
                       onChange={(v) => onModelChange('semanticVideoModel', v)}
@@ -197,8 +195,6 @@ export function AiModelsSection({
                   )}
                   {form.semanticPipelineMode !== 'video' && (
                     <ModelSelector
-                      mode="freetext"
-                      presets={VENDOR_PRESETS[activeVendor].semanticSnapshot}
                       value={form.semanticSnapshotModel}
                       defaultValue={vendorDefaults.semanticSnapshotModel}
                       onChange={(v) => onModelChange('semanticSnapshotModel', v)}
@@ -206,8 +202,6 @@ export function AiModelsSection({
                     />
                   )}
                   <ModelSelector
-                    mode="freetext"
-                    presets={VENDOR_PRESETS[activeVendor].patternDetection}
                     value={form.patternDetectionModel}
                     defaultValue={vendorDefaults.patternDetectionModel}
                     onChange={(v) => onModelChange('patternDetectionModel', v)}

--- a/src/renderer/pages/main-window/components/advanced-settings/ModelSelector.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/ModelSelector.tsx
@@ -1,16 +1,8 @@
 import { useState } from 'react'
 import { Input } from '@components/ui/input'
 import { Label } from '@components/ui/label'
-import { SegmentedControl } from './SegmentedControl'
-
-export interface ModelPreset {
-  id: string
-  label: string
-}
 
 interface ModelSelectorProps {
-  mode: 'preset' | 'freetext'
-  presets: ModelPreset[]
   value: string
   defaultValue: string
   onChange: (model: string) => void
@@ -18,30 +10,12 @@ interface ModelSelectorProps {
 }
 
 export function ModelSelector({
-  mode,
-  presets,
   value,
   defaultValue,
   onChange,
   label,
 }: ModelSelectorProps): React.JSX.Element {
   const [draft, setDraft] = useState<string | null>(null)
-
-  if (mode === 'preset') {
-    const effectiveValue = value || defaultValue
-    return (
-      <div className="space-y-1.5">
-        <Label className="text-xs text-muted-foreground">{label}</Label>
-        <SegmentedControl
-          ariaLabel={label}
-          layout="wrap"
-          value={effectiveValue}
-          onChange={(id) => onChange(id === defaultValue ? '' : id)}
-          options={presets.map((preset) => ({ value: preset.id, label: preset.label }))}
-        />
-      </div>
-    )
-  }
 
   const displayed = draft ?? (value || defaultValue)
 

--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -83,13 +83,17 @@ export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
   },
 }
 
-export function getVendorDefaults(vendor: Vendor): VendorModelDefaults {
-  const p = VENDOR_PRESETS[vendor]
+/** The default pick per slot: the head of each preset list, '' when empty. */
+export function getPresetDefaults(p: VendorPresets): VendorModelDefaults {
   return {
     semanticVideoModel: p.semanticVideo[0]?.id ?? '',
     semanticSnapshotModel: p.semanticSnapshot[0]?.id ?? '',
     patternDetectionModel: p.patternDetection[0]?.id ?? '',
   }
+}
+
+export function getVendorDefaults(vendor: Vendor): VendorModelDefaults {
+  return getPresetDefaults(VENDOR_PRESETS[vendor])
 }
 
 /**


### PR DESCRIPTION
Stacked on #233 — cleanup pass over the remote model config feature. Net −199 lines with no intended behavior change.

## What

- **`RemoteSyncService<T>` base class** — `RemoteBlacklistService` and `RemoteModelConfigService` were line-for-line clones; both are now ~40-line subclasses defining only endpoint, parsing, and log text. The cache loads in the constructor, so `index.ts` drops its duplicate startup disk read and the `cachedModelConfig` snapshot.
- **`pushModelSelections` choke point** — replaces the four drifting copies of the "push models into live services" sequence (vendor switch, settings save, remote apply, startup seeding). The settings-save path had already lost the cluster-override push; now all paths agree.
- **`resolveUserContextModel`** replaces `resolveTextTaskModels`, whose other two fields were an identity pass-through and dead code.
- **`getPresetDefaults`** — one copy of the head-of-preset-list default rule (was three).
- **`createUserDataJsonStore`** — shared userData JSON cache scaffold for the model-config and blacklist stores.
- **Renderer** — `ModelSelector`'s `preset` mode was unreachable after #233; removed along with the now-unused `presets` prop.
- **Tests** — shared `makeCaptureSettings` fixture instead of three full literals.

Known nuances: a settings save that changes any model field now idempotently re-pushes the full selection (closes the cluster-override drift); an empty tenant blacklist can fire one extra no-op `onChange` per boot.

Follow-up candidate (untouched by #233): convert `device-report-store` / `log-upload-store` to `createUserDataJsonStore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)