### PR TITLE
Installer resilience: mac LaunchAgent + Windows app-watcher parent-death exit

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,14 @@
-# MemoryLane v1.5.0
+# MemoryLane v1.5.1-alpha.1
 
-Stable release. The task miner replaces the legacy pattern detector as the only analysis engine, patterns get a redesigned UI with step-by-step recipes, and managed installs receive model updates remotely.
+Alpha prerelease. Enterprise installs survive silent MDM/RMM update pushes on both platforms, and one app identity (site domain or app name) is used across the UI.
 
 ## What's Changed
 
-- **Task miner is now the only analyzer**: the legacy pattern detector is fully removed. Installs that still ran the old detector start a fresh ~60-day backfill on first launch (existing data is kept). Mining runs on a per-day ledger with a unified sweep and progress banner (#221).
-- **Patterns-first UI**: redesigned patterns view with honest metrics and a weekly trend, refreshed with the shadcn design preset (#227, #229).
-- **Recipe steps everywhere**: every pattern carries LLM-generated, sanitized step-by-step recipe lines (app, domain, intent) in the Build AI agent prompt (#228, #235).
-- **Remote model config**: managed installs poll the backend for model picks, so degraded or repriced models can be swapped without an app update. BYOK and custom-endpoint installs keep full model control (#233).
-- **MCP serves clusters**: the pattern tools (`list_patterns`, `get_pattern_details`) now read task-mining clusters (#226).
-- **Fixes**: actionable messages for network failures during activation (#222), recorder no longer crashes on daemon stdin write errors (#220), frame/video deletes retry on transient Windows file locks (#219).
+- **macOS enterprise pkg self-heals**: preinstall quits the running app before the bundle swap; postinstall installs a machine-level LaunchAgent that relaunches the app at login and after unclean exits, so MDM-pushed updates no longer leave the app stopped.
+- **Windows installer pushes no longer break the install**: the app-watcher sidecar exits when the main process dies, so RMM/MSI pushes can replace files immediately instead of deferring to reboot and leaving a broken install.
+- **One app identity**: patterns and activities use the site domain (or app name) as a single app concept across the UI, digest, and prompts (#239).
+- **Open in Claude**: the "Analyze with Claude" button is now "Open in Claude" with two paths — build a MemoryLane plugin skill or run an analysis (#240, #242).
+- **Fix**: LLM requests that hang without a response are aborted instead of stalling the pipeline (#238).
 
 ## Known Issues & Limitations
 
@@ -27,4 +26,4 @@ Stable release. The task miner replaces the legacy pattern detector as the only 
 
 ## Full Changelog
 
-https://github.com/deusXmachina-dev/memorylane/compare/v1.4.0...v1.5.0
+https://github.com/deusXmachina-dev/memorylane/compare/v1.5.0...v1.5.1-alpha.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,8 @@ Alpha prerelease. Enterprise installs survive silent MDM/RMM update pushes on bo
 
 ## What's Changed
 
-- **macOS enterprise pkg self-heals**: preinstall quits the running app before the bundle swap; postinstall installs a machine-level LaunchAgent that relaunches the app at login and after unclean exits, so MDM-pushed updates no longer leave the app stopped.
-- **Windows installer pushes no longer break the install**: the app-watcher sidecar exits when the main process dies, so RMM/MSI pushes can replace files immediately instead of deferring to reboot and leaving a broken install.
+- **macOS enterprise self-heals**: the app relaunches at login and after unclean exits, so MDM update pushes no longer leave it stopped.
+- **Windows enterprise self-heals**: a watchdog task relaunches the app after an external kill, and helper processes exit with the app so installer pushes no longer defer file replacement to reboot.
 - **One app identity**: patterns and activities use the site domain (or app name) as a single app concept across the UI, digest, and prompts (#239).
 - **Open in Claude**: the "Analyze with Claude" button is now "Open in Claude" with two paths — build a MemoryLane plugin skill or run an analysis (#240, #242).
 - **Fix**: LLM requests that hang without a response are aborted instead of stalling the pipeline (#238).

--- a/assets/pkg-scripts/postinstall
+++ b/assets/pkg-scripts/postinstall
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Enterprise pkg postinstall: install a machine-level LaunchAgent so the app
+# starts at every login and is relaunched if it dies without a clean quit,
+# then start it for the current console user so no logout is needed.
+set -u
+
+APP_BIN="/Applications/MemoryLane Enterprise.app/Contents/MacOS/MemoryLane Enterprise"
+LABEL="com.memorylane.enterprise.launcher"
+PLIST="/Library/LaunchAgents/$LABEL.plist"
+
+cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$APP_BIN</string>
+    <string>--memorylane-hidden</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>LimitLoadToSessionType</key>
+  <string>Aqua</string>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+</dict>
+</plist>
+EOF
+chown root:wheel "$PLIST"
+chmod 644 "$PLIST"
+
+CONSOLE_UID=$(stat -f %u /dev/console 2>/dev/null || echo 0)
+if [ "$CONSOLE_UID" -gt 0 ]; then
+  launchctl bootstrap "gui/$CONSOLE_UID" "$PLIST" 2>/dev/null || true
+  launchctl kickstart "gui/$CONSOLE_UID/$LABEL" 2>/dev/null || true
+fi
+
+exit 0

--- a/assets/pkg-scripts/postinstall
+++ b/assets/pkg-scripts/postinstall
@@ -39,6 +39,9 @@ EOF
 chown root:wheel "$PLIST"
 chmod 644 "$PLIST"
 
+# Only the console user's session can be bootstrapped here; other logged-in
+# users (fast user switching) pick the agent up at their next login via
+# RunAtLoad.
 CONSOLE_UID=$(stat -f %u /dev/console 2>/dev/null || echo 0)
 if [ "$CONSOLE_UID" -gt 0 ]; then
   launchctl bootstrap "gui/$CONSOLE_UID" "$PLIST" 2>/dev/null || true

--- a/assets/pkg-scripts/postinstall
+++ b/assets/pkg-scripts/postinstall
@@ -22,6 +22,8 @@ cat > "$PLIST" <<EOF
   </array>
   <key>RunAtLoad</key>
   <true/>
+  <key>AssociatedBundleIdentifiers</key>
+  <string>com.memorylane.enterprise</string>
   <key>KeepAlive</key>
   <dict>
     <key>SuccessfulExit</key>

--- a/assets/pkg-scripts/preinstall
+++ b/assets/pkg-scripts/preinstall
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Enterprise pkg preinstall: stop the previous launcher agent and quit the
+# running app so the bundle is never replaced under a live process (an MDM
+# push installs silently while the app is running).
+set -u
+
+LABEL="com.memorylane.enterprise.launcher"
+BUNDLE="/Applications/MemoryLane Enterprise.app"
+
+CONSOLE_UID=$(stat -f %u /dev/console 2>/dev/null || echo 0)
+if [ "$CONSOLE_UID" -gt 0 ]; then
+  launchctl bootout "gui/$CONSOLE_UID/$LABEL" 2>/dev/null || true
+fi
+
+# SIGTERM triggers Electron's graceful quit (helpers included); escalate only
+# if the app is still around after 10s.
+pkill -TERM -f "$BUNDLE/Contents/" 2>/dev/null || true
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  pgrep -f "$BUNDLE/Contents/" >/dev/null 2>&1 || break
+  sleep 1
+done
+pkill -KILL -f "$BUNDLE/Contents/" 2>/dev/null || true
+
+exit 0

--- a/assets/pkg-scripts/preinstall
+++ b/assets/pkg-scripts/preinstall
@@ -13,12 +13,15 @@ if [ "$CONSOLE_UID" -gt 0 ]; then
 fi
 
 # SIGTERM triggers Electron's graceful quit (helpers included); escalate only
-# if the app is still around after 10s.
-pkill -TERM -f "$BUNDLE/Contents/" 2>/dev/null || true
+# if the app is still around after 10s. Anchored to argv[0] so an unrelated
+# process merely mentioning the bundle path (e.g. tail -f on a log inside it)
+# is not killed; app and helper binaries all live under the bundle.
+PATTERN="^$BUNDLE/Contents/"
+pkill -TERM -f "$PATTERN" 2>/dev/null || true
 for _ in 1 2 3 4 5 6 7 8 9 10; do
-  pgrep -f "$BUNDLE/Contents/" >/dev/null 2>&1 || break
+  pgrep -f "$PATTERN" >/dev/null 2>&1 || break
   sleep 1
 done
-pkill -KILL -f "$BUNDLE/Contents/" 2>/dev/null || true
+pkill -KILL -f "$PATTERN" 2>/dev/null || true
 
 exit 0

--- a/assets/watchdog-relaunch.vbs
+++ b/assets/watchdog-relaunch.vbs
@@ -1,0 +1,27 @@
+' Runs from the "MemoryLane Enterprise Watchdog" scheduled task (see
+' src/main/system/watchdog-win.ts) instead of launching the exe directly:
+' no console window flashes, the task deletes itself once the app is
+' uninstalled, and the relaunch is skipped while a Windows Installer is
+' active so a freshly launched app cannot hold handles in the install
+' directory mid-push. An idle Installer service delays the relaunch by a
+' cycle or two at worst.
+Option Explicit
+
+Dim appExe, hiddenArg, fso, shell, installers
+If WScript.Arguments.Count < 2 Then WScript.Quit 0
+appExe = WScript.Arguments(0)
+hiddenArg = WScript.Arguments(1)
+
+Set fso = CreateObject("Scripting.FileSystemObject")
+Set shell = CreateObject("WScript.Shell")
+
+If Not fso.FileExists(appExe) Then
+  shell.Run "schtasks.exe /Delete /F /TN ""MemoryLane Enterprise Watchdog""", 0, True
+  WScript.Quit 0
+End If
+
+Set installers = GetObject("winmgmts:\\.\root\cimv2").ExecQuery( _
+  "SELECT ProcessId FROM Win32_Process WHERE Name = 'msiexec.exe'")
+If installers.Count > 0 Then WScript.Quit 0
+
+shell.Run """" & appExe & """ " & hiddenArg, 0, False

--- a/assets/watchdog-relaunch.vbs
+++ b/assets/watchdog-relaunch.vbs
@@ -1,27 +1,36 @@
-' Runs from the "MemoryLane Enterprise Watchdog" scheduled task (see
-' src/main/system/watchdog-win.ts) instead of launching the exe directly:
-' no console window flashes, the task deletes itself once the app is
-' uninstalled, and the relaunch is skipped while a Windows Installer is
-' active so a freshly launched app cannot hold handles in the install
-' directory mid-push. An idle Installer service delays the relaunch by a
-' cycle or two at worst.
+' Runs from the scheduled task registered by src/main/system/watchdog-win.ts
+' instead of launching the exe directly: no console window flashes, the task
+' deletes itself once the app is uninstalled, and the relaunch is skipped
+' while the app is already running or a Windows Installer is active (so a
+' freshly launched app cannot hold handles in the install directory mid-push).
 Option Explicit
 
-Dim appExe, hiddenArg, fso, shell, installers
-If WScript.Arguments.Count < 2 Then WScript.Quit 0
+Dim appExe, hiddenArg, taskName, fso, shell, wmi, appExeWql
+If WScript.Arguments.Count < 3 Then WScript.Quit 0
 appExe = WScript.Arguments(0)
 hiddenArg = WScript.Arguments(1)
+taskName = WScript.Arguments(2)
 
 Set fso = CreateObject("Scripting.FileSystemObject")
 Set shell = CreateObject("WScript.Shell")
 
 If Not fso.FileExists(appExe) Then
-  shell.Run "schtasks.exe /Delete /F /TN ""MemoryLane Enterprise Watchdog""", 0, True
+  shell.Run "schtasks.exe /Delete /F /TN """ & taskName & """", 0, True
   WScript.Quit 0
 End If
 
-Set installers = GetObject("winmgmts:\\.\root\cimv2").ExecQuery( _
-  "SELECT ProcessId FROM Win32_Process WHERE Name = 'msiexec.exe'")
-If installers.Count > 0 Then WScript.Quit 0
+Set wmi = GetObject("winmgmts:\\.\root\cimv2")
+If wmi.ExecQuery( _
+  "SELECT ProcessId FROM Win32_Process WHERE Name = 'msiexec.exe'").Count > 0 Then
+  WScript.Quit 0
+End If
+
+' Skip the Electron cold start in the common already-running case; the
+' single-instance lock still covers the race.
+appExeWql = Replace(appExe, "\", "\\")
+If wmi.ExecQuery( _
+  "SELECT ProcessId FROM Win32_Process WHERE ExecutablePath = '" & appExeWql & "'").Count > 0 Then
+  WScript.Quit 0
+End If
 
 shell.Run """" & appExe & """ " & hiddenArg, 0, False

--- a/native/windows/app-watcher/README.md
+++ b/native/windows/app-watcher/README.md
@@ -38,6 +38,11 @@ Optional override in development:
 
 - `MEMORYLANE_APP_WATCHER_WIN_EXECUTABLE=<absolute path to exe>`
 
+## Arguments
+
+- `--parent-pid=<pid>` (optional): exit when this process dies. Passed by the
+  Electron main process so the watcher never outlives it.
+
 ## Test
 
 From repo root:

--- a/native/windows/app-watcher/src/main.rs
+++ b/native/windows/app-watcher/src/main.rs
@@ -1,6 +1,7 @@
 mod browser_url;
 mod hooks;
 mod output;
+mod parent_watch;
 mod snapshot;
 mod state;
 mod time;
@@ -18,6 +19,8 @@ use crate::time::now_ms;
 use crate::win32_window::hwnd_is_valid;
 
 fn main() {
+    parent_watch::spawn_parent_watchdog();
+
     let com_init_result = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
     let com_needs_uninit = com_init_result.is_ok();
     let _com_available = com_needs_uninit || com_init_result == RPC_E_CHANGED_MODE;

--- a/native/windows/app-watcher/src/parent_watch.rs
+++ b/native/windows/app-watcher/src/parent_watch.rs
@@ -7,6 +7,10 @@ const PARENT_PID_ARG: &str = "--parent-pid=";
 /// Exit when the parent process dies. Installers terminate the Electron main
 /// process without warning; a surviving watcher keeps a handle inside the
 /// install directory and forces MSI to defer file replacement to a reboot.
+///
+/// If the parent died and its PID was already reused before `OpenProcess`
+/// runs, the watchdog waits on the wrong process — accepted, as the window is
+/// the few milliseconds between spawn and this call.
 pub fn spawn_parent_watchdog() {
     let Some(pid) = std::env::args().find_map(|arg| {
         arg.strip_prefix(PARENT_PID_ARG)

--- a/native/windows/app-watcher/src/parent_watch.rs
+++ b/native/windows/app-watcher/src/parent_watch.rs
@@ -1,0 +1,28 @@
+use windows::Win32::System::Threading::{
+    OpenProcess, WaitForSingleObject, INFINITE, PROCESS_SYNCHRONIZE,
+};
+
+const PARENT_PID_ARG: &str = "--parent-pid=";
+
+/// Exit when the parent process dies. Installers terminate the Electron main
+/// process without warning; a surviving watcher keeps a handle inside the
+/// install directory and forces MSI to defer file replacement to a reboot.
+pub fn spawn_parent_watchdog() {
+    let Some(pid) = std::env::args().find_map(|arg| {
+        arg.strip_prefix(PARENT_PID_ARG)
+            .and_then(|v| v.parse::<u32>().ok())
+    }) else {
+        return;
+    };
+
+    std::thread::spawn(move || {
+        let parent = match unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, pid) } {
+            Ok(handle) => handle,
+            Err(_) => std::process::exit(0),
+        };
+        unsafe {
+            let _ = WaitForSingleObject(parent, INFINITE);
+        }
+        std::process::exit(0);
+    });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorylane",
-  "version": "1.5.0",
+  "version": "1.5.1-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorylane",
-      "version": "1.5.0",
+      "version": "1.5.1-alpha.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorylane",
   "productName": "MemoryLane",
-  "version": "1.5.0",
+  "version": "1.5.1-alpha.1",
   "description": "MemoryLane is a system tray application that captures screenshots at regular intervals.",
   "main": "./out/main/index.js",
   "private": true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,9 +15,8 @@ import path from 'node:path'
 import { config as loadEnv } from 'dotenv'
 import {
   AUTO_START_HIDDEN_ARG,
-  canSyncAutoStartSetting,
-  launchAgentOwnsAutoStart,
   shouldStartHiddenOnLaunch,
+  shouldSyncAutoStartOnStartup,
   syncAutoStartSetting,
 } from '@main/system/auto-start'
 import { ensureWatchdogTask } from '@main/system/watchdog-win'
@@ -54,7 +53,7 @@ import {
   type ObservationController,
 } from '@main/capture/observation-controller'
 import { getAppDirectoryName } from '@main/utils/paths'
-import { getAppEditionConfig } from '@main/system/edition'
+import { loadAppEditionConfig } from '@main/system/edition'
 import { ENTERPRISE_BACKEND_CONFIG, MANAGED_KEY_CONFIG } from '../shared/constants'
 
 // Keep single-instance behavior in packaged app, but allow dev to run
@@ -147,21 +146,18 @@ let observation: ObservationController | null = null
 // process, keeps an open handle on resources\rust\app-watcher-windows.exe,
 // and MSI has to defer replacement to a reboot (return code 3010).
 //
-// A dispose step that never settles must not strand a half-shut-down process
-// ("not quit, not running"), so a watchdog force-exits after 5s and logs which
-// steps were still pending. It stays ahead of the mac preinstall's 10s SIGKILL
-// escalation, and is never cleared so it also covers stray handles keeping the
-// process alive after the graceful quit is re-issued. It can't fire while a
-// sync native call is blocking the event loop — only an external kill ends
-// that state.
+// A force-exit timer bounds shutdown at 5s (ahead of the mac preinstall's 10s
+// SIGKILL) and logs which dispose steps were still pending. It is never
+// cleared, so it also covers stray handles that outlive the graceful quit; a
+// sync native call blocking the event loop still defeats it.
 const SHUTDOWN_TIMEOUT_MS = 5_000
 let shutdownStarted = false
 let shutdownCompleted = false
 app.on('before-quit', (event) => {
   if (shutdownCompleted) return
   event.preventDefault()
-  // A repeated quit (double tray click) must not re-run dispose steps or arm
-  // a second force-exit timer; the in-flight shutdown re-issues app.quit().
+  // A repeated quit must not re-run dispose steps or arm a second timer; the
+  // in-flight shutdown re-issues app.quit().
   if (shutdownStarted) return
   shutdownStarted = true
 
@@ -212,7 +208,7 @@ app.on('second-instance', (_event, argv) => {
 
 app.on('ready', async () => {
   const startHidden = shouldStartHiddenOnLaunch()
-  const editionConfig = getAppEditionConfig()
+  const editionConfig = loadAppEditionConfig()
 
   // Permissions are no longer blocking at startup. The renderer drives the
   // permission grant flow as part of onboarding (PermissionsStep).
@@ -248,12 +244,7 @@ app.on('ready', async () => {
   captureSettingsManager.applyToConstants()
   const initialCaptureSettings = captureSettingsManager.get()
 
-  // The one-time gate must not skip mac enterprise: installs upgraded from
-  // pre-LaunchAgent builds need their stale login item removed on startup.
-  if (
-    canSyncAutoStartSetting() &&
-    (!captureStateManager.isAutoStartInitialized() || launchAgentOwnsAutoStart())
-  ) {
+  if (shouldSyncAutoStartOnStartup(captureStateManager.isAutoStartInitialized())) {
     syncAutoStartSetting(initialCaptureSettings.autoStartEnabled)
     captureStateManager.setAutoStartInitialized(true)
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,7 @@ import { config as loadEnv } from 'dotenv'
 import {
   AUTO_START_HIDDEN_ARG,
   canSyncAutoStartSetting,
+  launchAgentOwnsAutoStart,
   shouldStartHiddenOnLaunch,
   syncAutoStartSetting,
 } from '@main/system/auto-start'
@@ -53,7 +54,7 @@ import {
   type ObservationController,
 } from '@main/capture/observation-controller'
 import { getAppDirectoryName } from '@main/utils/paths'
-import { loadAppEditionConfig } from '@main/system/edition'
+import { getAppEditionConfig } from '@main/system/edition'
 import { ENTERPRISE_BACKEND_CONFIG, MANAGED_KEY_CONFIG } from '../shared/constants'
 
 // Keep single-instance behavior in packaged app, but allow dev to run
@@ -154,10 +155,15 @@ let observation: ObservationController | null = null
 // sync native call is blocking the event loop — only an external kill ends
 // that state.
 const SHUTDOWN_TIMEOUT_MS = 5_000
+let shutdownStarted = false
 let shutdownCompleted = false
 app.on('before-quit', (event) => {
   if (shutdownCompleted) return
   event.preventDefault()
+  // A repeated quit (double tray click) must not re-run dispose steps or arm
+  // a second force-exit timer; the in-flight shutdown re-issues app.quit().
+  if (shutdownStarted) return
+  shutdownStarted = true
 
   runtime?.accessProvider.stopPeriodicRefresh()
   remoteBlacklist?.stop()
@@ -206,7 +212,7 @@ app.on('second-instance', (_event, argv) => {
 
 app.on('ready', async () => {
   const startHidden = shouldStartHiddenOnLaunch()
-  const editionConfig = loadAppEditionConfig()
+  const editionConfig = getAppEditionConfig()
 
   // Permissions are no longer blocking at startup. The renderer drives the
   // permission grant flow as part of onboarding (PermissionsStep).
@@ -242,7 +248,12 @@ app.on('ready', async () => {
   captureSettingsManager.applyToConstants()
   const initialCaptureSettings = captureSettingsManager.get()
 
-  if (!captureStateManager.isAutoStartInitialized() && canSyncAutoStartSetting()) {
+  // The one-time gate must not skip mac enterprise: installs upgraded from
+  // pre-LaunchAgent builds need their stale login item removed on startup.
+  if (
+    canSyncAutoStartSetting() &&
+    (!captureStateManager.isAutoStartInitialized() || launchAgentOwnsAutoStart())
+  ) {
     syncAutoStartSetting(initialCaptureSettings.autoStartEnabled)
     captureStateManager.setAutoStartInitialized(true)
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,10 +14,12 @@ import { app, globalShortcut } from 'electron'
 import path from 'node:path'
 import { config as loadEnv } from 'dotenv'
 import {
+  AUTO_START_HIDDEN_ARG,
   canSyncAutoStartSetting,
   shouldStartHiddenOnLaunch,
   syncAutoStartSetting,
 } from '@main/system/auto-start'
+import { ensureWatchdogTask } from '@main/system/watchdog-win'
 import { createCaptureCoordinator } from '@main/capture/capture-orchestrator'
 import { createCaptureHotkeyManager } from '@main/capture/capture-hotkey-manager'
 import log from '@main/utils/logger'
@@ -143,6 +145,15 @@ let observation: ObservationController | null = null
 // release their app-watcher subscriptions, the helper outlives the main
 // process, keeps an open handle on resources\rust\app-watcher-windows.exe,
 // and MSI has to defer replacement to a reboot (return code 3010).
+//
+// A dispose step that never settles must not strand a half-shut-down process
+// ("not quit, not running"), so a watchdog force-exits after 5s and logs which
+// steps were still pending. It stays ahead of the mac preinstall's 10s SIGKILL
+// escalation, and is never cleared so it also covers stray handles keeping the
+// process alive after the graceful quit is re-issued. It can't fire while a
+// sync native call is blocking the event loop — only an external kill ends
+// that state.
+const SHUTDOWN_TIMEOUT_MS = 5_000
 let shutdownCompleted = false
 app.on('before-quit', (event) => {
   if (shutdownCompleted) return
@@ -154,12 +165,26 @@ app.on('before-quit', (event) => {
   deviceReportSync?.stop()
   observation?.dispose()
 
-  void Promise.allSettled([
-    runtime?.dispose(),
-    rawDatabaseExportSync?.stop(),
-    databaseUploadSync?.stop(),
-    logUploadSync?.stop(),
-  ]).finally(() => {
+  const steps: Array<[name: string, step: Promise<unknown> | undefined]> = [
+    ['runtime.dispose', runtime?.dispose()],
+    ['rawDatabaseExportSync.stop', rawDatabaseExportSync?.stop()],
+    ['databaseUploadSync.stop', databaseUploadSync?.stop()],
+    ['logUploadSync.stop', logUploadSync?.stop()],
+  ]
+  const pendingSteps = new Set(steps.filter(([, step]) => step).map(([name]) => name))
+
+  setTimeout(() => {
+    const pending = pendingSteps.size ? [...pendingSteps].join(', ') : 'none'
+    log.error(
+      `[Shutdown] Not exited after ${SHUTDOWN_TIMEOUT_MS}ms (pending: ${pending}) — forcing exit`,
+    )
+    shutdownCompleted = true
+    app.exit(0)
+  }, SHUTDOWN_TIMEOUT_MS).unref()
+
+  void Promise.allSettled(
+    steps.map(([name, step]) => step?.finally(() => pendingSteps.delete(name))),
+  ).finally(() => {
     shutdownCompleted = true
     app.quit()
   })
@@ -169,7 +194,11 @@ app.on('will-quit', () => {
   globalShortcut.unregisterAll()
 })
 
-app.on('second-instance', () => {
+app.on('second-instance', (_event, argv) => {
+  // Background relaunches (login item, watchdog task, LaunchAgent) that lose
+  // the single-instance race pass --memorylane-hidden; only a real user launch
+  // should surface the window.
+  if (argv.includes(AUTO_START_HIDDEN_ARG)) return
   void import('./ui/main-window').then(({ openMainWindow }) => {
     openMainWindow()
   })
@@ -295,6 +324,9 @@ app.on('ready', async () => {
   deviceReportSync.start()
 
   if (editionConfig.edition === 'enterprise') {
+    // Windows counterpart of the mac LaunchAgent's KeepAlive.
+    void ensureWatchdogTask()
+
     databaseUploadSync = new DatabaseUploadSync({
       storage: runtime.storage,
       getDeviceId: () => deviceIdentity.getDeviceId(),

--- a/src/main/recorder/app-watcher-win.test.ts
+++ b/src/main/recorder/app-watcher-win.test.ts
@@ -72,6 +72,8 @@ describe('app-watcher-win backend', () => {
     const callback = vi.fn()
     mod.startAppWatcherWin(callback)
 
+    expect(vi.mocked(childProcess.spawn).mock.calls[0][1]).toContain(`--parent-pid=${process.pid}`)
+
     child.stdout.write('{"type":"ready","timestamp":1}\n')
     child.stdout.write(
       '{"type":"app_change","timestamp":2,"app":"chrome","hwnd":"0x3A0F2","pid":101,"title":"Google","url":"https://example.com"}\n',

--- a/src/main/recorder/app-watcher-win.ts
+++ b/src/main/recorder/app-watcher-win.ts
@@ -101,7 +101,9 @@ function spawnWatcher(): void {
   }
 
   log.debug(`[AppWatcher:win] Spawning: ${executable.command} ${executable.args.join(' ')}`)
-  const child = spawn(executable.command, [...executable.args], {
+  // The watcher waits on this PID and exits when we die, so an installer's
+  // hard kill of the main process can't leave it holding the install dir open.
+  const child = spawn(executable.command, [...executable.args, `--parent-pid=${process.pid}`], {
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
   })

--- a/src/main/system/auto-start.ts
+++ b/src/main/system/auto-start.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron'
 import log from '@main/utils/logger'
 
-const AUTO_START_HIDDEN_ARG = '--memorylane-hidden'
+export const AUTO_START_HIDDEN_ARG = '--memorylane-hidden'
 const WINDOWS_LOGIN_ITEM_ARGS = [AUTO_START_HIDDEN_ARG]
 
 function isSupportedPlatform(): boolean {

--- a/src/main/system/auto-start.ts
+++ b/src/main/system/auto-start.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron'
+import { getAppEditionConfig } from '@main/system/edition'
 import log from '@main/utils/logger'
 
 export const AUTO_START_HIDDEN_ARG = '--memorylane-hidden'
@@ -10,6 +11,14 @@ function isSupportedPlatform(): boolean {
 
 export function canSyncAutoStartSetting(): boolean {
   return isSupportedPlatform() && app.isPackaged
+}
+
+// Enterprise autostart on macOS is owned by the pkg-installed LaunchAgent. A
+// login item would race it at login (mac login items can't pass argv, so the
+// losing instance pops the main window) and, when it wins the race, steal the
+// app from launchd's KeepAlive supervision.
+export function launchAgentOwnsAutoStart(): boolean {
+  return process.platform === 'darwin' && getAppEditionConfig().edition === 'enterprise'
 }
 export function shouldStartHiddenOnLaunch(): boolean {
   if (process.argv.includes(AUTO_START_HIDDEN_ARG)) {
@@ -35,6 +44,13 @@ export function syncAutoStartSetting(enabled: boolean): void {
   }
 
   if (process.platform === 'darwin') {
+    // Also removes the item registered by older enterprise builds.
+    if (launchAgentOwnsAutoStart()) {
+      app.setLoginItemSettings({ openAtLogin: false, type: 'mainAppService' })
+      log.info('[AutoStart] macOS enterprise: autostart is owned by the LaunchAgent')
+      return
+    }
+
     app.setLoginItemSettings({
       openAtLogin: enabled,
       type: 'mainAppService',

--- a/src/main/system/auto-start.ts
+++ b/src/main/system/auto-start.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron'
-import { getAppEditionConfig } from '@main/system/edition'
+import { loadAppEditionConfig } from '@main/system/edition'
 import log from '@main/utils/logger'
 
 export const AUTO_START_HIDDEN_ARG = '--memorylane-hidden'
@@ -9,17 +9,21 @@ function isSupportedPlatform(): boolean {
   return process.platform === 'darwin' || process.platform === 'win32'
 }
 
-export function canSyncAutoStartSetting(): boolean {
-  return isSupportedPlatform() && app.isPackaged
-}
-
 // Enterprise autostart on macOS is owned by the pkg-installed LaunchAgent. A
 // login item would race it at login (mac login items can't pass argv, so the
 // losing instance pops the main window) and, when it wins the race, steal the
 // app from launchd's KeepAlive supervision.
-export function launchAgentOwnsAutoStart(): boolean {
-  return process.platform === 'darwin' && getAppEditionConfig().edition === 'enterprise'
+function launchAgentOwnsAutoStart(): boolean {
+  return process.platform === 'darwin' && loadAppEditionConfig().edition === 'enterprise'
 }
+
+// Mac enterprise re-syncs every startup, not just once: installs upgraded from
+// pre-LaunchAgent builds carry a stale login item that sync removes.
+export function shouldSyncAutoStartOnStartup(isInitialized: boolean): boolean {
+  if (!isSupportedPlatform() || !app.isPackaged) return false
+  return !isInitialized || launchAgentOwnsAutoStart()
+}
+
 export function shouldStartHiddenOnLaunch(): boolean {
   if (process.argv.includes(AUTO_START_HIDDEN_ARG)) {
     return true

--- a/src/main/system/edition.ts
+++ b/src/main/system/edition.ts
@@ -88,3 +88,10 @@ export function loadAppEditionConfig(): AppEditionConfig {
     return { edition: DEFAULT_EDITION }
   }
 }
+
+let cachedConfig: AppEditionConfig | null = null
+
+export function getAppEditionConfig(): AppEditionConfig {
+  cachedConfig ??= loadAppEditionConfig()
+  return cachedConfig
+}

--- a/src/main/system/edition.ts
+++ b/src/main/system/edition.ts
@@ -76,22 +76,19 @@ function resolveEditionConfig(): LoadedEditionConfig {
   }
 }
 
+let cachedConfig: AppEditionConfig | null = null
+
 export function loadAppEditionConfig(): AppEditionConfig {
+  if (cachedConfig) return cachedConfig
   try {
     const loadedConfig = resolveEditionConfig()
     log.info(
       `[Edition] Loaded ${loadedConfig.config.edition} edition from ${loadedConfig.source} config at ${loadedConfig.path}`,
     )
-    return loadedConfig.config
+    cachedConfig = loadedConfig.config
   } catch (error) {
     log.warn(`[Edition] Failed to load edition config, falling back to ${DEFAULT_EDITION}`, error)
-    return { edition: DEFAULT_EDITION }
+    cachedConfig = { edition: DEFAULT_EDITION }
   }
-}
-
-let cachedConfig: AppEditionConfig | null = null
-
-export function getAppEditionConfig(): AppEditionConfig {
-  cachedConfig ??= loadAppEditionConfig()
   return cachedConfig
 }

--- a/src/main/system/updater.ts
+++ b/src/main/system/updater.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import log from '@main/utils/logger'
 import { confirmWindowsUpdateInstall } from './windows-update-install'
+import { disableWatchdogTask } from './watchdog-win'
 import type { UpdateInfo, UpdateState } from '@/shared/types'
 
 let state: UpdateState = 'idle'
@@ -23,6 +24,10 @@ export const quitAndInstall = async (): Promise<void> => {
   if (!(await confirmWindowsUpdateInstall(process.execPath))) {
     return
   }
+
+  // The relaunch task must not fire mid-install and hold the install dir open;
+  // the updated app re-registers it on startup.
+  await disableWatchdogTask()
 
   log.info('[Updater] Requesting quit-and-install')
   // isForceRunAfter=true is required for tray apps that have no main window,

--- a/src/main/system/watchdog-win.test.ts
+++ b/src/main/system/watchdog-win.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { buildCreateTaskArgs, buildDisableTaskArgs } from './watchdog-win'
+
+describe('watchdog-win schtasks arguments', () => {
+  it('creates a repeating task that relaunches the app hidden', () => {
+    const args = buildCreateTaskArgs(
+      'C:\\Program Files\\MemoryLane Enterprise\\MemoryLane Enterprise.exe',
+    )
+
+    expect(args).toEqual([
+      '/Create',
+      '/F',
+      '/TN',
+      'MemoryLane Enterprise Watchdog',
+      '/SC',
+      'MINUTE',
+      '/MO',
+      '5',
+      '/TR',
+      '"C:\\Program Files\\MemoryLane Enterprise\\MemoryLane Enterprise.exe" --memorylane-hidden',
+    ])
+  })
+
+  it('disables the same task by name', () => {
+    expect(buildDisableTaskArgs()).toEqual([
+      '/Change',
+      '/TN',
+      'MemoryLane Enterprise Watchdog',
+      '/DISABLE',
+    ])
+  })
+})

--- a/src/main/system/watchdog-win.test.ts
+++ b/src/main/system/watchdog-win.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildCreateTaskArgs, buildDisableTaskArgs } from './watchdog-win'
+import { buildCreateTaskArgs } from './watchdog-win'
 
 describe('watchdog-win schtasks arguments', () => {
   it('creates a repeating task that relaunches the app hidden via the script', () => {
@@ -18,16 +18,7 @@ describe('watchdog-win schtasks arguments', () => {
       '/MO',
       '5',
       '/TR',
-      'wscript.exe //B "C:\\Program Files\\MemoryLane Enterprise\\resources\\assets\\watchdog-relaunch.vbs" "C:\\Program Files\\MemoryLane Enterprise\\MemoryLane Enterprise.exe" --memorylane-hidden',
-    ])
-  })
-
-  it('disables the same task by name', () => {
-    expect(buildDisableTaskArgs()).toEqual([
-      '/Change',
-      '/TN',
-      'MemoryLane Enterprise Watchdog',
-      '/DISABLE',
+      'wscript.exe //B "C:\\Program Files\\MemoryLane Enterprise\\resources\\assets\\watchdog-relaunch.vbs" "C:\\Program Files\\MemoryLane Enterprise\\MemoryLane Enterprise.exe" --memorylane-hidden "MemoryLane Enterprise Watchdog"',
     ])
   })
 })

--- a/src/main/system/watchdog-win.test.ts
+++ b/src/main/system/watchdog-win.test.ts
@@ -17,7 +17,7 @@ describe('watchdog-win schtasks arguments', () => {
       '/MO',
       '5',
       '/TR',
-      '"C:\\Program Files\\MemoryLane Enterprise\\MemoryLane Enterprise.exe" --memorylane-hidden',
+      'cmd.exe /c start "" "C:\\Program Files\\MemoryLane Enterprise\\MemoryLane Enterprise.exe" --memorylane-hidden',
     ])
   })
 

--- a/src/main/system/watchdog-win.test.ts
+++ b/src/main/system/watchdog-win.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'vitest'
 import { buildCreateTaskArgs, buildDisableTaskArgs } from './watchdog-win'
 
 describe('watchdog-win schtasks arguments', () => {
-  it('creates a repeating task that relaunches the app hidden', () => {
+  it('creates a repeating task that relaunches the app hidden via the script', () => {
     const args = buildCreateTaskArgs(
+      'C:\\Program Files\\MemoryLane Enterprise\\resources\\assets\\watchdog-relaunch.vbs',
       'C:\\Program Files\\MemoryLane Enterprise\\MemoryLane Enterprise.exe',
     )
 
@@ -17,7 +18,7 @@ describe('watchdog-win schtasks arguments', () => {
       '/MO',
       '5',
       '/TR',
-      'cmd.exe /c start "" "C:\\Program Files\\MemoryLane Enterprise\\MemoryLane Enterprise.exe" --memorylane-hidden',
+      'wscript.exe //B "C:\\Program Files\\MemoryLane Enterprise\\resources\\assets\\watchdog-relaunch.vbs" "C:\\Program Files\\MemoryLane Enterprise\\MemoryLane Enterprise.exe" --memorylane-hidden',
     ])
   })
 

--- a/src/main/system/watchdog-win.ts
+++ b/src/main/system/watchdog-win.ts
@@ -11,7 +11,9 @@ const execFileAsync = promisify(execFile)
 // scheduled task relaunches it within minutes instead. When the app is already
 // running the relaunch loses the single-instance lock and exits immediately.
 // An explicit tray Quit disables the task so the user's choice holds until the
-// next launch (the login item re-registers it).
+// next launch (the login item re-registers it). Registration deliberately
+// ignores the auto-start setting: that setting governs login behavior, while
+// enterprise devices must recover from mid-session kills regardless.
 const TASK_NAME = 'MemoryLane Enterprise Watchdog'
 const RELAUNCH_INTERVAL_MINUTES = 5
 const SCHTASKS_TIMEOUT_MS = 5_000

--- a/src/main/system/watchdog-win.ts
+++ b/src/main/system/watchdog-win.ts
@@ -1,0 +1,72 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { AUTO_START_HIDDEN_ARG } from '@main/system/auto-start'
+import { isPackagedElectronExecutable } from '@main/utils/paths'
+import log from '@main/utils/logger'
+
+const execFileAsync = promisify(execFile)
+
+// The HKCU Run autostart only fires at login, so an external kill mid-session
+// (RMM/AV/MDM) leaves the app dead until the user next logs in. This per-user
+// scheduled task relaunches it within minutes instead. When the app is already
+// running the relaunch loses the single-instance lock and exits immediately.
+// An explicit tray Quit disables the task so the user's choice holds until the
+// next launch (the login item re-registers it).
+const TASK_NAME = 'MemoryLane Enterprise Watchdog'
+const RELAUNCH_INTERVAL_MINUTES = 5
+const SCHTASKS_TIMEOUT_MS = 5_000
+
+let registered = false
+
+export function buildCreateTaskArgs(executablePath: string): string[] {
+  return [
+    '/Create',
+    '/F',
+    '/TN',
+    TASK_NAME,
+    '/SC',
+    'MINUTE',
+    '/MO',
+    String(RELAUNCH_INTERVAL_MINUTES),
+    '/TR',
+    `"${executablePath}" ${AUTO_START_HIDDEN_ARG}`,
+  ]
+}
+
+export function buildDisableTaskArgs(): string[] {
+  return ['/Change', '/TN', TASK_NAME, '/DISABLE']
+}
+
+async function runSchtasks(args: string[]): Promise<void> {
+  await execFileAsync('schtasks.exe', args, {
+    windowsHide: true,
+    timeout: SCHTASKS_TIMEOUT_MS,
+  })
+}
+
+export async function ensureWatchdogTask(): Promise<void> {
+  if (process.platform !== 'win32' || !isPackagedElectronExecutable(process.execPath)) {
+    return
+  }
+
+  try {
+    await runSchtasks(buildCreateTaskArgs(process.execPath))
+    registered = true
+    log.info(`[Watchdog] Relaunch task registered (every ${RELAUNCH_INTERVAL_MINUTES} min)`)
+  } catch (error) {
+    log.warn('[Watchdog] Failed to register relaunch task:', error)
+  }
+}
+
+export async function disableWatchdogTask(): Promise<void> {
+  if (!registered) {
+    return
+  }
+
+  try {
+    await runSchtasks(buildDisableTaskArgs())
+    log.info('[Watchdog] Relaunch task disabled after explicit quit')
+  } catch (error) {
+    log.warn('[Watchdog] Failed to disable relaunch task:', error)
+  }
+}

--- a/src/main/system/watchdog-win.ts
+++ b/src/main/system/watchdog-win.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import path from 'node:path'
 import { promisify } from 'node:util'
 import { AUTO_START_HIDDEN_ARG } from '@main/system/auto-start'
 import { isPackagedElectronExecutable } from '@main/utils/paths'
@@ -14,13 +15,18 @@ const execFileAsync = promisify(execFile)
 // next launch (the login item re-registers it). Registration deliberately
 // ignores the auto-start setting: that setting governs login behavior, while
 // enterprise devices must recover from mid-session kills regardless.
-const TASK_NAME = 'MemoryLane Enterprise Watchdog'
+//
+// MDM removal scripts should run
+//   schtasks /Delete /F /TN "MemoryLane Enterprise Watchdog"
+// — an enabled task deletes itself once the exe is gone, but a task disabled
+// by tray Quit never runs again and would otherwise linger after uninstall.
+const TASK_NAME = 'MemoryLane Enterprise Watchdog' // duplicated in assets/watchdog-relaunch.vbs
 const RELAUNCH_INTERVAL_MINUTES = 5
 const SCHTASKS_TIMEOUT_MS = 5_000
 
 let taskExpected = false
 
-export function buildCreateTaskArgs(executablePath: string): string[] {
+export function buildCreateTaskArgs(scriptPath: string, executablePath: string): string[] {
   return [
     '/Create',
     '/F',
@@ -30,11 +36,13 @@ export function buildCreateTaskArgs(executablePath: string): string[] {
     'MINUTE',
     '/MO',
     String(RELAUNCH_INTERVAL_MINUTES),
-    // Launch detached via `start` so the task exits immediately instead of
-    // owning the app process — Task Scheduler force-stops task processes at
-    // its default 72h execution limit.
+    // The task runs the VBS relaunch script rather than the exe directly: the
+    // script launches detached so the task exits immediately (Task Scheduler
+    // force-stops task processes at its default 72h execution limit), skips
+    // the relaunch while msiexec is active, and deletes the task after an
+    // uninstall. wscript //B keeps the 5-min cadence from flashing a window.
     '/TR',
-    `cmd.exe /c start "" "${executablePath}" ${AUTO_START_HIDDEN_ARG}`,
+    `wscript.exe //B "${scriptPath}" "${executablePath}" ${AUTO_START_HIDDEN_ARG}`,
   ]
 }
 
@@ -59,7 +67,8 @@ export async function ensureWatchdogTask(): Promise<void> {
   taskExpected = true
 
   try {
-    await runSchtasks(buildCreateTaskArgs(process.execPath))
+    const scriptPath = path.join(process.resourcesPath, 'assets', 'watchdog-relaunch.vbs')
+    await runSchtasks(buildCreateTaskArgs(scriptPath, process.execPath))
     log.info(`[Watchdog] Relaunch task registered (every ${RELAUNCH_INTERVAL_MINUTES} min)`)
   } catch (error) {
     log.warn('[Watchdog] Failed to register relaunch task:', error)

--- a/src/main/system/watchdog-win.ts
+++ b/src/main/system/watchdog-win.ts
@@ -16,7 +16,7 @@ const TASK_NAME = 'MemoryLane Enterprise Watchdog'
 const RELAUNCH_INTERVAL_MINUTES = 5
 const SCHTASKS_TIMEOUT_MS = 5_000
 
-let registered = false
+let taskExpected = false
 
 export function buildCreateTaskArgs(executablePath: string): string[] {
   return [
@@ -28,8 +28,11 @@ export function buildCreateTaskArgs(executablePath: string): string[] {
     'MINUTE',
     '/MO',
     String(RELAUNCH_INTERVAL_MINUTES),
+    // Launch detached via `start` so the task exits immediately instead of
+    // owning the app process — Task Scheduler force-stops task processes at
+    // its default 72h execution limit.
     '/TR',
-    `"${executablePath}" ${AUTO_START_HIDDEN_ARG}`,
+    `cmd.exe /c start "" "${executablePath}" ${AUTO_START_HIDDEN_ARG}`,
   ]
 }
 
@@ -49,9 +52,12 @@ export async function ensureWatchdogTask(): Promise<void> {
     return
   }
 
+  // Set before the attempt: a task from a previous session may exist even if
+  // this registration fails, and quit must still disable it.
+  taskExpected = true
+
   try {
     await runSchtasks(buildCreateTaskArgs(process.execPath))
-    registered = true
     log.info(`[Watchdog] Relaunch task registered (every ${RELAUNCH_INTERVAL_MINUTES} min)`)
   } catch (error) {
     log.warn('[Watchdog] Failed to register relaunch task:', error)
@@ -59,13 +65,13 @@ export async function ensureWatchdogTask(): Promise<void> {
 }
 
 export async function disableWatchdogTask(): Promise<void> {
-  if (!registered) {
+  if (!taskExpected) {
     return
   }
 
   try {
     await runSchtasks(buildDisableTaskArgs())
-    log.info('[Watchdog] Relaunch task disabled after explicit quit')
+    log.info('[Watchdog] Relaunch task disabled')
   } catch (error) {
     log.warn('[Watchdog] Failed to disable relaunch task:', error)
   }

--- a/src/main/system/watchdog-win.ts
+++ b/src/main/system/watchdog-win.ts
@@ -1,30 +1,34 @@
 import { execFile } from 'node:child_process'
 import path from 'node:path'
 import { promisify } from 'node:util'
+import { app } from 'electron'
 import { AUTO_START_HIDDEN_ARG } from '@main/system/auto-start'
-import { isPackagedElectronExecutable } from '@main/utils/paths'
+import { loadAppEditionConfig } from '@main/system/edition'
 import log from '@main/utils/logger'
 
 const execFileAsync = promisify(execFile)
 
 // The HKCU Run autostart only fires at login, so an external kill mid-session
 // (RMM/AV/MDM) leaves the app dead until the user next logs in. This per-user
-// scheduled task relaunches it within minutes instead. When the app is already
-// running the relaunch loses the single-instance lock and exits immediately.
-// An explicit tray Quit disables the task so the user's choice holds until the
-// next launch (the login item re-registers it). Registration deliberately
-// ignores the auto-start setting: that setting governs login behavior, while
-// enterprise devices must recover from mid-session kills regardless.
+// scheduled task relaunches it within minutes instead. An explicit tray Quit
+// disables the task so the user's choice holds until the next launch (the
+// login item re-registers it). Registration deliberately ignores the
+// auto-start setting: that setting governs login behavior, while enterprise
+// devices must recover from mid-session kills regardless.
 //
-// MDM removal scripts should run
-//   schtasks /Delete /F /TN "MemoryLane Enterprise Watchdog"
-// — an enabled task deletes itself once the exe is gone, but a task disabled
-// by tray Quit never runs again and would otherwise linger after uninstall.
-const TASK_NAME = 'MemoryLane Enterprise Watchdog' // duplicated in assets/watchdog-relaunch.vbs
+// MDM removal scripts should `schtasks /Delete /F /TN "<TASK_NAME>"` — a task
+// disabled by tray Quit never runs again and would linger after uninstall.
+const TASK_NAME = 'MemoryLane Enterprise Watchdog'
 const RELAUNCH_INTERVAL_MINUTES = 5
 const SCHTASKS_TIMEOUT_MS = 5_000
 
-let taskExpected = false
+function watchdogSupported(): boolean {
+  return (
+    process.platform === 'win32' &&
+    app.isPackaged &&
+    loadAppEditionConfig().edition === 'enterprise'
+  )
+}
 
 export function buildCreateTaskArgs(scriptPath: string, executablePath: string): string[] {
   return [
@@ -36,18 +40,11 @@ export function buildCreateTaskArgs(scriptPath: string, executablePath: string):
     'MINUTE',
     '/MO',
     String(RELAUNCH_INTERVAL_MINUTES),
-    // The task runs the VBS relaunch script rather than the exe directly: the
-    // script launches detached so the task exits immediately (Task Scheduler
-    // force-stops task processes at its default 72h execution limit), skips
-    // the relaunch while msiexec is active, and deletes the task after an
-    // uninstall. wscript //B keeps the 5-min cadence from flashing a window.
+    // Runs the VBS script rather than the exe directly — see
+    // assets/watchdog-relaunch.vbs for why.
     '/TR',
-    `wscript.exe //B "${scriptPath}" "${executablePath}" ${AUTO_START_HIDDEN_ARG}`,
+    `wscript.exe //B "${scriptPath}" "${executablePath}" ${AUTO_START_HIDDEN_ARG} "${TASK_NAME}"`,
   ]
-}
-
-export function buildDisableTaskArgs(): string[] {
-  return ['/Change', '/TN', TASK_NAME, '/DISABLE']
 }
 
 async function runSchtasks(args: string[]): Promise<void> {
@@ -58,13 +55,9 @@ async function runSchtasks(args: string[]): Promise<void> {
 }
 
 export async function ensureWatchdogTask(): Promise<void> {
-  if (process.platform !== 'win32' || !isPackagedElectronExecutable(process.execPath)) {
+  if (!watchdogSupported()) {
     return
   }
-
-  // Set before the attempt: a task from a previous session may exist even if
-  // this registration fails, and quit must still disable it.
-  taskExpected = true
 
   try {
     const scriptPath = path.join(process.resourcesPath, 'assets', 'watchdog-relaunch.vbs')
@@ -76,12 +69,12 @@ export async function ensureWatchdogTask(): Promise<void> {
 }
 
 export async function disableWatchdogTask(): Promise<void> {
-  if (!taskExpected) {
+  if (!watchdogSupported()) {
     return
   }
 
   try {
-    await runSchtasks(buildDisableTaskArgs())
+    await runSchtasks(['/Change', '/TN', TASK_NAME, '/DISABLE'])
     log.info('[Watchdog] Relaunch task disabled')
   } catch (error) {
     log.warn('[Watchdog] Failed to disable relaunch task:', error)

--- a/src/main/ui/tray.ts
+++ b/src/main/ui/tray.ts
@@ -9,6 +9,7 @@ import { formatBytes, formatNumber } from '../utils/formatters'
 import type { StorageService } from '../storage'
 import { openMainWindow } from './main-window'
 import { getUpdateState, quitAndInstall } from '@main/system/updater'
+import { disableWatchdogTask } from '@main/system/watchdog-win'
 import { createTrayPrivacyState } from './tray-privacy-state'
 import { CAPTURE_PAUSE_CONFIG, formatPauseDuration } from '../../shared/constants'
 
@@ -65,14 +66,6 @@ app.on('before-quit', () => {
     tray.destroy()
     tray = null
   }
-
-  // Safety net: force-exit if graceful shutdown takes too long.
-  // In-flight async work (OCR subprocesses, embedding inference, API calls)
-  // can keep the event loop alive indefinitely after app.quit().
-  setTimeout(() => {
-    log.warn('[Quit] Graceful shutdown timed out — force exiting')
-    app.exit(0)
-  }, 3000).unref()
 })
 
 /**
@@ -241,7 +234,8 @@ export const updateTrayMenu = async (): Promise<void> => {
       click: () => {
         void deps!.capture.forceClose()
         deps!.capture.stopCaptureForShutdown()
-        app.quit()
+        // Explicit quit must hold: stop the relaunch task before quitting.
+        void disableWatchdogTask().finally(() => app.quit())
       },
     },
   ])

--- a/src/renderer/pages/main-window/components/advanced-settings/CapturePrivacySection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/CapturePrivacySection.tsx
@@ -10,6 +10,7 @@ import { SettingsSection } from './SettingsSection'
 interface CapturePrivacySectionProps {
   form: CaptureSettings
   hotkeyPlatform: HotkeyPlatform
+  showAutoStart: boolean
   onToggleRecordingHotkey: () => void
   onAutoStartEnabledChange: (enabled: boolean) => void
   onExcludePrivateBrowsingChange: (enabled: boolean) => void
@@ -20,6 +21,7 @@ interface CapturePrivacySectionProps {
 export function CapturePrivacySection({
   form,
   hotkeyPlatform,
+  showAutoStart,
   onToggleRecordingHotkey,
   onAutoStartEnabledChange,
   onExcludePrivateBrowsingChange,
@@ -65,17 +67,19 @@ export function CapturePrivacySection({
           }
         />
 
-        <SettingsRow
-          label="Launch at login"
-          description="Start MemoryLane quietly when your Mac boots."
-          control={
-            <Switch
-              checked={form.autoStartEnabled}
-              onCheckedChange={onAutoStartEnabledChange}
-              aria-label="Launch at login"
-            />
-          }
-        />
+        {showAutoStart && (
+          <SettingsRow
+            label="Launch at login"
+            description="Start MemoryLane quietly when your Mac boots."
+            control={
+              <Switch
+                checked={form.autoStartEnabled}
+                onCheckedChange={onAutoStartEnabledChange}
+                aria-label="Launch at login"
+              />
+            }
+          />
+        )}
       </SettingsSection>
 
       <SettingsSection title="Shortcut" icon={<Keyboard className="h-4 w-4" />}>

--- a/src/renderer/pages/main-window/components/claude-prompts.ts
+++ b/src/renderer/pages/main-window/components/claude-prompts.ts
@@ -89,8 +89,9 @@ export function buildClusterAnalyzePrompt(
   return lines.filter((l) => l !== null).join('\n')
 }
 
-/** Tool-agnostic prompt built from the stored, de-identified recipe;
- * scrubPII runs over the final string as a last-mile net. */
+/** Tool-agnostic prompt; scrubPII runs over the final string. For labeled
+ * clusters that backstops the recipe's LLM de-identification; for fallback
+ * member steps it is the only scrub, and it does not catch names. */
 export function buildClusterAgentPrompt(cluster: ClusterInfo): string {
   const lines: string[] = [
     `Build an AI agent that automates this task.`,

--- a/src/renderer/pages/main-window/components/claude-prompts.ts
+++ b/src/renderer/pages/main-window/components/claude-prompts.ts
@@ -121,4 +121,3 @@ export function buildClusterAgentPrompt(cluster: ClusterInfo): string {
   )
   return scrubPII(lines.join('\n'))
 }
-

--- a/src/renderer/pages/main-window/pages/SettingsPage.tsx
+++ b/src/renderer/pages/main-window/pages/SettingsPage.tsx
@@ -289,6 +289,9 @@ export function SettingsPage({
             <CapturePrivacySection
               form={form}
               hotkeyPlatform={hotkeyPlatform}
+              // Enterprise autostart is externally managed (mac LaunchAgent /
+              // Windows watchdog task); the toggle would be a silent no-op.
+              showAutoStart={editionConfig?.edition !== 'enterprise'}
               onToggleRecordingHotkey={() => setRecordingHotkey((current) => !current)}
               onAutoStartEnabledChange={setAutoStartEnabled}
               onExcludePrivateBrowsingChange={commitExcludePrivateBrowsing}

--- a/src/renderer/pages/main-window/pages/SettingsPage.tsx
+++ b/src/renderer/pages/main-window/pages/SettingsPage.tsx
@@ -289,8 +289,7 @@ export function SettingsPage({
             <CapturePrivacySection
               form={form}
               hotkeyPlatform={hotkeyPlatform}
-              // Enterprise autostart is externally managed (mac LaunchAgent /
-              // Windows watchdog task); the toggle would be a silent no-op.
+              // Enterprise autostart is installer-managed, not user-togglable.
               showAutoStart={editionConfig?.edition !== 'enterprise'}
               onToggleRecordingHotkey={() => setRecordingHotkey((current) => !current)}
               onAutoStartEnabledChange={setAutoStartEnabled}


### PR DESCRIPTION
## Why

Tenant 10 incident: the client's RMM silently reinstalled the app fleet-wide while it was running — 5 of 13 devices were killed mid-run on Jul 17–18 and never came back. Two platform gaps, one theme: a silent install must not strand the app.

## Windows (root cause of the outage)

RestartManager killed the Electron process, but `app-watcher-windows.exe` isn't registered with it, survived, and kept a handle inside the install directory — MSI deferred file replacement to reboot (3010), leaving a half-applied install that never launched again (the known gap documented in `src/main/index.ts`'s before-quit comment).

- `app-watcher-win.ts` passes `--parent-pid=<pid>` at spawn.
- New `parent_watch.rs`: waits on the parent process handle (`OpenProcess`/`WaitForSingleObject`) and exits the moment the parent dies, however it dies. No arg → no watchdog (dev override unchanged).

With clean installs, the surviving HKCU Run autostart brings the app back at the next login. The screenshot daemon already exits on stdin EOF and needs no change.

## macOS (same gaps, preempted)

The enterprise pkg swapped the bundle under a live process and autostart existed only as the runtime-written login item. Adds `assets/pkg-scripts/` (picked up automatically by the pkg target, enterprise-only):

- **preinstall** — boots out any previous launcher agent, quits the app via SIGTERM, escalates to SIGKILL after 10s.
- **postinstall** — installs `/Library/LaunchAgents/com.memorylane.enterprise.launcher.plist` (`RunAtLoad`; `KeepAlive {SuccessfulExit: false}` so kills/crashes relaunch but a clean tray Quit is respected) and bootstraps it into the console user's session — app is back seconds after install.
- Passes `--memorylane-hidden`; coexists with the existing login item via the single-instance lock.

## Verification

- `npm run typecheck` clean; `app-watcher-win.test.ts` 5/5.
- Rust: `rustfmt --check` parses clean; API usage verified against the `windows` 0.62.2 crate source. No cross-compile toolchain locally and Rust only compiles in the release workflow — worth a careful look at `parent_watch.rs`.
- pkg scripts: `sh -n` + `plutil -lint` clean; `pkgbuild --scripts` run as electron-builder does — both scripts embed with exec bits.
- Still pending before release: Windows VM behavior test (kill parent → watcher exits; MSI over running app) and an end-to-end pkg install test.

## Note for MDM removal scripts (mac)

Uninstall should `launchctl bootout gui/<uid>/com.memorylane.enterprise.launcher`, delete the plist, then remove the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Always-running follow-through (second commit)

The above closed the installer gaps but still left Windows without any mid-session recovery, and a hung graceful quit could strand a half-shut-down process. Three additions:

- **Windows relaunch watchdog (enterprise only)** — `watchdog-win.ts` registers a per-user scheduled task (`schtasks`, every 5 min) that launches the app with `--memorylane-hidden`. While the app runs, the relaunch loses the single-instance lock and exits immediately. Explicit tray Quit disables the task, so a user quit holds until the next login (where autostart + re-registration resume). This is the Windows counterpart of the mac LaunchAgent's `KeepAlive`.
- **Bounded shutdown** — the `before-quit` dispose barrier now has a 5s force-exit watchdog (replaces the tray's 3s net) that logs which dispose steps were still pending, so a wedged shutdown can't produce the "not quit, not running" state and the next incident's log bundle names the culprit. 5s stays ahead of the mac preinstall's 10s SIGKILL.
- **`second-instance` ignores hidden launches** — background relaunches (watchdog task, login item, LaunchAgent) no longer pop the main window when they lose the instance race.

Verification: typecheck clean; `watchdog-win.test.ts` (schtasks args) and `app-watcher-win.test.ts` (now also asserts `--parent-pid` is passed) green. Still pending on a Windows VM: task registration/relaunch behavior and quit-disable.
