### PR TITLE
fix: retry failed mining sweeps via a polled, backoff-gated scheduler

### DIFF
--- a/src/main/capture/capture-orchestrator.test.ts
+++ b/src/main/capture/capture-orchestrator.test.ts
@@ -25,14 +25,12 @@ describe('createCaptureCoordinator', () => {
     const capture = createCaptureMock()
     const stateManager = createCaptureStateManagerMock()
     const userContextBuilder = { scheduleRun: vi.fn() }
-    const taskMiner = { scheduleRun: vi.fn() }
 
     const coordinator = createCaptureCoordinator({
       capture,
       captureStateManager: stateManager as never,
       isPaused: () => false,
       userContextBuilder: userContextBuilder as never,
-      taskMiner: taskMiner as never,
     })
 
     coordinator.controls.requestStartCapture()
@@ -40,21 +38,18 @@ describe('createCaptureCoordinator', () => {
     expect(stateManager.setCaptureEnabled).toHaveBeenCalledWith(true)
     expect(capture.startCapture).toHaveBeenCalledTimes(1)
     expect(userContextBuilder.scheduleRun).toHaveBeenCalledTimes(1)
-    expect(taskMiner.scheduleRun).toHaveBeenCalledTimes(1)
   })
 
   it('does not start capture or schedule analyzers on manual start while paused', () => {
     const capture = createCaptureMock()
     const stateManager = createCaptureStateManagerMock()
     const userContextBuilder = { scheduleRun: vi.fn() }
-    const taskMiner = { scheduleRun: vi.fn() }
 
     const coordinator = createCaptureCoordinator({
       capture,
       captureStateManager: stateManager as never,
       isPaused: () => true,
       userContextBuilder: userContextBuilder as never,
-      taskMiner: taskMiner as never,
     })
 
     coordinator.controls.requestStartCapture()
@@ -62,28 +57,24 @@ describe('createCaptureCoordinator', () => {
     expect(stateManager.setCaptureEnabled).toHaveBeenCalledWith(true)
     expect(capture.startCapture).not.toHaveBeenCalled()
     expect(userContextBuilder.scheduleRun).not.toHaveBeenCalled()
-    expect(taskMiner.scheduleRun).not.toHaveBeenCalled()
   })
 
   it('keeps scheduling behavior on resume path', () => {
     const capture = createCaptureMock()
     const stateManager = createCaptureStateManagerMock()
     const userContextBuilder = { scheduleRun: vi.fn() }
-    const taskMiner = { scheduleRun: vi.fn() }
 
     const coordinator = createCaptureCoordinator({
       capture,
       captureStateManager: stateManager as never,
       isPaused: () => false,
       userContextBuilder: userContextBuilder as never,
-      taskMiner: taskMiner as never,
     })
 
     coordinator.resumeCaptureIfDesired('resume')
 
     expect(capture.startCapture).toHaveBeenCalledTimes(1)
     expect(userContextBuilder.scheduleRun).toHaveBeenCalledTimes(1)
-    expect(taskMiner.scheduleRun).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -105,7 +96,6 @@ describe('createCaptureCoordinator timed pause', () => {
       captureStateManager: stateManager as never,
       isPaused: overrides?.isPaused ?? (() => false),
       userContextBuilder: { scheduleRun: vi.fn() } as never,
-      taskMiner: { scheduleRun: vi.fn() } as never,
       onStateChanged,
     })
     return { capture, stateManager, onStateChanged, coordinator }

--- a/src/main/capture/capture-orchestrator.ts
+++ b/src/main/capture/capture-orchestrator.ts
@@ -30,8 +30,6 @@ export function createCaptureCoordinator(params: {
   captureStateManager: CaptureStateManager
   isPaused: () => boolean
   userContextBuilder: UserContextBuilder | null
-  /** The scheduled background miner (TaskMiner; structural for tests). */
-  taskMiner: { scheduleRun(): void } | null
   /**
    * Notifies the UI (tray + renderer) after any capture-state transition
    * (start/stop/pause/resume) so the displayed state stays in sync — including
@@ -54,7 +52,6 @@ export function createCaptureCoordinator(params: {
 
   const scheduleBackgroundAnalyzers = (): void => {
     params.userContextBuilder?.scheduleRun()
-    params.taskMiner?.scheduleRun()
   }
 
   const notifyStateChanged = (): void => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -406,7 +406,6 @@ app.on('ready', async () => {
     captureStateManager,
     isPaused: shouldPause,
     userContextBuilder,
-    taskMiner,
     onStateChanged: () => {
       void updateTrayMenu()
       void sendStatusToRenderer()
@@ -535,7 +534,11 @@ app.on('ready', async () => {
     retryFailedMiningDays: () => {
       if (!runtime || !taskMiner) return 0
       const retried = runtime.storage.miningDays.retryFailed()
-      if (retried > 0) taskMiner.scheduleRun()
+      if (retried > 0) {
+        // Manual retry: don't make the user wait out an active failure backoff.
+        taskMiner.resetBackoff()
+        taskMiner.scheduleRun()
+      }
       return retried
     },
     observation,
@@ -546,8 +549,8 @@ app.on('ready', async () => {
 
   runtime.accessProvider.startPeriodicRefresh()
 
-  // Recover interrupted mining days and kick the ledger sweep. A fresh DB
-  // enqueues its 60-day seed here; a mined DB just picks up any gap days.
+  // Recover interrupted mining days and start the sweep poll. A fresh DB
+  // enqueues its 60-day seed on the first tick; a mined DB picks up gap days.
   if (taskMiner) {
     const miner = taskMiner
     // After a derived-data wipe (CLUSTER_SCHEMA_VERSION bump) the DB is still

--- a/src/main/services/task-miner/index.ts
+++ b/src/main/services/task-miner/index.ts
@@ -46,6 +46,8 @@ export class TaskMiner {
   /** Settled counts snapshotted at sweep start; null outside a sweep. */
   private sweepBaseline: { completed: number; failed: number } | null = null
   private settleTimer: ReturnType<typeof setTimeout> | null = null
+  private retryTimer: ReturnType<typeof setTimeout> | null = null
+  private retryDelayMs = TASK_BACKFILL.RETRY_INITIAL_MS
   private model = ''
   /** Remote override for the clustering (label/merge/split) passes; null = follow `model`. */
   private clusterModel: string | null = null
@@ -64,7 +66,26 @@ export class TaskMiner {
 
   setEnabled(enabled: boolean): void {
     this.enabled = enabled
+    if (!enabled) this.clearRetry()
     log.info(`[TaskMiner] ${enabled ? 'Enabled' : 'Disabled'}`)
+  }
+
+  private clearRetry(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer)
+      this.retryTimer = null
+    }
+  }
+
+  private scheduleRetry(): void {
+    if (this.retryTimer) return
+    const delay = this.retryDelayMs
+    this.retryDelayMs = Math.min(this.retryDelayMs * 2, TASK_BACKFILL.RETRY_MAX_MS)
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null
+      this.scheduleRun()
+    }, delay)
+    log.info(`[TaskMiner] Retry sweep in ${Math.round(delay / 60_000)}m`)
   }
 
   updateModel(model: string): void {
@@ -183,8 +204,9 @@ export class TaskMiner {
    * labels feed the known-procedure vocabulary later days scan against) and
    * mine each one. A day's sightings and its `completed` status commit in one
    * transaction (see runDetection.onCommit), so a crash retries cleanly. A
-   * failed day records the attempt and stops the sweep — the next trigger
-   * retries it, and once its attempts are exhausted the claim skips past it.
+   * failed day records the attempt and stops the sweep — a backoff retry timer
+   * (or any earlier trigger) retries it, and once its attempts are exhausted
+   * the claim skips past it.
    * Clusters at the CLUSTER_EVERY_DAYS barrier and once at the end.
    */
   private async sweep(provider: InferenceProvider): Promise<BackfillSummary> {
@@ -193,6 +215,7 @@ export class TaskMiner {
       return { daysMined: 0, daysSkipped: 0, daysFailed: 0, skipped: 'busy' }
     }
     this.running = true
+    this.clearRetry()
     const settled = this.storage.miningDays.countByStatus()
     this.sweepBaseline = { completed: settled.completed, failed: settled.failed }
     this.emitStatus()
@@ -284,6 +307,8 @@ export class TaskMiner {
             `${daysSkipped} already present, ${daysFailed} failed`,
         )
       }
+      if (daysFailed > 0 && this.storage.miningDays.hasPending()) this.scheduleRetry()
+      else if (daysFailed === 0) this.retryDelayMs = TASK_BACKFILL.RETRY_INITIAL_MS
       return { daysMined, daysSkipped, daysFailed, clustering }
     } finally {
       this.running = false

--- a/src/main/services/task-miner/index.ts
+++ b/src/main/services/task-miner/index.ts
@@ -15,8 +15,9 @@
  * After mining, a clustering pass (see ./clustering) groups sightings into
  * persistent recurring-process clusters with stable ids.
  *
- * Includes built-in scheduling: call scheduleRun() on screen unlock and the
- * service handles interval guards, settle delays, and error isolation.
+ * Includes built-in scheduling: startup() arms a poll interval that sweeps
+ * whenever the ledger has pending days, paced by a doubling backoff after a
+ * failed sweep.
  */
 
 import type { StorageService } from '../../storage'
@@ -45,9 +46,9 @@ export class TaskMiner {
   private running = false
   /** Settled counts snapshotted at sweep start; null outside a sweep. */
   private sweepBaseline: { completed: number; failed: number } | null = null
-  private settleTimer: ReturnType<typeof setTimeout> | null = null
-  private retryTimer: ReturnType<typeof setTimeout> | null = null
+  private pollTimer: ReturnType<typeof setInterval> | null = null
   private retryDelayMs = TASK_BACKFILL.RETRY_INITIAL_MS
+  private nextAttemptAt = 0
   private model = ''
   /** Remote override for the clustering (label/merge/split) passes; null = follow `model`. */
   private clusterModel: string | null = null
@@ -66,26 +67,13 @@ export class TaskMiner {
 
   setEnabled(enabled: boolean): void {
     this.enabled = enabled
-    if (!enabled) this.clearRetry()
     log.info(`[TaskMiner] ${enabled ? 'Enabled' : 'Disabled'}`)
   }
 
-  private clearRetry(): void {
-    if (this.retryTimer) {
-      clearTimeout(this.retryTimer)
-      this.retryTimer = null
-    }
-  }
-
-  private scheduleRetry(): void {
-    if (this.retryTimer) return
-    const delay = this.retryDelayMs
-    this.retryDelayMs = Math.min(this.retryDelayMs * 2, TASK_BACKFILL.RETRY_MAX_MS)
-    this.retryTimer = setTimeout(() => {
-      this.retryTimer = null
-      this.scheduleRun()
-    }, delay)
-    log.info(`[TaskMiner] Retry sweep in ${Math.round(delay / 60_000)}m`)
+  /** Clears the failure backoff so the next scheduleRun() may sweep immediately. */
+  resetBackoff(): void {
+    this.nextAttemptAt = 0
+    this.retryDelayMs = TASK_BACKFILL.RETRY_INITIAL_MS
   }
 
   updateModel(model: string): void {
@@ -98,9 +86,9 @@ export class TaskMiner {
     log.info(`[TaskMiner] Cluster model updated to: ${this.clusterModel ?? '(follow miner model)'}`)
   }
 
-  /** True while a run is executing or its settle timer is armed. */
+  /** True while a run is executing. */
   isBusy(): boolean {
-    return this.running || this.settleTimer !== null
+    return this.running
   }
 
   /** Settled counts at the current sweep's start, for per-run progress; null outside a sweep. */
@@ -118,36 +106,41 @@ export class TaskMiner {
   }
 
   /**
-   * Startup entry point: recover days left `running` by a crash, then try to
-   * schedule a sweep (the settle timer keeps the launch path calm and a fresh
-   * DB starts its 60-day seed without waiting for the first unlock).
+   * Startup entry point: recover days left `running` by a crash, then start
+   * the poll that drives every sweep. The first tick — not launch itself —
+   * starts the first sweep, so the launch path stays calm and a fresh DB
+   * begins its 60-day seed a few minutes in without any external trigger.
    */
   startup(): void {
     const recovered = this.storage.miningDays.resetStaleRunning(TASK_BACKFILL.MAX_DAY_ATTEMPTS)
     if (recovered) log.info(`[TaskMiner] Recovered ${recovered} interrupted mining day(s)`)
-    this.scheduleRun()
+    if (!this.pollTimer) {
+      this.pollTimer = setInterval(() => this.scheduleRun(), TASK_BACKFILL.POLL_INTERVAL_MS)
+    }
   }
 
   /**
-   * Try to schedule a mining sweep. Call this on screen unlock / wake.
+   * Start a sweep now if the guards and the failure backoff allow it. Runs on
+   * every poll tick; safe to call from anywhere.
    */
   scheduleRun(): void {
     if (!this.enabled) return
-    if (this.running || this.settleTimer) return
+    if (this.running) return
+    if (Date.now() < this.nextAttemptAt) return
 
     if (!this.provider || !this.provider.isConfigured()) {
-      log.info('[TaskMiner] No inference provider configured, skipping')
+      log.debug('[TaskMiner] No inference provider configured, skipping')
       return
     }
 
     if (!this.model) {
-      log.info('[TaskMiner] No model configured, skipping')
+      log.debug('[TaskMiner] No model configured, skipping')
       return
     }
 
     const activityCount = this.storage.activities.count()
     if (activityCount < PATTERN_DETECTION_CONFIG.MIN_ACTIVITIES) {
-      log.info(
+      log.debug(
         `[TaskMiner] Only ${activityCount} activities (need ${PATTERN_DETECTION_CONFIG.MIN_ACTIVITIES}), skipping`,
       )
       return
@@ -155,18 +148,11 @@ export class TaskMiner {
 
     this.ensureEnqueued()
     if (!this.storage.miningDays.hasPending()) {
-      log.info('[TaskMiner] No days pending, skipping')
+      log.debug('[TaskMiner] No days pending, skipping')
       return
     }
 
-    log.info(`[TaskMiner] Scheduling sweep in ${PATTERN_DETECTION_CONFIG.SETTLE_DELAY_MS / 1000}s`)
-    const provider = this.provider
-    this.settleTimer = setTimeout(() => {
-      this.settleTimer = null
-      void this.sweep(provider)
-    }, PATTERN_DETECTION_CONFIG.SETTLE_DELAY_MS)
-    // An armed timer counts as busy — push so an open window flips to "Analyzing" now.
-    this.emitStatus()
+    void this.sweep(this.provider)
   }
 
   /**
@@ -204,9 +190,9 @@ export class TaskMiner {
    * labels feed the known-procedure vocabulary later days scan against) and
    * mine each one. A day's sightings and its `completed` status commit in one
    * transaction (see runDetection.onCommit), so a crash retries cleanly. A
-   * failed day records the attempt and stops the sweep — a backoff retry timer
-   * (or any earlier trigger) retries it, and once its attempts are exhausted
-   * the claim skips past it.
+   * failed day records the attempt and stops the sweep — the next poll tick
+   * retries it (paced by a doubling backoff), and once its attempts are
+   * exhausted the claim skips past it.
    * Clusters at the CLUSTER_EVERY_DAYS barrier and once at the end.
    */
   private async sweep(provider: InferenceProvider): Promise<BackfillSummary> {
@@ -215,7 +201,6 @@ export class TaskMiner {
       return { daysMined: 0, daysSkipped: 0, daysFailed: 0, skipped: 'busy' }
     }
     this.running = true
-    this.clearRetry()
     const settled = this.storage.miningDays.countByStatus()
     this.sweepBaseline = { completed: settled.completed, failed: settled.failed }
     this.emitStatus()
@@ -307,8 +292,13 @@ export class TaskMiner {
             `${daysSkipped} already present, ${daysFailed} failed`,
         )
       }
-      if (daysFailed > 0 && this.storage.miningDays.hasPending()) this.scheduleRetry()
-      else if (daysFailed === 0) this.retryDelayMs = TASK_BACKFILL.RETRY_INITIAL_MS
+      if (daysFailed > 0 && this.storage.miningDays.hasPending()) {
+        this.nextAttemptAt = Date.now() + this.retryDelayMs
+        log.info(`[TaskMiner] Retry sweep in ${Math.round(this.retryDelayMs / 60_000)}m`)
+        this.retryDelayMs = Math.min(this.retryDelayMs * 2, TASK_BACKFILL.RETRY_MAX_MS)
+      } else {
+        this.resetBackoff()
+      }
       return { daysMined, daysSkipped, daysFailed, clustering }
     } finally {
       this.running = false
@@ -415,7 +405,7 @@ export class TaskMiner {
       log.info('[TaskMiner] Backfill skipped: no inference provider configured')
       return { daysMined: 0, daysSkipped: 0, daysFailed: 0, skipped: 'no-provider' }
     }
-    if (this.running || this.settleTimer) {
+    if (this.running) {
       log.info('[TaskMiner] Backfill skipped: a mining run is already in progress')
       return { daysMined: 0, daysSkipped: 0, daysFailed: 0, skipped: 'busy' }
     }

--- a/src/main/services/task-miner/task-miner.test.ts
+++ b/src/main/services/task-miner/task-miner.test.ts
@@ -111,6 +111,25 @@ describe('TaskMiner sweep', () => {
     }
   }
 
+  // Enough activities to pass the MIN_ACTIVITIES guard, all inside already-seeded
+  // days, so a fired retry timer can reach the settle-timer branch.
+  const seedFiller = (): void => {
+    for (let i = 0; i < PATTERN_DETECTION_CONFIG.MIN_ACTIVITIES; i++) {
+      storage.activities.add({
+        id: `filler-${i}`,
+        appName: 'TestApp',
+        windowTitle: 'w',
+        tld: null,
+        startTimestamp: dayStart(1) + 3000 + i,
+        endTimestamp: dayStart(1) + 4000 + i,
+        summary: 's',
+        summaryModel: '',
+        ocrText: '',
+        vector: v(0.1),
+      })
+    }
+  }
+
   beforeEach(() => {
     deleteDbFiles(TEST_DB_PATH)
     storage = new StorageService(TEST_DB_PATH)
@@ -133,6 +152,7 @@ describe('TaskMiner sweep', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     storage.close()
     deleteDbFiles(TEST_DB_PATH)
   })
@@ -247,27 +267,55 @@ describe('TaskMiner sweep', () => {
 
   it('scheduleRun arms nothing when every day is already settled', async () => {
     seedDays(2)
-    // Enough activities to pass the MIN_ACTIVITIES guard, all inside days the
-    // sweep below settles — the pending check must be what stands down.
-    for (let i = 0; i < PATTERN_DETECTION_CONFIG.MIN_ACTIVITIES; i++) {
-      storage.activities.add({
-        id: `filler-${i}`,
-        appName: 'TestApp',
-        windowTitle: 'w',
-        tld: null,
-        startTimestamp: dayStart(1) + 3000 + i,
-        endTimestamp: dayStart(1) + 4000 + i,
-        summary: 's',
-        summaryModel: '',
-        ocrText: '',
-        vector: v(0.1),
-      })
-    }
+    seedFiller()
     await miner.sweepNow(configuredProvider)
 
     miner.scheduleRun()
 
     expect(miner.isBusy()).toBe(false)
+  })
+
+  it('retries a failed sweep on an internal timer', async () => {
+    vi.useFakeTimers()
+    seedDays(2)
+    seedFiller()
+    mockedRunDetection.mockRejectedValueOnce(new Error('blip'))
+
+    await miner.sweepNow(configuredProvider)
+    expect(miner.isBusy()).toBe(false)
+
+    vi.advanceTimersByTime(TASK_BACKFILL.RETRY_INITIAL_MS)
+    expect(miner.isBusy()).toBe(true)
+  })
+
+  it('doubles the retry delay after consecutive failed sweeps', async () => {
+    vi.useFakeTimers()
+    seedDays(2)
+    seedFiller()
+    mockedRunDetection.mockRejectedValue(new Error('down'))
+
+    await miner.sweepNow(configuredProvider)
+    await miner.sweepNow(configuredProvider)
+
+    vi.advanceTimersByTime(TASK_BACKFILL.RETRY_INITIAL_MS)
+    expect(miner.isBusy()).toBe(false)
+    vi.advanceTimersByTime(TASK_BACKFILL.RETRY_INITIAL_MS)
+    expect(miner.isBusy()).toBe(true)
+  })
+
+  it('clears the armed retry after a clean sweep', async () => {
+    vi.useFakeTimers()
+    seedDays(2)
+    seedFiller()
+    mockedRunDetection.mockRejectedValueOnce(new Error('blip'))
+
+    await miner.sweepNow(configuredProvider)
+    const second = await miner.sweepNow(configuredProvider)
+    expect(second).toMatchObject({ daysMined: 2, daysFailed: 0 })
+
+    await vi.advanceTimersByTimeAsync(TASK_BACKFILL.RETRY_MAX_MS)
+    expect(miner.isBusy()).toBe(false)
+    expect(mockedRunDetection).toHaveBeenCalledTimes(3)
   })
 
   it('startup resets a stale running day so the sweep can retry it', async () => {

--- a/src/main/services/task-miner/task-miner.test.ts
+++ b/src/main/services/task-miner/task-miner.test.ts
@@ -23,8 +23,8 @@ const embedder: MinerEmbedder = {
   embedBatch: async (texts) => texts.map(() => [0.1, 0.2, 0.3]),
 }
 
-// scheduleRun() only arms the settle timer once the DB has at least this many
-// activities, so seed that many to reach the timer branch.
+// scheduleRun() only sweeps once the DB has at least this many activities,
+// so seed that many to reach the sweep branch.
 const seedActivities = (storage: StorageService, count: number): void => {
   for (let i = 0; i < count; i++) {
     storage.activities.add({
@@ -63,17 +63,17 @@ describe('TaskMiner.isBusy', () => {
     expect(miner.isBusy()).toBe(false)
   })
 
-  it('is true once a run is armed (settle timer set), before it fires', () => {
-    vi.useFakeTimers()
+  it('is true while a sweep is in flight', async () => {
     seedActivities(storage, PATTERN_DETECTION_CONFIG.MIN_ACTIVITIES)
     const miner = new TaskMiner(storage, configuredProvider, embedder)
     miner.updateModel('test/model')
 
     expect(miner.isBusy()).toBe(false)
     miner.scheduleRun()
-    // The settle timer is armed but has not fired — this is exactly the
-    // in-flight state a wipe must not slip past.
+    // The sweep started synchronously — this is exactly the in-flight state a
+    // wipe must not slip past.
     expect(miner.isBusy()).toBe(true)
+    while (miner.isBusy()) await Promise.resolve()
   })
 })
 
@@ -112,7 +112,7 @@ describe('TaskMiner sweep', () => {
   }
 
   // Enough activities to pass the MIN_ACTIVITIES guard, all inside already-seeded
-  // days, so a fired retry timer can reach the settle-timer branch.
+  // days, so scheduleRun can reach the sweep branch.
   const seedFiller = (): void => {
     for (let i = 0; i < PATTERN_DETECTION_CONFIG.MIN_ACTIVITIES; i++) {
       storage.activities.add({
@@ -265,7 +265,11 @@ describe('TaskMiner sweep', () => {
     )
   })
 
-  it('scheduleRun arms nothing when every day is already settled', async () => {
+  const drain = async (): Promise<void> => {
+    while (miner.isBusy()) await Promise.resolve()
+  }
+
+  it('scheduleRun stands down when every day is already settled', async () => {
     seedDays(2)
     seedFiller()
     await miner.sweepNow(configuredProvider)
@@ -275,50 +279,84 @@ describe('TaskMiner sweep', () => {
     expect(miner.isBusy()).toBe(false)
   })
 
-  it('retries a failed sweep on an internal timer', async () => {
+  it('the poll started by startup() triggers a sweep', async () => {
+    vi.useFakeTimers()
+    seedDays(2)
+    seedFiller()
+
+    miner.startup()
+    expect(miner.isBusy()).toBe(false)
+
+    vi.advanceTimersByTime(TASK_BACKFILL.POLL_INTERVAL_MS)
+    expect(miner.isBusy()).toBe(true)
+    await drain()
+    expect(storage.miningDays.getAll().every((d) => d.status === 'completed')).toBe(true)
+  })
+
+  it('backoff-gates scheduleRun after a failed sweep', async () => {
     vi.useFakeTimers()
     seedDays(2)
     seedFiller()
     mockedRunDetection.mockRejectedValueOnce(new Error('blip'))
-
     await miner.sweepNow(configuredProvider)
+
+    miner.scheduleRun()
     expect(miner.isBusy()).toBe(false)
 
     vi.advanceTimersByTime(TASK_BACKFILL.RETRY_INITIAL_MS)
+    miner.scheduleRun()
     expect(miner.isBusy()).toBe(true)
+    await drain()
+    expect(storage.miningDays.getAll().every((d) => d.status === 'completed')).toBe(true)
   })
 
-  it('doubles the retry delay after consecutive failed sweeps', async () => {
+  it('doubles the backoff after consecutive failed sweeps', async () => {
     vi.useFakeTimers()
     seedDays(2)
     seedFiller()
     mockedRunDetection.mockRejectedValue(new Error('down'))
 
     await miner.sweepNow(configuredProvider)
-    await miner.sweepNow(configuredProvider)
+    vi.advanceTimersByTime(TASK_BACKFILL.RETRY_INITIAL_MS)
+    miner.scheduleRun()
+    await drain()
 
     vi.advanceTimersByTime(TASK_BACKFILL.RETRY_INITIAL_MS)
+    miner.scheduleRun()
     expect(miner.isBusy()).toBe(false)
+
     vi.advanceTimersByTime(TASK_BACKFILL.RETRY_INITIAL_MS)
+    miner.scheduleRun()
     expect(miner.isBusy()).toBe(true)
+    await drain()
   })
 
-  it('clears the armed retry after a clean sweep', async () => {
+  it('resets the backoff after a clean sweep', async () => {
     vi.useFakeTimers()
     seedDays(2)
     seedFiller()
-    mockedRunDetection.mockRejectedValueOnce(new Error('blip'))
+    mockedRunDetection
+      .mockRejectedValueOnce(new Error('blip'))
+      .mockRejectedValueOnce(new Error('blip'))
 
     await miner.sweepNow(configuredProvider)
-    const second = await miner.sweepNow(configuredProvider)
-    expect(second).toMatchObject({ daysMined: 2, daysFailed: 0 })
+    await miner.sweepNow(configuredProvider)
+    const clean = await miner.sweepNow(configuredProvider)
+    expect(clean).toMatchObject({ daysMined: 2, daysFailed: 0 })
 
-    await vi.advanceTimersByTimeAsync(TASK_BACKFILL.RETRY_MAX_MS)
-    expect(miner.isBusy()).toBe(false)
-    expect(mockedRunDetection).toHaveBeenCalledTimes(3)
+    storage.wipeTasks()
+    mockedRunDetection.mockRejectedValueOnce(new Error('blip'))
+    await miner.sweepNow(configuredProvider)
+
+    // An un-reset backoff would gate this attempt for 8 minutes, not 2.
+    vi.advanceTimersByTime(TASK_BACKFILL.RETRY_INITIAL_MS)
+    miner.scheduleRun()
+    expect(miner.isBusy()).toBe(true)
+    await drain()
   })
 
   it('startup resets a stale running day so the sweep can retry it', async () => {
+    vi.useFakeTimers()
     seedDays(1)
     storage.miningDays.enqueueMissing([localLabel(1)])
     storage.miningDays.claimOldestPending() // simulate a crash mid-mine

--- a/src/main/utils/day.test.ts
+++ b/src/main/utils/day.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { getDayBoundaries } from './day'
+
+describe('getDayBoundaries', () => {
+  const originalTZ = process.env.TZ
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    process.env.TZ = 'America/New_York'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (originalTZ === undefined) delete process.env.TZ
+    else process.env.TZ = originalTZ
+  })
+
+  it('spans 24 hours on a regular day', () => {
+    vi.setSystemTime(new Date(2026, 6, 15, 12, 0, 0))
+    const { start, end, label } = getDayBoundaries(1)
+    expect(label).toBe('2026-07-14')
+    expect(end - start + 1).toBe(24 * 3_600_000)
+  })
+
+  it('spans 23 hours on the spring-forward day', () => {
+    vi.setSystemTime(new Date(2026, 2, 10, 12, 0, 0))
+    const { start, end, label } = getDayBoundaries(2)
+    expect(label).toBe('2026-03-08')
+    expect(end - start + 1).toBe(23 * 3_600_000)
+  })
+
+  it('spans 25 hours on the fall-back day', () => {
+    vi.setSystemTime(new Date(2026, 10, 3, 12, 0, 0))
+    const { start, end, label } = getDayBoundaries(2)
+    expect(label).toBe('2026-11-01')
+    expect(end - start + 1).toBe(25 * 3_600_000)
+  })
+
+  it('adjacent day windows abut exactly across a DST transition', () => {
+    vi.setSystemTime(new Date(2026, 2, 10, 12, 0, 0))
+    expect(getDayBoundaries(2).end + 1).toBe(getDayBoundaries(1).start)
+  })
+})

--- a/src/main/utils/day.ts
+++ b/src/main/utils/day.ts
@@ -16,7 +16,7 @@ export function getDayBoundaries(daysBack: number): {
   const now = new Date()
   const day = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysBack)
   const start = day.getTime()
-  const end = start + 24 * 60 * 60 * 1000 - 1
+  const end = new Date(day.getFullYear(), day.getMonth(), day.getDate() + 1).getTime() - 1
   const label = `${day.getFullYear()}-${String(day.getMonth() + 1).padStart(2, '0')}-${String(day.getDate()).padStart(2, '0')}`
   return { start, end, label }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -150,7 +150,8 @@ export const TASK_BACKFILL = {
   // Mining attempts per calendar day before the ledger marks it failed.
   MAX_DAY_ATTEMPTS: 3,
   POLL_INTERVAL_MS: 5 * 60_000,
-  RETRY_INITIAL_MS: 2 * 60_000,
+  // Must exceed POLL_INTERVAL_MS, else an outage burns MAX_DAY_ATTEMPTS in minutes.
+  RETRY_INITIAL_MS: 10 * 60_000,
   RETRY_MAX_MS: 30 * 60_000,
 }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -113,7 +113,7 @@ export const USER_CONTEXT_CONFIG = {
   MODEL: 'minimax/minimax-m3',
   LOOKBACK_DAYS: 7, // Analyze past week of activities
   MIN_ACTIVITIES: 50, // Minimum total activities in DB before first run
-  SETTLE_DELAY_MS: 30 * 1000, // 30s after unlock — runs before pattern detection (60s)
+  SETTLE_DELAY_MS: 30 * 1000, // 30s after unlock
 }
 
 // Pattern Detection Configuration
@@ -121,7 +121,6 @@ export const PATTERN_DETECTION_CONFIG = {
   MODEL: 'minimax/minimax-m3',
   LOOKBACK_DAYS: 1, // Days back from today to analyze (1 = yesterday)
   MIN_ACTIVITIES: 200, // Minimum total activities in DB before first run
-  SETTLE_DELAY_MS: 60 * 1000, // 1 min after unlock before running
 }
 
 // Sightings older than this are pruned on every mining run; cluster stats use
@@ -150,6 +149,7 @@ export const TASK_BACKFILL = {
   CLUSTER_EVERY_DAYS: 5,
   // Mining attempts per calendar day before the ledger marks it failed.
   MAX_DAY_ATTEMPTS: 3,
+  POLL_INTERVAL_MS: 5 * 60_000,
   RETRY_INITIAL_MS: 2 * 60_000,
   RETRY_MAX_MS: 30 * 60_000,
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -150,6 +150,8 @@ export const TASK_BACKFILL = {
   CLUSTER_EVERY_DAYS: 5,
   // Mining attempts per calendar day before the ledger marks it failed.
   MAX_DAY_ATTEMPTS: 3,
+  RETRY_INITIAL_MS: 2 * 60_000,
+  RETRY_MAX_MS: 30 * 60_000,
 }
 
 // User-initiated timed capture pause (auto-resumes when the timer elapses).


### PR DESCRIPTION
## Problem

A single failed day halts the mining sweep, and recovery waits for the next external trigger (mostly capture-stop). Prod log showed 5 halts in the past week — 3 LLM timeouts, 2 minimax non-JSON responses — all transient (every day succeeded on attempt 2), yet one stall lasted 4 hours and a 60-day re-mine needed 3 triggers across 13 hours.

## Fix

Mining no longer depends on external triggers at all. `startup()` arms a 5-minute poll that calls `scheduleRun()`; every existing guard (enabled, busy, provider, model, min activities, pending days) re-applies on each tick, so a tick with nothing to do is a no-op SQLite count. The capture start/resume wiring and the settle timer are removed — the poll cadence is the pacing.

- A failed sweep with days still pending sets a `nextAttemptAt` gate inside `scheduleRun`: 10 min, doubling per consecutive failed sweep, capped at 30 min. The initial gate deliberately exceeds the 5-min poll so consecutive failed sweeps skip ticks — an outage spends the day's 3 attempts over ~30+ minutes instead of ~15. The gate (vs sweeping every tick) keeps a provider outage from burning a day attempt every 5 minutes.
- The backoff resets whenever a sweep ends without arming a retry, so a transient failure long after an outage starts back at 2 minutes.
- The manual retry-failed-days action clears the gate so the user never waits out an active backoff.
- Break-on-failure stays: a poison day still self-resolves after `MAX_DAY_ATTEMPTS` and the sweep flows past it.
- `getDayBoundaries` end is now the next local midnight − 1 instead of `start + 24h − 1`, so day windows abut exactly on 23/25-hour DST days.

## Tests

Poll and backoff tests (tick triggers a sweep, gate blocks then opens, delay doubles, clean sweep resets it) and DST window tests under `America/New_York`. Full suite green (1223 passed), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
