### PR TITLE
refactor: extract Claude clipboard prompts into a shared module

### DIFF
--- a/src/renderer/pages/main-window/components/ClusterDetailPane.tsx
+++ b/src/renderer/pages/main-window/components/ClusterDetailPane.tsx
@@ -3,11 +3,11 @@ import { toast } from 'sonner'
 import { Button } from '@components/ui/button'
 import { ScrollArea } from '@components/ui/scroll-area'
 import { ChevronDown, ChevronUp, Copy } from 'lucide-react'
-import type { ClusterDetailInfo, ClusterInfo, ClusterSightingInfo, MainWindowAPI } from '@types'
-import { formatFrequency, formatMinutes, formatMonthlyHours } from './activities/format'
+import type { ClusterDetailInfo, ClusterInfo, MainWindowAPI } from '@types'
+import { formatMinutes, formatMonthlyHours, formatSightingTime } from './activities/format'
 import { WeeklyTrend } from './WeeklyTrend'
 import { ClaudeWordmark } from './ClaudeWordmark'
-import { scrubPII } from '@/shared/sanitize'
+import { buildClusterAgentPrompt, buildClusterAnalyzePrompt } from './claude-prompts'
 
 interface ClusterDetailPaneProps {
   api: MainWindowAPI
@@ -17,127 +17,6 @@ interface ClusterDetailPaneProps {
 // Delay showing "Loading…" so fast list-nav between clusters doesn't flash.
 const LOADING_DELAY_MS = 150
 const INITIAL_SIGHTINGS = 3
-
-function formatSightingTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  })
-}
-
-function buildCopyPrompt(cluster: ClusterInfo, sightings: ClusterSightingInfo[]): string {
-  const recent = sightings.slice(0, 5)
-  const sampleActivityIds = recent.flatMap((s) => s.activityIds).slice(0, 20)
-  const hasIds = sampleActivityIds.length > 0
-  const lines = [
-    `Here's a recurring task I'd like to explore: "${cluster.title}".`,
-    ``,
-    cluster.description ? `Context: ${cluster.description}` : null,
-    `Apps involved: ${cluster.apps.join(', ') || 'unknown'}.`,
-    cluster.timesPerWeek > 0
-      ? `I do this about ${formatFrequency(cluster.timesPerWeek)} (${cluster.timesSeen} runs over ${cluster.observedDays} active days); a run takes ~${Math.round(cluster.avgActiveMin)} min of hands-on work.`
-      : `I've done this ${cluster.timesSeen} time${cluster.timesSeen === 1 ? '' : 's'}; a run takes ~${Math.round(cluster.avgActiveMin)} min of hands-on work.`,
-    ``,
-    ...(hasIds ? [`Activity IDs for research: ${sampleActivityIds.join(', ')}.`, ``] : []),
-    `Recent occurrences:`,
-    ...recent.map(
-      (s) => `- ${formatSightingTime(s.startedAt)}: ${s.title}${s.subject ? `, ${s.subject}` : ''}`,
-    ),
-    ``,
-    `## Choose a path`,
-    ``,
-    `Use AskUserQuestion to ask me:`,
-    `1. **Build a Claude Skill** to automate this task`,
-    `2. **Analyze this pattern** to understand the workflow in detail`,
-    ``,
-    `---`,
-    ``,
-    `## Path 1: Build a Claude Skill`,
-    ``,
-    `### Research`,
-    `Use the MemoryLane MCP tools to understand what this task really involves:`,
-    ...(hasIds
-      ? [
-          `1. Call get_activity_details on the activity IDs above to read the OCR evidence of what I actually did.`,
-          `2. Call browse_timeline around those timestamps (±15 minutes) to see the full workflow.`,
-        ]
-      : [
-          `1. Call browse_timeline around the occurrences above (±15 minutes) to see the full workflow.`,
-        ]),
-    ``,
-    `### Ask me questions`,
-    `Before building, ask me:`,
-    `- Which steps vary between occurrences?`,
-    `- What inputs or variables are needed?`,
-    `- What tools, APIs, or services do I have available?`,
-    ``,
-    `Wait for my answers, then create a Claude skill (a SKILL.md file with YAML frontmatter: name, description, allowed-tools, and step-by-step instructions). Save it and tell me where it was saved.`,
-    ``,
-    `---`,
-    ``,
-    `## Path 2: Analyze this pattern`,
-    ``,
-    `### Quick analysis`,
-    `Use the MemoryLane MCP tools:`,
-    ...(hasIds
-      ? [
-          `1. Call get_activity_details on the activity IDs above.`,
-          `2. Call browse_timeline around those timestamps (±15 minutes).`,
-        ]
-      : [`1. Call browse_timeline around the occurrences above (±15 minutes).`]),
-    ``,
-    `Then summarize:`,
-    `- Step-by-step workflow (activity level, not click level)`,
-    `- Time per app per run`,
-    `- What varies vs what stays constant across runs`,
-    `- Rough automatable rating: low / medium / high`,
-    ``,
-    `### What next?`,
-    `After the summary, use AskUserQuestion:`,
-    `1. **Build a Claude Skill** (skip research since you already did it, go straight to asking me questions from Path 1, then create the SKILL.md)`,
-    `2. **Run deep ROI analysis** (deep dive with time/cost quantification and automation recommendations)`,
-    `3. **I'm done, thanks**`,
-    ``,
-    `If "Run deep ROI analysis": invoke /process-analyst-new focused on this pattern.`,
-    `If /process-analyst-new is not available, suggest I install the MemoryLane plugin for Claude (it includes the process analyst skill for deep workflow analysis and a reporting skill to generate shareable reports). Then offer to run a lighter analysis inline using the MCP tools instead (decompose steps, estimate time per step, flag what looks automatable).`,
-  ]
-  return lines.filter((l) => l !== null).join('\n')
-}
-
-/** Tool-agnostic prompt built from the stored, de-identified recipe;
- * scrubPII runs over the final string as a last-mile net. */
-function buildAgentPrompt(cluster: ClusterInfo): string {
-  const lines: string[] = [
-    `Build an AI agent that automates this task.`,
-    ``,
-    `Goal: ${cluster.description || cluster.title}`,
-    ``,
-  ]
-  if (cluster.steps.length > 0) {
-    lines.push(`Step-by-step:`)
-    cluster.steps.forEach((step, i) => lines.push(`${i + 1}. ${step}`))
-  } else {
-    lines.push(
-      `Apps: ${cluster.apps.join(', ') || 'unknown'}. Work out the steps, then confirm with me.`,
-    )
-  }
-  if (cluster.variables.length > 0) {
-    lines.push(``, `Changes each run: ${cluster.variables.join(', ')}.`)
-  }
-  lines.push(``, `Before building, ask me:`)
-  if (cluster.variables.length === 0) {
-    lines.push(`- Which steps or inputs change each run?`)
-  }
-  lines.push(
-    `- What tools and API access are available?`,
-    `- What should happen when a step fails?`,
-    ``,
-    `Then build it and tell me how to run it.`,
-  )
-  return scrubPII(lines.join('\n'))
-}
 
 function Stat({ value, label }: { value: string; label: string }): React.JSX.Element {
   return (
@@ -197,7 +76,7 @@ export function ClusterDetailPane({ api, cluster }: ClusterDetailPaneProps): Rea
 
   const handleCopyPrompt = (): void => {
     navigator.clipboard
-      .writeText(buildCopyPrompt(cluster, sightings))
+      .writeText(buildClusterAnalyzePrompt(cluster, sightings))
       .then(() => toast.success('Copied! Paste it into Claude Cowork'))
       .catch((err) => {
         console.warn('[clusters] clipboard.writeText failed', err)
@@ -207,7 +86,7 @@ export function ClusterDetailPane({ api, cluster }: ClusterDetailPaneProps): Rea
 
   const handleCopyAgentPrompt = (): void => {
     navigator.clipboard
-      .writeText(buildAgentPrompt(cluster))
+      .writeText(buildClusterAgentPrompt(cluster))
       .then(() => toast.success('Agent prompt copied to clipboard'))
       .catch((err) => {
         console.warn('[clusters] clipboard.writeText failed', err)

--- a/src/renderer/pages/main-window/components/activities/format.ts
+++ b/src/renderer/pages/main-window/components/activities/format.ts
@@ -30,6 +30,15 @@ export function formatDuration(ms: number): string {
   return m === 0 ? `${h}h` : `${h}h ${m}m`
 }
 
+export function formatSightingTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
 export function formatShortDate(ms: number): string {
   return new Date(ms).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })
 }

--- a/src/renderer/pages/main-window/components/claude-prompts.ts
+++ b/src/renderer/pages/main-window/components/claude-prompts.ts
@@ -1,0 +1,124 @@
+import type { ClusterInfo, ClusterSightingInfo } from '@types'
+import { scrubPII } from '@/shared/sanitize'
+import { formatFrequency, formatSightingTime } from './activities/format'
+
+/** Clipboard prompts for the "Analyze with Claude" / "Build AI agent" buttons.
+ * The analyze prompt is NOT scrubbed: activity ids are UUIDs, and
+ * scrubPII's id/phone patterns would corrupt all-digit segments (DEU-207
+ * tracks the egress-scrub redesign). */
+
+export function buildClusterAnalyzePrompt(
+  cluster: ClusterInfo,
+  sightings: ClusterSightingInfo[],
+): string {
+  const recent = sightings.slice(0, 5)
+  const sampleActivityIds = recent.flatMap((s) => s.activityIds).slice(0, 20)
+  const hasIds = sampleActivityIds.length > 0
+  const lines = [
+    `Here's a recurring task I'd like to explore: "${cluster.title}".`,
+    ``,
+    cluster.description ? `Context: ${cluster.description}` : null,
+    `Apps involved: ${cluster.apps.join(', ') || 'unknown'}.`,
+    cluster.timesPerWeek > 0
+      ? `I do this about ${formatFrequency(cluster.timesPerWeek)} (${cluster.timesSeen} runs over ${cluster.observedDays} active days); a run takes ~${Math.round(cluster.avgActiveMin)} min of hands-on work.`
+      : `I've done this ${cluster.timesSeen} time${cluster.timesSeen === 1 ? '' : 's'}; a run takes ~${Math.round(cluster.avgActiveMin)} min of hands-on work.`,
+    ``,
+    ...(hasIds ? [`Activity IDs for research: ${sampleActivityIds.join(', ')}.`, ``] : []),
+    `Recent occurrences:`,
+    ...recent.map(
+      (s) => `- ${formatSightingTime(s.startedAt)}: ${s.title}${s.subject ? `, ${s.subject}` : ''}`,
+    ),
+    ``,
+    `## Choose a path`,
+    ``,
+    `Use AskUserQuestion to ask me:`,
+    `1. **Build a Claude Skill** to automate this task`,
+    `2. **Analyze this pattern** to understand the workflow in detail`,
+    ``,
+    `---`,
+    ``,
+    `## Path 1: Build a Claude Skill`,
+    ``,
+    `### Research`,
+    `Use the MemoryLane MCP tools to understand what this task really involves:`,
+    ...(hasIds
+      ? [
+          `1. Call get_activity_details on the activity IDs above to read the OCR evidence of what I actually did.`,
+          `2. Call browse_timeline around those timestamps (±15 minutes) to see the full workflow.`,
+        ]
+      : [
+          `1. Call browse_timeline around the occurrences above (±15 minutes) to see the full workflow.`,
+        ]),
+    ``,
+    `### Ask me questions`,
+    `Before building, ask me:`,
+    `- Which steps vary between occurrences?`,
+    `- What inputs or variables are needed?`,
+    `- What tools, APIs, or services do I have available?`,
+    ``,
+    `Wait for my answers, then create a Claude skill (a SKILL.md file with YAML frontmatter: name, description, allowed-tools, and step-by-step instructions). Save it and tell me where it was saved.`,
+    ``,
+    `---`,
+    ``,
+    `## Path 2: Analyze this pattern`,
+    ``,
+    `### Quick analysis`,
+    `Use the MemoryLane MCP tools:`,
+    ...(hasIds
+      ? [
+          `1. Call get_activity_details on the activity IDs above.`,
+          `2. Call browse_timeline around those timestamps (±15 minutes).`,
+        ]
+      : [`1. Call browse_timeline around the occurrences above (±15 minutes).`]),
+    ``,
+    `Then summarize:`,
+    `- Step-by-step workflow (activity level, not click level)`,
+    `- Time per app per run`,
+    `- What varies vs what stays constant across runs`,
+    `- Rough automatable rating: low / medium / high`,
+    ``,
+    `### What next?`,
+    `After the summary, use AskUserQuestion:`,
+    `1. **Build a Claude Skill** (skip research since you already did it, go straight to asking me questions from Path 1, then create the SKILL.md)`,
+    `2. **Run deep ROI analysis** (deep dive with time/cost quantification and automation recommendations)`,
+    `3. **I'm done, thanks**`,
+    ``,
+    `If "Run deep ROI analysis": invoke /process-analyst-new focused on this pattern.`,
+    `If /process-analyst-new is not available, suggest I install the MemoryLane plugin for Claude (it includes the process analyst skill for deep workflow analysis and a reporting skill to generate shareable reports). Then offer to run a lighter analysis inline using the MCP tools instead (decompose steps, estimate time per step, flag what looks automatable).`,
+  ]
+  return lines.filter((l) => l !== null).join('\n')
+}
+
+/** Tool-agnostic prompt built from the stored, de-identified recipe;
+ * scrubPII runs over the final string as a last-mile net. */
+export function buildClusterAgentPrompt(cluster: ClusterInfo): string {
+  const lines: string[] = [
+    `Build an AI agent that automates this task.`,
+    ``,
+    `Goal: ${cluster.description || cluster.title}`,
+    ``,
+  ]
+  if (cluster.steps.length > 0) {
+    lines.push(`Step-by-step:`)
+    cluster.steps.forEach((step, i) => lines.push(`${i + 1}. ${step}`))
+  } else {
+    lines.push(
+      `Apps: ${cluster.apps.join(', ') || 'unknown'}. Work out the steps, then confirm with me.`,
+    )
+  }
+  if (cluster.variables.length > 0) {
+    lines.push(``, `Changes each run: ${cluster.variables.join(', ')}.`)
+  }
+  lines.push(``, `Before building, ask me:`)
+  if (cluster.variables.length === 0) {
+    lines.push(`- Which steps or inputs change each run?`)
+  }
+  lines.push(
+    `- What tools and API access are available?`,
+    `- What should happen when a step fails?`,
+    ``,
+    `Then build it and tell me how to run it.`,
+  )
+  return scrubPII(lines.join('\n'))
+}
+


### PR DESCRIPTION
## Summary

Reopens #241 (auto-closed when the #240 branch it was stacked on got deleted at merge), rebased onto main.

- Moves both clipboard prompt builders out of `ClusterDetailPane.tsx` into `claude-prompts.ts`: `buildClusterAnalyzePrompt` (two-path) and `buildClusterAgentPrompt` (scrubbed) — components stay UI-only, prompt copy has one findable home
- `formatSightingTime` moves to `activities/format.ts` so both the detail pane and the prompt module can use it
- The analyze prompt stays deliberately unscrubbed: `scrubPII`'s id/phone patterns would corrupt all-digit UUID segments in the activity IDs (egress-scrub redesign tracked in DEU-207)

The earlier revision also ported a legacy `PatternsSection` prompt — dropped: that component was already deleted on main by the clusters-UI cutover and only survived on the stale #240 branch.

No behavior change.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Cluster detail: "Analyze with Claude" and "Build AI agent" copy the same prompts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)