### PR TITLE
ui(mining): pulsing status dot instead of progress-bar glow sweep

### DIFF
--- a/src/main/services/task-miner/index.ts
+++ b/src/main/services/task-miner/index.ts
@@ -139,8 +139,7 @@ export class TaskMiner {
       this.settleTimer = null
       void this.sweep(provider)
     }, PATTERN_DETECTION_CONFIG.SETTLE_DELAY_MS)
-    // An armed timer counts as busy — push it so an already-open window
-    // switches to "Analyzing" now instead of at the sweep's first emit.
+    // An armed timer counts as busy — push so an open window flips to "Analyzing" now.
     this.emitStatus()
   }
 

--- a/src/main/services/task-miner/index.ts
+++ b/src/main/services/task-miner/index.ts
@@ -139,6 +139,9 @@ export class TaskMiner {
       this.settleTimer = null
       void this.sweep(provider)
     }, PATTERN_DETECTION_CONFIG.SETTLE_DELAY_MS)
+    // An armed timer counts as busy — push it so an already-open window
+    // switches to "Analyzing" now instead of at the sweep's first emit.
+    this.emitStatus()
   }
 
   /**

--- a/src/renderer/components/ui/ping-dot.tsx
+++ b/src/renderer/components/ui/ping-dot.tsx
@@ -1,0 +1,13 @@
+/** Small status dot; pulses while active, static and muted otherwise. */
+export function PingDot({ active = true }: { active?: boolean }): React.JSX.Element {
+  return (
+    <span className="relative inline-flex size-2 shrink-0">
+      {active && (
+        <span className="absolute inset-0 animate-ping rounded-full bg-primary opacity-75" />
+      )}
+      <span
+        className={`relative inline-flex size-2 rounded-full ${active ? 'bg-primary' : 'bg-muted-foreground'}`}
+      />
+    </span>
+  )
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -138,12 +138,3 @@
     @apply font-sans;
   }
 }
-
-@keyframes mining-glow {
-  from {
-    transform: translateX(-100%);
-  }
-  to {
-    transform: translateX(300%);
-  }
-}

--- a/src/renderer/pages/main-window/components/ClustersSection.tsx
+++ b/src/renderer/pages/main-window/components/ClustersSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@components/ui/button'
+import { PingDot } from '@components/ui/ping-dot'
 import { ScrollArea } from '@components/ui/scroll-area'
 import type { ClusterInfo, MainWindowAPI, MiningStatus } from '@types'
 import { ClusterListItem } from './ClusterListItem'
@@ -12,16 +13,9 @@ function MiningProgressBanner({ status }: { status: MiningStatus }): React.JSX.E
   const pct = Math.max(1.5, (done / status.totalDays) * 100)
   return (
     <div className="space-y-1.5">
-      <div className="flex items-baseline justify-between gap-4 text-xs">
+      <div className="flex items-center justify-between gap-4 text-xs">
         <span className="flex min-w-0 items-center gap-2 font-medium text-foreground/85">
-          <span className="relative inline-flex size-2 shrink-0">
-            {mining && (
-              <span className="absolute inset-0 animate-ping rounded-full bg-primary opacity-75" />
-            )}
-            <span
-              className={`relative inline-flex size-2 rounded-full ${mining ? 'bg-primary' : 'bg-muted-foreground'}`}
-            />
-          </span>
+          <PingDot active={mining} />
           <span className="truncate">{mining ? 'Analyzing your history' : 'Analysis paused'}</span>
         </span>
         <span className="shrink-0 tabular-nums text-muted-foreground">

--- a/src/renderer/pages/main-window/components/ClustersSection.tsx
+++ b/src/renderer/pages/main-window/components/ClustersSection.tsx
@@ -13,8 +13,16 @@ function MiningProgressBanner({ status }: { status: MiningStatus }): React.JSX.E
   return (
     <div className="space-y-1.5">
       <div className="flex items-baseline justify-between gap-4 text-xs">
-        <span className="truncate font-medium text-foreground/85">
-          {mining ? 'Analyzing your history' : 'Analysis paused'}
+        <span className="flex min-w-0 items-center gap-2 font-medium text-foreground/85">
+          <span className="relative inline-flex size-2 shrink-0">
+            {mining && (
+              <span className="absolute inset-0 animate-ping rounded-full bg-primary opacity-75" />
+            )}
+            <span
+              className={`relative inline-flex size-2 rounded-full ${mining ? 'bg-primary' : 'bg-muted-foreground'}`}
+            />
+          </span>
+          <span className="truncate">{mining ? 'Analyzing your history' : 'Analysis paused'}</span>
         </span>
         <span className="shrink-0 tabular-nums text-muted-foreground">
           {done} of {status.totalDays} days
@@ -22,13 +30,9 @@ function MiningProgressBanner({ status }: { status: MiningStatus }): React.JSX.E
       </div>
       <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
         <div
-          className="relative h-full overflow-hidden rounded-full bg-primary transition-[width] duration-700 ease-out"
+          className="h-full rounded-full bg-primary transition-[width] duration-700 ease-out"
           style={{ width: `${pct}%` }}
-        >
-          {mining && (
-            <div className="absolute inset-y-0 w-1/3 animate-[mining-glow_1.6s_ease-in-out_infinite] bg-gradient-to-r from-transparent via-white/60 to-transparent" />
-          )}
-        </div>
+        />
       </div>
     </div>
   )

--- a/src/renderer/pages/main-window/components/advanced-settings/exclusions/ObservationRunningBanner.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/exclusions/ObservationRunningBanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { PingDot } from '@components/ui/ping-dot'
 import type { ObservationState } from '@types'
 
 function formatCountdown(seconds: number): string {
@@ -36,10 +37,7 @@ export function ObservationRunningBanner({
       aria-live="polite"
       className="mt-2 flex items-center gap-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs"
     >
-      <span className="relative inline-flex size-2 shrink-0">
-        <span className="absolute inset-0 animate-ping rounded-full bg-primary opacity-75" />
-        <span className="relative inline-flex size-2 rounded-full bg-primary" />
-      </span>
+      <PingDot />
       <div className="flex-1 leading-snug">
         <span className="font-medium text-foreground">Observing: </span>
         <span className="text-muted-foreground">


### PR DESCRIPTION
## What

- Replace the sliding gradient glow sweep on the mining progress bar with a small pulsing status dot before "Analyzing your history" (same ping-dot pattern as the exclusions Observing banner).
- Dot goes static and muted when the sweep is paused.
- Remove the now-unused `mining-glow` keyframes from `index.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)