### PR TITLE
fix(llm): abort SDK provider requests that hang without a response

### DIFF
--- a/src/main/llm/inference-provider.test.ts
+++ b/src/main/llm/inference-provider.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { InferenceProviderImpl } from './inference-provider'
+import { InferenceProviderImpl, withRequestTimeout } from './inference-provider'
 import { OPENROUTER_BASE_URL } from './adapters'
 import { VendorCredentialsManager } from '../settings/vendor-credentials-manager'
 import type { Vendor } from '../../shared/types'
@@ -138,5 +138,31 @@ describe('InferenceProviderImpl', () => {
     unsubscribe()
     h.provider.notifyConfigChanged()
     expect(firedCount).toBe(1)
+  })
+})
+
+describe('withRequestTimeout', () => {
+  const hangingFetch: typeof globalThis.fetch = (_input, init) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(init.signal!.reason))
+    })
+
+  it('aborts a request that never responds', async () => {
+    const wrapped = withRequestTimeout(hangingFetch, 20)
+    await expect(wrapped('https://example.test')).rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+
+  it('a caller-supplied signal still aborts first', async () => {
+    const wrapped = withRequestTimeout(hangingFetch, 60_000)
+    const controller = new AbortController()
+    const pending = wrapped('https://example.test', { signal: controller.signal })
+    controller.abort()
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('passes responses through untouched', async () => {
+    const response = new Response('ok')
+    const wrapped = withRequestTimeout(async () => response, 20)
+    await expect(wrapped('https://example.test')).resolves.toBe(response)
   })
 })

--- a/src/main/llm/inference-provider.ts
+++ b/src/main/llm/inference-provider.ts
@@ -40,6 +40,26 @@ export interface InferenceProviderOptions {
   getActiveVendor: () => Vendor
   /** Optional fetch override forwarded to all underlying SDK providers (tests). */
   fetch?: typeof globalThis.fetch
+  /** Per-request timeout for SDK provider HTTP calls. Defaults to DEFAULT_REQUEST_TIMEOUT_MS. */
+  requestTimeoutMs?: number
+}
+
+/**
+ * Upstream providers can accept a request and then stall indefinitely while
+ * the gateway keeps the connection alive, so an explicit deadline is the only
+ * thing that ever fails the call. Normal completions finish well under this.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000
+
+export function withRequestTimeout(
+  fetchImpl: typeof globalThis.fetch,
+  timeoutMs: number,
+): typeof globalThis.fetch {
+  return (input, init) => {
+    const timeout = AbortSignal.timeout(timeoutMs)
+    const signal = init?.signal ? AbortSignal.any([init.signal, timeout]) : timeout
+    return fetchImpl(input, { ...init, signal })
+  }
 }
 
 interface CacheEntry {
@@ -51,6 +71,7 @@ export class InferenceProviderImpl implements InferenceProvider {
   private readonly credentials: VendorCredentialsManager
   private readonly getActiveVendorAccessor: () => Vendor
   private readonly customFetch: typeof globalThis.fetch | undefined
+  private readonly requestTimeoutMs: number
   private readonly sdkCache = new Map<Vendor, CacheEntry>()
   private readonly loggedRouteSnapshots = new Set<string>()
   private readonly listeners = new Set<() => void>()
@@ -59,6 +80,7 @@ export class InferenceProviderImpl implements InferenceProvider {
     this.credentials = options.credentials
     this.getActiveVendorAccessor = options.getActiveVendor
     this.customFetch = options.fetch
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
   }
 
   isConfigured(): boolean {
@@ -80,7 +102,9 @@ export class InferenceProviderImpl implements InferenceProvider {
     if (cached && cached.signature === signature) {
       return cached.sdkProvider.languageModel(modelId)
     }
-    const sdkProvider = createSdkProvider(vendor, creds, { fetch: this.customFetch })
+    const sdkProvider = createSdkProvider(vendor, creds, {
+      fetch: withRequestTimeout(this.customFetch ?? globalThis.fetch, this.requestTimeoutMs),
+    })
     this.sdkCache.set(vendor, { signature, sdkProvider })
     log.info(`[InferenceProvider] built provider ${describeRoute(vendor, creds)}`)
     return sdkProvider.languageModel(modelId)


### PR DESCRIPTION
## Problem

A mining sweep hung indefinitely in production: OpenRouter accepted the Phase-1 scan request, the upstream provider (Novita) never generated, and the gateway's keepalive bytes prevented any socket-level timeout from firing. `generateText` has no deadline of its own, so the sweep — and the "Analyzing your history" banner — blocked forever on one request.

## Fix

Wrap the SDK provider `fetch` in `InferenceProvider` with a hard 5-minute deadline (`withRequestTimeout`). A caller-supplied abort signal is combined via `AbortSignal.any`, so existing per-call signals (semantic service) still abort first. On timeout the request rejects, `formatApiError` records it on the day's ledger attempt, and the sweep's existing retry path takes over.

The raw-HTTP video path already had its own timeout; the SDK path was the only one without a deadline.

## Tests

- Hung request rejects with `TimeoutError` after the deadline
- Caller-supplied signal still aborts first
- Responses pass through untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)