### PR TITLE
fix: raise default inference request timeout to 10 minutes

### DIFF
--- a/src/main/llm/inference-provider.ts
+++ b/src/main/llm/inference-provider.ts
@@ -49,7 +49,7 @@ export interface InferenceProviderOptions {
  * the gateway keeps the connection alive, so an explicit deadline is the only
  * thing that ever fails the call. Normal completions finish well under this.
  */
-export const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000
+export const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000
 
 export function withRequestTimeout(
   fetchImpl: typeof globalThis.fetch,


### PR DESCRIPTION
## Context

Task-mining LLM requests were timing out. The task miner (`src/main/services/task-miner/`) makes its `generateText` calls through the shared `InferenceProviderImpl` and sets no per-call timeout of its own, so the only deadline that applies is the hardcoded per-request fetch timeout — previously 5 minutes. Large scan/ground calls (long prompts, tool use, big models) exceed 5 minutes and get aborted.

## Change

Bump `DEFAULT_REQUEST_TIMEOUT_MS` in `src/main/llm/inference-provider.ts` from 5 to 10 minutes.

The provider instance is shared with the semantic pipeline, but semantic self-caps with its own tighter `Promise.race` (`semanticRequestTimeoutMs`), so raising this fetch deadline only extends task-mining requests in practice — semantic and other self-capping consumers are unaffected.

## Verification

- `npm run typecheck` passes.
- No other reference hardcodes the old value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)