### PR TITLE
Exit app-watcher when the Electron main process dies

### DIFF
--- a/native/windows/app-watcher/README.md
+++ b/native/windows/app-watcher/README.md
@@ -38,6 +38,11 @@ Optional override in development:
 
 - `MEMORYLANE_APP_WATCHER_WIN_EXECUTABLE=<absolute path to exe>`
 
+## Arguments
+
+- `--parent-pid=<pid>` (optional): exit when this process dies. Passed by the
+  Electron main process so the watcher never outlives it.
+
 ## Test
 
 From repo root:

--- a/native/windows/app-watcher/src/main.rs
+++ b/native/windows/app-watcher/src/main.rs
@@ -1,6 +1,7 @@
 mod browser_url;
 mod hooks;
 mod output;
+mod parent_watch;
 mod snapshot;
 mod state;
 mod time;
@@ -18,6 +19,8 @@ use crate::time::now_ms;
 use crate::win32_window::hwnd_is_valid;
 
 fn main() {
+    parent_watch::spawn_parent_watchdog();
+
     let com_init_result = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
     let com_needs_uninit = com_init_result.is_ok();
     let _com_available = com_needs_uninit || com_init_result == RPC_E_CHANGED_MODE;

--- a/native/windows/app-watcher/src/parent_watch.rs
+++ b/native/windows/app-watcher/src/parent_watch.rs
@@ -1,0 +1,28 @@
+use windows::Win32::System::Threading::{
+    OpenProcess, WaitForSingleObject, INFINITE, PROCESS_SYNCHRONIZE,
+};
+
+const PARENT_PID_ARG: &str = "--parent-pid=";
+
+/// Exit when the parent process dies. Installers terminate the Electron main
+/// process without warning; a surviving watcher keeps a handle inside the
+/// install directory and forces MSI to defer file replacement to a reboot.
+pub fn spawn_parent_watchdog() {
+    let Some(pid) = std::env::args().find_map(|arg| {
+        arg.strip_prefix(PARENT_PID_ARG)
+            .and_then(|v| v.parse::<u32>().ok())
+    }) else {
+        return;
+    };
+
+    std::thread::spawn(move || {
+        let parent = match unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, pid) } {
+            Ok(handle) => handle,
+            Err(_) => std::process::exit(0),
+        };
+        unsafe {
+            let _ = WaitForSingleObject(parent, INFINITE);
+        }
+        std::process::exit(0);
+    });
+}

--- a/src/main/recorder/app-watcher-win.ts
+++ b/src/main/recorder/app-watcher-win.ts
@@ -101,7 +101,9 @@ function spawnWatcher(): void {
   }
 
   log.debug(`[AppWatcher:win] Spawning: ${executable.command} ${executable.args.join(' ')}`)
-  const child = spawn(executable.command, [...executable.args], {
+  // The watcher waits on this PID and exits when we die, so an installer's
+  // hard kill of the main process can't leave it holding the install dir open.
+  const child = spawn(executable.command, [...executable.args, `--parent-pid=${process.pid}`], {
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
   })


### PR DESCRIPTION
## Why

Root cause of the tenant 10 outage (5 devices dark since Jul 17): the client's RMM silently installed the MSI while the app was running. RestartManager killed the Electron process, but `app-watcher-windows.exe` isn't registered with it, survived, and kept a handle inside the install directory — MSI deferred file replacement to reboot (3010), leaving a half-applied install that never launched again (already documented as a known gap in `src/main/index.ts`'s before-quit comment).

## What

- `app-watcher-win.ts` passes `--parent-pid=<pid>` at spawn.
- New `parent_watch.rs`: a thread opens the parent process handle (`OpenProcess`/`WaitForSingleObject`) and exits the watcher the moment the parent dies — regardless of how it dies. No arg → no watchdog (dev override / direct runs unchanged).

With this, an RMM push kills the app, the watcher follows instantly, the MSI completes cleanly, and the existing HKCU Run autostart brings the app back at the next login.

The Windows screenshot daemon already exits on stdin EOF, so it needs no change.

## Verification

- `npm run typecheck` clean; `app-watcher-win.test.ts` passes (5/5).
- Rust: `rustfmt --check` parses clean; API usage verified against the vendored `windows` 0.62.2 source (`OpenProcess(PROCESS_ACCESS_RIGHTS, bool, u32) -> Result<HANDLE>`, `WaitForSingleObject(HANDLE, u32)`; both in the already-enabled `Win32_System_Threading` feature). No cross-compile toolchain on this machine — the release workflow is the compile gate, so worth a careful look at `parent_watch.rs`.
- Behavior test (kill main process, watch the watcher exit, then MSI-over-running-app) still needs a Windows VM before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)