### PR TITLE
fix: run MSI custom actions through WixQuietExec64 — no console windows

### DIFF
--- a/assets/msi-launch-task.ps1
+++ b/assets/msi-launch-task.ps1
@@ -1,4 +1,4 @@
-# Run by the MSI as SYSTEM (see patches/app-builder-lib+*.patch) to start the
+# Run by the MSI as SYSTEM (see build/msi-custom-actions.js) to start the
 # app after an install/upgrade/repair. A SYSTEM custom action cannot spawn into
 # the logged-on user's interactive session directly, so it registers a
 # trigger-less scheduled task under the Users group and starts it once. The

--- a/build/msi-custom-actions.js
+++ b/build/msi-custom-actions.js
@@ -23,18 +23,35 @@ const fs = require('fs')
 // action cannot spawn into the user session directly. The task never fires on
 // its own; rollback and uninstall delete it so no orphan is left behind.
 //
-// Directory-type actions with [System64Folder]-qualified executables: the
-// ExeCommand is formatted (a static Property value is not), and the Installer
-// service must not depend on PATH.
+// All actions run through WixQuietExec64 (WixUtilExtension, linked via
+// additionalWixArgs) instead of ExeCommand: a plain EXE custom action pops a
+// visible console window for every console binary, so an interactive
+// install/reinstall flashed one terminal per action. QuietExec captures the
+// output into the MSI log instead. Each action reads its command line from a
+// property — WixQuietExec64CmdLine for the immediate kill, the action's own
+// name (CustomActionData) for the deferred/rollback ones — set by a type-51
+// action sequenced just before it, which also formats [APPLICATIONFOLDER] and
+// [System64Folder] (the Installer service must not depend on PATH).
 function buildCustomActionsXml(productName) {
+  const killCmd = `"[System64Folder]WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$d = \\"[APPLICATIONFOLDER] \\".TrimEnd(); if ($d.Length -gt 3) { Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Path -and $_.Path.StartsWith($d, &apos;OrdinalIgnoreCase&apos;) } | Stop-Process -Force -ErrorAction SilentlyContinue }"`
+  const registerCmd = `"[System64Folder]WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "[APPLICATIONFOLDER]resources\\assets\\msi-launch-task.ps1" -ProductName "${productName}"`
+  const deleteCmd = `"[System64Folder]schtasks.exe" /Delete /F /TN "${productName} Launcher"`
   return [
-    `    <CustomAction Id="killAppProcesses" Directory="TARGETDIR" ExeCommand='"[System64Folder]WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$d = \\"[APPLICATIONFOLDER] \\".TrimEnd(); if ($d.Length -gt 3) { Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Path -and $_.Path.StartsWith($d, &apos;OrdinalIgnoreCase&apos;) } | Stop-Process -Force -ErrorAction SilentlyContinue }"' Execute="immediate" Return="ignore"/>`,
-    `    <CustomAction Id="registerLaunchTask" Directory="TARGETDIR" ExeCommand='"[System64Folder]WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "[APPLICATIONFOLDER]resources\\assets\\msi-launch-task.ps1" -ProductName "${productName}"' Execute="deferred" Impersonate="no" Return="ignore"/>`,
-    `    <CustomAction Id="rollbackLaunchTask" Directory="TARGETDIR" ExeCommand='"[System64Folder]schtasks.exe" /Delete /F /TN "${productName} Launcher"' Execute="rollback" Impersonate="no" Return="ignore"/>`,
-    `    <CustomAction Id="deleteLaunchTask" Directory="TARGETDIR" ExeCommand='"[System64Folder]schtasks.exe" /Delete /F /TN "${productName} Launcher"' Execute="deferred" Impersonate="no" Return="ignore"/>`,
+    `    <CustomAction Id="setKillAppProcesses" Property="WixQuietExec64CmdLine" Value='${killCmd}'/>`,
+    `    <CustomAction Id="killAppProcesses" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="immediate" Return="ignore"/>`,
+    `    <CustomAction Id="setRegisterLaunchTask" Property="registerLaunchTask" Value='${registerCmd}'/>`,
+    `    <CustomAction Id="registerLaunchTask" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore"/>`,
+    `    <CustomAction Id="setRollbackLaunchTask" Property="rollbackLaunchTask" Value='${deleteCmd}'/>`,
+    `    <CustomAction Id="rollbackLaunchTask" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="rollback" Impersonate="no" Return="ignore"/>`,
+    `    <CustomAction Id="setDeleteLaunchTask" Property="deleteLaunchTask" Value='${deleteCmd}'/>`,
+    `    <CustomAction Id="deleteLaunchTask" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore"/>`,
     '    <InstallExecuteSequence>',
+    '      <Custom Action="setKillAppProcesses" Before="killAppProcesses">1</Custom>',
     '      <Custom Action="killAppProcesses" Before="InstallValidate">1</Custom>',
-    '      <Custom Action="deleteLaunchTask" After="InstallInitialize">REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>',
+    '      <Custom Action="setDeleteLaunchTask" After="InstallInitialize">REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>',
+    '      <Custom Action="deleteLaunchTask" After="setDeleteLaunchTask">REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>',
+    '      <Custom Action="setRegisterLaunchTask" Before="setRollbackLaunchTask">NOT (REMOVE~="ALL")</Custom>',
+    '      <Custom Action="setRollbackLaunchTask" Before="rollbackLaunchTask">NOT (REMOVE~="ALL")</Custom>',
     '      <Custom Action="rollbackLaunchTask" Before="registerLaunchTask">NOT (REMOVE~="ALL")</Custom>',
     '      <Custom Action="registerLaunchTask" Before="InstallFinalize">NOT (REMOVE~="ALL")</Custom>',
     '    </InstallExecuteSequence>',

--- a/build/msi-custom-actions.js
+++ b/build/msi-custom-actions.js
@@ -36,6 +36,10 @@ function buildCustomActionsXml(productName) {
   const killCmd = `"[System64Folder]WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$d = \\"[APPLICATIONFOLDER] \\".TrimEnd(); if ($d.Length -gt 3) { Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Path -and $_.Path.StartsWith($d, &apos;OrdinalIgnoreCase&apos;) } | Stop-Process -Force -ErrorAction SilentlyContinue }"`
   const registerCmd = `"[System64Folder]WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "[APPLICATIONFOLDER]resources\\assets\\msi-launch-task.ps1" -ProductName "${productName}"`
   const deleteCmd = `"[System64Folder]schtasks.exe" /Delete /F /TN "${productName} Launcher"`
+  // A setter must share its action's condition — if they drift, the action
+  // runs with an empty command and Return="ignore" hides the failure.
+  const installCond = 'NOT (REMOVE~="ALL")'
+  const uninstallCond = 'REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE'
   return [
     `    <CustomAction Id="setKillAppProcesses" Property="WixQuietExec64CmdLine" Value='${killCmd}'/>`,
     `    <CustomAction Id="killAppProcesses" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="immediate" Return="ignore"/>`,
@@ -48,12 +52,12 @@ function buildCustomActionsXml(productName) {
     '    <InstallExecuteSequence>',
     '      <Custom Action="setKillAppProcesses" Before="killAppProcesses">1</Custom>',
     '      <Custom Action="killAppProcesses" Before="InstallValidate">1</Custom>',
-    '      <Custom Action="setDeleteLaunchTask" After="InstallInitialize">REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>',
-    '      <Custom Action="deleteLaunchTask" After="setDeleteLaunchTask">REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>',
-    '      <Custom Action="setRegisterLaunchTask" Before="setRollbackLaunchTask">NOT (REMOVE~="ALL")</Custom>',
-    '      <Custom Action="setRollbackLaunchTask" Before="rollbackLaunchTask">NOT (REMOVE~="ALL")</Custom>',
-    '      <Custom Action="rollbackLaunchTask" Before="registerLaunchTask">NOT (REMOVE~="ALL")</Custom>',
-    '      <Custom Action="registerLaunchTask" Before="InstallFinalize">NOT (REMOVE~="ALL")</Custom>',
+    `      <Custom Action="setDeleteLaunchTask" After="InstallInitialize">${uninstallCond}</Custom>`,
+    `      <Custom Action="deleteLaunchTask" After="setDeleteLaunchTask">${uninstallCond}</Custom>`,
+    `      <Custom Action="setRegisterLaunchTask" Before="setRollbackLaunchTask">${installCond}</Custom>`,
+    `      <Custom Action="setRollbackLaunchTask" Before="rollbackLaunchTask">${installCond}</Custom>`,
+    `      <Custom Action="rollbackLaunchTask" Before="registerLaunchTask">${installCond}</Custom>`,
+    `      <Custom Action="registerLaunchTask" Before="InstallFinalize">${installCond}</Custom>`,
     '    </InstallExecuteSequence>',
     '',
   ].join('\n')

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -127,6 +127,8 @@ module.exports = {
     perMachine: true,
     oneClick: true,
     artifactName: '${productName}-Setup.${ext}',
+    // WixCA/WixQuietExec64 for the injected custom actions (build/msi-custom-actions.js)
+    additionalWixArgs: ['-ext', 'WixUtilExtension'],
   },
   pkg: {
     artifactName: '${productName}-${arch}-mac.${ext}',

--- a/src/main/system/msi-launch-installer.test.ts
+++ b/src/main/system/msi-launch-installer.test.ts
@@ -67,8 +67,11 @@ describe('MSI launch installer contract', () => {
     vi.stubEnv('EDITION', 'enterprise')
     const builderConfig = require(path.join(process.cwd(), 'electron-builder.config.js')) as {
       msiProjectCreated: string
+      msi: { additionalWixArgs: string[] }
     }
     expect(builderConfig.msiProjectCreated).toBe('build/msi-custom-actions.js')
+    // WixQuietExec64 lives in WixUtilExtension; without it light fails on WixCA.
+    expect(builderConfig.msi.additionalWixArgs).toEqual(['-ext', 'WixUtilExtension'])
   })
 
   it('injection expands the product name from the wxs and wires the scripts', () => {
@@ -92,6 +95,37 @@ describe('MSI launch installer contract', () => {
     expect(injected).toContain('"[System64Folder]schtasks.exe"')
   })
 
+  it('actions run through WixQuietExec so no console window flashes', () => {
+    // A plain EXE custom action pops a terminal per console binary during
+    // interactive installs.
+    expect(injected).not.toContain('ExeCommand')
+    for (const action of [
+      'killAppProcesses',
+      'registerLaunchTask',
+      'rollbackLaunchTask',
+      'deleteLaunchTask',
+    ]) {
+      expect(injected).toMatch(
+        new RegExp(`Id="${action}" BinaryKey="WixCA" DllEntry="WixQuietExec64"`),
+      )
+    }
+    // The immediate action reads WixQuietExec64CmdLine; deferred/rollback ones
+    // read CustomActionData, so the type-51 property must equal the action id.
+    expect(injected).toContain('Property="WixQuietExec64CmdLine"')
+    expect(injected).toContain('Property="registerLaunchTask"')
+    expect(injected).toContain('Property="rollbackLaunchTask"')
+    expect(injected).toContain('Property="deleteLaunchTask"')
+    // Each quiet action needs its command set earlier in the same sequence.
+    for (const setter of [
+      'setKillAppProcesses',
+      'setRegisterLaunchTask',
+      'setRollbackLaunchTask',
+      'setDeleteLaunchTask',
+    ]) {
+      expect(injected).toMatch(new RegExp(`Custom Action="${setter}"`))
+    }
+  })
+
   it('kill action matches paths literally, not as wildcards', () => {
     expect(injected).toContain('.StartsWith($d, &apos;OrdinalIgnoreCase&apos;)')
     expect(injected).not.toContain('$_.Path -like')
@@ -101,7 +135,7 @@ describe('MSI launch installer contract', () => {
     expect(injected).toContain('Id="rollbackLaunchTask"')
     expect(injected).toContain('Id="deleteLaunchTask"')
     expect(injected).toMatch(/Custom Action="rollbackLaunchTask" Before="registerLaunchTask"/)
-    expect(injected).toMatch(/Custom Action="deleteLaunchTask" After="InstallInitialize"/)
+    expect(injected).toMatch(/Custom Action="deleteLaunchTask" After="setDeleteLaunchTask"/)
   })
 
   it('default product name matches the enterprise product the MSI expands', () => {

--- a/src/main/system/msi-launch-installer.test.ts
+++ b/src/main/system/msi-launch-installer.test.ts
@@ -116,13 +116,30 @@ describe('MSI launch installer contract', () => {
     expect(injected).toContain('Property="rollbackLaunchTask"')
     expect(injected).toContain('Property="deleteLaunchTask"')
     // Each quiet action needs its command set earlier in the same sequence.
-    for (const setter of [
-      'setKillAppProcesses',
-      'setRegisterLaunchTask',
-      'setRollbackLaunchTask',
-      'setDeleteLaunchTask',
+    expect(injected).toMatch(/Custom Action="setKillAppProcesses" Before="killAppProcesses"/)
+    expect(injected).toMatch(/Custom Action="setRegisterLaunchTask" Before="setRollbackLaunchTask"/)
+    expect(injected).toMatch(/Custom Action="setRollbackLaunchTask" Before="rollbackLaunchTask"/)
+    expect(injected).toMatch(/Custom Action="setDeleteLaunchTask" After="InstallInitialize"/)
+  })
+
+  it('setter conditions match their actions', () => {
+    // A drifted condition leaves the action with an empty command line, and
+    // Return="ignore" hides the failure.
+    const conditions = new Map(
+      [...injected.matchAll(/<Custom Action="(\w+)"[^>]*>([^<]*)<\/Custom>/g)].map((m) => [
+        m[1],
+        m[2],
+      ]),
+    )
+    for (const action of [
+      'killAppProcesses',
+      'registerLaunchTask',
+      'rollbackLaunchTask',
+      'deleteLaunchTask',
     ]) {
-      expect(injected).toMatch(new RegExp(`Custom Action="${setter}"`))
+      const setter = `set${action[0].toUpperCase()}${action.slice(1)}`
+      expect(conditions.get(setter), setter).toBeTruthy()
+      expect(conditions.get(setter), setter).toBe(conditions.get(action))
     }
   })
 


### PR DESCRIPTION
## Problem

Reinstalling/upgrading the MSI flashes several terminal windows: the custom actions from #247 are plain EXE custom actions running console binaries (`powershell.exe` for the pre-kill and task registration, `schtasks.exe` for task deletes), and Windows Installer shows a console window for each.

## Fix

- All four actions now run through `BinaryKey="WixCA" DllEntry="WixQuietExec64"` (the standard WiX quiet-exec), which spawns without a window and captures output into the MSI log. Command strings are unchanged.
- Quiet-exec reads its command from a property, so each action gets a type-51 setter sequenced just before it: `WixQuietExec64CmdLine` for the immediate kill, property = action id (CustomActionData) for the deferred/rollback ones. The setters keep `[APPLICATIONFOLDER]`/`[System64Folder]` formatting.
- `msi.additionalWixArgs: ['-ext', 'WixUtilExtension']` links the extension (flows to both candle and light). Verified electron-builder's bundled `wix-4.0.0.5512.2` ships WixUtilExtension with `WixCA` exporting `WixQuietExec64`.
- Contract tests pin quiet-exec on all four actions and the extension wiring; fixed the stale patch-package reference in the `msi-launch-task.ps1` header.

## Verification

- `msi-launch-installer.test.ts` — 11 passing.
- Injected wxs rendered and validated with xmllint.
- Not yet exercised on Windows — needs a reinstall on the VM (pending VM matrix pass) to confirm no windows appear and the launch task still registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)