### PR TITLE
DEU-205 step 1: PII scrubber bake-off (eval harness + decision)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "yazl": "^3.3.1"
       },
       "devDependencies": {
+        "@coffeeandfun/remove-pii": "^3.0.1",
         "@electron/notarize": "^3.1.1",
         "@tailwindcss/vite": "^4.1.18",
         "@types/better-sqlite3": "^7.6.13",
@@ -68,6 +69,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "prettier": "^3.8.1",
+        "redact-pii": "^3.4.0",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.19.0",
         "typescript": "~5.7.0",
@@ -845,6 +847,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@coffeeandfun/remove-pii": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@coffeeandfun/remove-pii/-/remove-pii-3.0.1.tgz",
+      "integrity": "sha512-LPsHgzU8Ydg42gudEsJM2mj2YST3MroR7GcWf9iMYgIuz5UvJdVaT/OV9hZnEN5Ot0V+ey/ULETRptPK/X9D+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -2183,6 +2195,52 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@google-cloud/dlp": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/dlp/-/dlp-4.4.3.tgz",
+      "integrity": "sha512-ZNjSqeFkiJrBTNJKVfkdpuGOa6Ov0bc6XyM7iJ+yI7rL78ZeRwQK70lU8oCp7g48J9W9quJrPA4Ni5y08wEk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^3.5.8"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.8.22",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.22.tgz",
+      "integrity": "sha512-oAjDdN7fzbUi+4hZjKG96MR6KTEubAeMpQEb+77qy+3r0Ua5xTFuie6JOLr4ZZgl5g+W5/uRTS2M1V8mVAFPuA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.0",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -2921,6 +2979,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
+      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
       }
     },
     "node_modules/@malept/cross-spawn-promise": {
@@ -5645,6 +5716,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -5668,6 +5750,45 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -5724,6 +5845,17 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "*",
         "@types/node": "*"
       }
     },
@@ -6418,6 +6550,19 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -6949,6 +7094,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -7136,6 +7291,13 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -7593,6 +7755,19 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -8540,6 +8715,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -8947,6 +9135,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -9262,6 +9463,93 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -9736,6 +10024,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -10002,6 +10300,13 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -10795,6 +11100,181 @@
         "node": ">=18"
       }
     },
+    "node_modules/google-gax": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.6.1.tgz",
+      "integrity": "sha512-g/lcUjGcB6DSw2HxgEmCDOrI/CByOwqRvsuUvNalHUK2iPPPlmAIpbMbl62u0YufGMr8zgE3JL7th6dCb1Ry+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "~1.8.0",
+        "@grpc/proto-loader": "^0.7.0",
+        "@types/long": "^4.0.0",
+        "@types/rimraf": "^3.0.2",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "fast-text-encoding": "^1.0.3",
+        "google-auth-library": "^8.0.2",
+        "is-stream-ended": "^0.1.4",
+        "node-fetch": "^2.6.1",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^1.0.0",
+        "protobufjs": "7.2.4",
+        "protobufjs-cli": "1.1.1",
+        "retry-request": "^5.0.0"
+      },
+      "bin": {
+        "compileProtos": "build/tools/compileProtos.js",
+        "minifyProtoJson": "build/tools/minify.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/google-gax/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/google-gax/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
+      "integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.3.0",
+        "gtoken": "^6.1.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/google-gax/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/google-gax/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-gax/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/google-gax/node_modules/protobufjs": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/google-gax/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/google-logging-utils": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
@@ -10802,6 +11282,23 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/google-p12-pem": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
+      "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
+      "deprecated": "Package is no longer maintained",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "^1.3.1"
+      },
+      "bin": {
+        "gp12-pem": "build/src/bin/gp12-pem.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/gopd": {
@@ -10854,6 +11351,85 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gtoken": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
+      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^5.0.1",
+        "google-p12-pem": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gtoken/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gtoken/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/guid-typescript": {
       "version": "1.0.9",
@@ -11683,6 +12259,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-stream-ended": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -11905,6 +12488,69 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdoc/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsdoc/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -12021,6 +12667,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/kleur": {
@@ -12319,6 +12975,26 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.2.tgz",
@@ -12500,6 +13176,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -12702,6 +13385,58 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -12722,6 +13457,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -13167,6 +13909,16 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "11.5.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
@@ -13299,6 +14051,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -14148,6 +14910,19 @@
         "node": ">= 4"
       }
     },
+    "node_modules/proto3-json-serializer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.1.tgz",
+      "integrity": "sha512-AwAuY4g9nxx0u52DnSMkqqgyLHaW/XaPLtaAo3y/ZCfeaQB/g4YDH4kb8Wc/mWzWvu0YjOznVnfn373MVZZrgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
@@ -14170,6 +14945,86 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs-cli": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz",
+      "integrity": "sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "escodegen": "^1.13.0",
+        "espree": "^9.0.0",
+        "estraverse": "^5.1.0",
+        "glob": "^8.0.0",
+        "jsdoc": "^4.0.0",
+        "minimist": "^1.2.0",
+        "semver": "^7.1.2",
+        "tmp": "^0.2.1",
+        "uglify-js": "^3.7.7"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "protobufjs": "^7.0.0"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/protobufjs-cli/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/proxy-addr": {
@@ -14199,6 +15054,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14537,6 +15402,18 @@
         "node": ">= 4"
       }
     },
+    "node_modules/redact-pii": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/redact-pii/-/redact-pii-3.4.0.tgz",
+      "integrity": "sha512-eXx5rwqqdJGD3LVvuJawJf5ge2G42Cx9ec4ItVzjZEoatN+pg2wJg3S6eBht7dQMI+6UbkKigLziOoD3FmF6ug==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@google-cloud/dlp": "^4.1.0",
+        "lodash": "^4.17.21"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -14598,6 +15475,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/resedit": {
@@ -14710,6 +15597,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.2.tgz",
+      "integrity": "sha512-wfI3pk7EE80lCIXprqh7ym48IHYdwmAAzESdbU8Q9l7pnRCk9LEhpbOTNKjz6FARLm/Bl5m+4F0ABxOkYUujSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/reusify": {
@@ -15836,6 +16737,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -16391,6 +17299,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -17069,6 +17984,26 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/uiohook-napi": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/uiohook-napi/-/uiohook-napi-1.5.4.tgz",
@@ -17100,6 +18035,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.28.0",
@@ -18036,6 +18978,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -18302,6 +19262,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eval-summaries": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/eval-summaries.ts",
     "eval-tasks": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/eval-tasks.ts",
     "eval-cluster-review": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/eval-cluster-review.ts",
+    "eval-pii-scrub": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/eval-pii-scrub.ts",
     "dump-review-input": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/dump-review-input.ts",
     "export-day": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/export-day.ts",
     "build-task-fixture": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/build-task-fixture.ts",
@@ -65,6 +66,7 @@
   },
   "license": "GPL-3.0-or-later",
   "devDependencies": {
+    "@coffeeandfun/remove-pii": "^3.0.1",
     "@electron/notarize": "^3.1.1",
     "@tailwindcss/vite": "^4.1.18",
     "@types/better-sqlite3": "^7.6.13",
@@ -88,6 +90,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
+    "redact-pii": "^3.4.0",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.19.0",
     "typescript": "~5.7.0",

--- a/scripts/eval-pii-scrub.ts
+++ b/scripts/eval-pii-scrub.ts
@@ -1,0 +1,728 @@
+#!/usr/bin/env npx tsx
+/**
+ * DEU-205 PII scrubber bake-off: recall per category, false positives on clean
+ * controls, and latency for each candidate stack (regex libs, NER models,
+ * layered combos). Optionally replays a real dev-DB day for FP realism.
+ *
+ * Usage:
+ *   npm run eval-pii-scrub                              # full matrix on the fixture
+ *   npm run eval-pii-scrub -- --scrubber current,rampart
+ *   npm run eval-pii-scrub -- --dev-db-day 2026-07-03
+ *   npm run eval-pii-scrub -- --out evals/findings/pii-scrub-eval.md
+ *
+ * Reports with --dev-db-day contain real PII — write them to the private
+ * evals repo, never to findings/.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import Database from 'better-sqlite3'
+import { scrubPII } from '../src/shared/sanitize'
+import { getDefaultDbPath, getModelCacheDir } from '../src/main/utils/paths'
+import {
+  PII_PLANTS,
+  CLEAN_CONTROLS,
+  type PiiCategory,
+  type PiiPlant,
+} from '../src/main/eval/pii-fixture'
+
+const CATEGORIES: PiiCategory[] = [
+  'name',
+  'email',
+  'phone',
+  'address',
+  'ssn',
+  'dob',
+  'credit_card',
+  'bank',
+  'employee_id',
+  'username',
+  'password',
+  'secret',
+]
+
+const CATEGORY_LABELS: Record<PiiCategory, string> = {
+  name: 'name',
+  email: 'email',
+  phone: 'phone',
+  address: 'addr',
+  ssn: 'ssn',
+  dob: 'dob',
+  credit_card: 'card',
+  bank: 'bank',
+  employee_id: 'emp',
+  username: 'user',
+  password: 'pass',
+  secret: 'secret',
+}
+
+const NER_MODELS: Record<string, { id: string; dtype: string }> = {
+  rampart: { id: 'nationaldesignstudio/rampart', dtype: 'q4' },
+  piiranha: { id: 'onnx-community/piiranha-v1-detect-personal-information-ONNX', dtype: 'int8' },
+}
+
+const ALL_SCRUBBERS = [
+  'current',
+  'remove-pii',
+  'redact-pii',
+  'rampart',
+  'piiranha',
+  'rampart+current',
+  'piiranha+current',
+  'remove-pii+rampart',
+  'redact-pii+rampart',
+]
+
+const LABEL_PLACEHOLDERS: Record<string, string> = {
+  GIVENNAME: '[redacted name]',
+  SURNAME: '[redacted name]',
+  MIDDLENAME: '[redacted name]',
+  FIRSTNAME: '[redacted name]',
+  LASTNAME: '[redacted name]',
+  NAME: '[redacted name]',
+  PER: '[redacted name]',
+  PERSON: '[redacted name]',
+  EMAIL: '[email address]',
+  TELEPHONENUM: '[phone number]',
+  PHONENUMBER: '[phone number]',
+  PHONE: '[phone number]',
+  STREET: '[redacted address]',
+  STREETADDRESS: '[redacted address]',
+  BUILDINGNUM: '[redacted address]',
+  CITY: '[redacted address]',
+  STATE: '[redacted address]',
+  ZIPCODE: '[redacted address]',
+  POSTCODE: '[redacted address]',
+  SOCIALNUM: '[redacted personal id]',
+  SOCIALSECURITYNUMBER: '[redacted personal id]',
+  SSN: '[redacted personal id]',
+  IDCARDNUM: '[redacted personal id]',
+  DRIVERLICENSENUM: '[redacted personal id]',
+  DRIVERSLICENSE: '[redacted personal id]',
+  PASSPORTNUM: '[redacted personal id]',
+  PASSPORTNUMBER: '[redacted personal id]',
+  TAXNUM: '[redacted personal id]',
+  TAXID: '[redacted personal id]',
+  GOVERNMENTID: '[redacted personal id]',
+  NATIONALID: '[redacted personal id]',
+  CREDITCARDNUMBER: '[redacted payment card]',
+  CREDITCARD: '[redacted payment card]',
+  ACCOUNTNUM: '[redacted bank account]',
+  IBAN: '[redacted bank account]',
+  DATEOFBIRTH: '[redacted date of birth]',
+  DOB: '[redacted date of birth]',
+  USERNAME: '[redacted username]',
+  PASSWORD: '[redacted password]',
+  SECRET: '[redacted secret]',
+  APIKEY: '[redacted secret]',
+  TOKEN: '[redacted secret]',
+}
+
+const SKIP_TYPES = new Set(['URL'])
+
+interface Scrubber {
+  name: string
+  init(): Promise<void>
+  scrub(text: string): Promise<string>
+  loadMs: number
+  footprint(): string
+  unmappedLabels?: Set<string>
+}
+
+interface RawTok {
+  entity: string
+  score: number
+  index: number
+  word: string
+  start: number | null
+  end: number | null
+}
+
+interface Span {
+  start: number
+  end: number
+  type: string
+  score: number
+}
+
+const WINDOW_CHARS = 1800
+const WINDOW_OVERLAP = 200
+
+class NerScrubber implements Scrubber {
+  name: string
+  loadMs = 0
+  unmappedLabels = new Set<string>()
+  private modelId: string
+  private dtype: string
+  private threshold: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private pipe: any = null
+
+  constructor(name: string, modelId: string, dtype: string, threshold: number) {
+    this.name = name
+    this.modelId = modelId
+    this.dtype = dtype
+    this.threshold = threshold
+  }
+
+  async init(): Promise<void> {
+    if (this.pipe) return
+    const { pipeline, env } = await import('@huggingface/transformers')
+    env.cacheDir = getModelCacheDir()
+    const t0 = performance.now()
+    this.pipe = await pipeline('token-classification', this.modelId, { dtype: this.dtype })
+    this.loadMs = Math.round(performance.now() - t0)
+  }
+
+  footprint(): string {
+    const dir = path.join(getModelCacheDir(), ...this.modelId.split('/'))
+    const mb = dirSizeMb(dir)
+    return mb === null ? '?' : `${mb.toFixed(0)}MB model`
+  }
+
+  async scrub(text: string): Promise<string> {
+    const spans: Span[] = []
+    for (const { offset, slice } of windows(text)) {
+      const raw = (await this.pipe(slice)) as RawTok[]
+      for (const span of this.buildSpans(slice, raw)) {
+        spans.push({ ...span, start: span.start + offset, end: span.end + offset })
+      }
+    }
+    const kept = spans.filter((s) => !SKIP_TYPES.has(normalizeLabel(s.type)))
+    const resolved = mergeSpans(kept).map((s) => ({
+      ...s,
+      placeholder: this.placeholderFor(s.type),
+    }))
+    return replaceSpans(text, resolved)
+  }
+
+  private placeholderFor(type: string): string {
+    const norm = normalizeLabel(type)
+    const mapped = LABEL_PLACEHOLDERS[norm]
+    if (mapped) return mapped
+    this.unmappedLabels.add(type)
+    return `[redacted ${norm.toLowerCase()}]`
+  }
+
+  private buildSpans(text: string, toks: RawTok[]): Span[] {
+    const lower = text.toLowerCase()
+    const spans: Span[] = []
+    let cur: (Span & { lastIndex: number }) | null = null
+    let cursor = 0
+
+    for (const tok of toks) {
+      if (tok.score < this.threshold) continue
+      const type = tok.entity.replace(/^[BI]-/, '')
+      let start = typeof tok.start === 'number' ? tok.start : null
+      let end = typeof tok.end === 'number' ? tok.end : null
+      if (start === null || end === null) {
+        const located = locateToken(lower, cursor, tok.word)
+        if (!located) continue
+        start = located.start
+        end = located.end
+      }
+      cursor = Math.max(cursor, end)
+
+      if (cur && cur.type === type && tok.index === cur.lastIndex + 1) {
+        cur.end = Math.max(cur.end, end)
+        cur.score = Math.max(cur.score, tok.score)
+        cur.lastIndex = tok.index
+      } else {
+        if (cur) spans.push({ start: cur.start, end: cur.end, type: cur.type, score: cur.score })
+        cur = { start, end, type, score: tok.score, lastIndex: tok.index }
+      }
+    }
+    if (cur) spans.push({ start: cur.start, end: cur.end, type: cur.type, score: cur.score })
+    return spans
+  }
+}
+
+function normalizeLabel(type: string): string {
+  return type.toUpperCase().replace(/[^A-Z]/g, '')
+}
+
+function locateToken(
+  lowerText: string,
+  cursor: number,
+  word: string,
+): { start: number; end: number } | null {
+  const piece = word.replace(/^##/, '').replace(/▁/g, ' ').trim().toLowerCase()
+  if (!piece) return null
+  const at = lowerText.indexOf(piece, cursor)
+  if (at === -1) return null
+  return { start: at, end: at + piece.length }
+}
+
+function* windows(text: string): Generator<{ offset: number; slice: string }> {
+  if (text.length <= WINDOW_CHARS) {
+    yield { offset: 0, slice: text }
+    return
+  }
+  let offset = 0
+  while (offset < text.length) {
+    yield { offset, slice: text.slice(offset, offset + WINDOW_CHARS) }
+    if (offset + WINDOW_CHARS >= text.length) break
+    offset += WINDOW_CHARS - WINDOW_OVERLAP
+  }
+}
+
+function mergeSpans(spans: Span[]): Span[] {
+  const sorted = [...spans].sort((a, b) => a.start - b.start || b.end - a.end)
+  const merged: Span[] = []
+  for (const span of sorted) {
+    const last = merged[merged.length - 1]
+    if (last && span.start < last.end) {
+      last.end = Math.max(last.end, span.end)
+      if (span.score > last.score) last.type = span.type
+    } else {
+      merged.push({ ...span })
+    }
+  }
+  return merged
+}
+
+function replaceSpans(text: string, spans: (Span & { placeholder: string })[]): string {
+  let out = text
+  for (const span of [...spans].sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, span.start) + span.placeholder + out.slice(span.end)
+  }
+  return out
+}
+
+function makeSimpleScrubber(
+  name: string,
+  load: () => Promise<(text: string) => string>,
+  footprint: () => string,
+): Scrubber {
+  let fn: ((text: string) => string) | null = null
+  const scrubber: Scrubber = {
+    name,
+    loadMs: 0,
+    async init() {
+      if (fn) return
+      const t0 = performance.now()
+      fn = await load()
+      scrubber.loadMs = Math.round(performance.now() - t0)
+    },
+    async scrub(text: string) {
+      if (!fn) throw new Error(`${name} not initialized`)
+      return fn(text)
+    },
+    footprint,
+  }
+  return scrubber
+}
+
+function pkgFootprint(pkgs: string[]): string {
+  const total = pkgs
+    .map((p) => dirSizeMb(path.resolve('node_modules', p)) ?? 0)
+    .reduce((a, b) => a + b, 0)
+  return `${total.toFixed(1)}MB deps`
+}
+
+function dirSizeMb(dir: string): number | null {
+  if (!fs.existsSync(dir)) return null
+  let bytes = 0
+  const stack = [dir]
+  while (stack.length) {
+    const cur = stack.pop() as string
+    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+      const full = path.join(cur, entry.name)
+      if (entry.isDirectory()) stack.push(full)
+      else if (entry.isFile()) bytes += fs.statSync(full).size
+    }
+  }
+  return bytes / 1024 / 1024
+}
+
+class ChainScrubber implements Scrubber {
+  name: string
+  private parts: Scrubber[]
+
+  constructor(name: string, parts: Scrubber[]) {
+    this.name = name
+    this.parts = parts
+  }
+
+  get loadMs(): number {
+    return this.parts.reduce((a, p) => a + p.loadMs, 0)
+  }
+
+  async init(): Promise<void> {
+    for (const p of this.parts) await p.init()
+  }
+
+  async scrub(text: string): Promise<string> {
+    let out = text
+    for (const p of this.parts) out = await p.scrub(out)
+    return out
+  }
+
+  footprint(): string {
+    return this.parts.map((p) => p.footprint()).join(' + ')
+  }
+}
+
+function buildScrubber(spec: string, threshold: number, cache: Map<string, Scrubber>): Scrubber {
+  const parts = spec.split('+')
+  if (parts.length > 1) {
+    return new ChainScrubber(
+      spec,
+      parts.map((p) => buildScrubber(p, threshold, cache)),
+    )
+  }
+  const existing = cache.get(spec)
+  if (existing) return existing
+
+  const [base, thrStr] = spec.split('@')
+  let scrubber: Scrubber
+  if (spec === 'current') {
+    scrubber = makeSimpleScrubber(
+      'current',
+      async () => scrubPII,
+      () => '0MB (built-in)',
+    )
+  } else if (spec === 'remove-pii') {
+    scrubber = makeSimpleScrubber(
+      'remove-pii',
+      async () => {
+        const mod = await import('@coffeeandfun/remove-pii')
+        return (text: string) => mod.removePII(text)
+      },
+      () => pkgFootprint(['@coffeeandfun/remove-pii']),
+    )
+  } else if (spec === 'redact-pii') {
+    scrubber = makeSimpleScrubber(
+      'redact-pii',
+      async () => {
+        const mod = await import('redact-pii')
+        const redactor = new mod.SyncRedactor()
+        return (text: string) => redactor.redact(text)
+      },
+      () => pkgFootprint(['redact-pii', '@google-cloud/dlp', 'lodash']),
+    )
+  } else if (NER_MODELS[base]) {
+    const m = NER_MODELS[base]
+    scrubber = new NerScrubber(spec, m.id, m.dtype, thrStr ? parseFloat(thrStr) : threshold)
+  } else {
+    throw new Error(`Unknown scrubber "${spec}". Known: ${ALL_SCRUBBERS.join(', ')}`)
+  }
+  cache.set(spec, scrubber)
+  return scrubber
+}
+
+const normalizeForLeak = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+function leaked(output: string, pii: string): boolean {
+  const normOut = normalizeForLeak(output)
+  const normPii = normalizeForLeak(pii)
+  const window = Math.min(12, normPii.length)
+  for (let i = 0; i + window <= normPii.length; i++) {
+    if (normOut.includes(normPii.slice(i, i + window))) return true
+  }
+  return false
+}
+
+interface CategoryResult {
+  caught: number
+  total: number
+  missed: PiiPlant[]
+}
+
+interface FixtureResult {
+  name: string
+  byCategory: Record<PiiCategory, CategoryResult>
+  caughtTotal: number
+  plantTotal: number
+  falsePositives: { id: string; kind: string; before: string; after: string }[]
+  msPerText: number
+  loadMs: number
+  footprint: string
+  unmappedLabels: string[]
+}
+
+async function runOnFixture(scrubber: Scrubber): Promise<FixtureResult> {
+  const byCategory = {} as Record<PiiCategory, CategoryResult>
+  for (const c of CATEGORIES) byCategory[c] = { caught: 0, total: 0, missed: [] }
+
+  const t0 = performance.now()
+  for (const p of PII_PLANTS) {
+    const out = await scrubber.scrub(p.text)
+    byCategory[p.category].total++
+    if (leaked(out, p.pii)) byCategory[p.category].missed.push(p)
+    else byCategory[p.category].caught++
+  }
+
+  const falsePositives: FixtureResult['falsePositives'] = []
+  for (const c of CLEAN_CONTROLS) {
+    const out = await scrubber.scrub(c.text)
+    if (out !== c.text) falsePositives.push({ id: c.id, kind: c.kind, before: c.text, after: out })
+  }
+  const elapsed = performance.now() - t0
+
+  const caughtTotal = CATEGORIES.reduce((a, c) => a + byCategory[c].caught, 0)
+  return {
+    name: scrubber.name,
+    byCategory,
+    caughtTotal,
+    plantTotal: PII_PLANTS.length,
+    falsePositives,
+    msPerText: elapsed / (PII_PLANTS.length + CLEAN_CONTROLS.length),
+    loadMs: scrubber.loadMs,
+    footprint: scrubber.footprint(),
+    unmappedLabels: [...(scrubber.unmappedLabels ?? [])],
+  }
+}
+
+interface DbResult {
+  name: string
+  altered: number
+  total: number
+  samples: { before: string; after: string }[]
+}
+
+async function runOnDbTexts(scrubber: Scrubber, texts: string[]): Promise<DbResult> {
+  let altered = 0
+  const samples: DbResult['samples'] = []
+  for (const text of texts) {
+    const out = await scrubber.scrub(text)
+    if (out !== text) {
+      altered++
+      if (samples.length < 12) samples.push(diffSample(text, out))
+    }
+  }
+  return { name: scrubber.name, altered, total: texts.length, samples }
+}
+
+function diffSample(before: string, after: string): { before: string; after: string } {
+  let i = 0
+  while (i < before.length && i < after.length && before[i] === after[i]) i++
+  const from = Math.max(0, i - 40)
+  const clip = (s: string): string =>
+    (from > 0 ? '…' : '') +
+    s.slice(from, from + 120).replace(/\n/g, '⏎ ') +
+    (s.length > from + 120 ? '…' : '')
+  return { before: clip(before), after: clip(after) }
+}
+
+function loadDayTexts(dbPath: string, day: string, includeOcr: boolean, cap: number): string[] {
+  const start = new Date(`${day}T00:00:00`).getTime()
+  const end = start + 24 * 60 * 60 * 1000
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true })
+  try {
+    const rows = db
+      .prepare(
+        'SELECT window_title, summary, ocr_text FROM activities WHERE start_timestamp >= ? AND start_timestamp < ?',
+      )
+      .all(start, end) as { window_title: string; summary: string; ocr_text: string }[]
+    const texts = new Set<string>()
+    for (const r of rows) {
+      if (r.window_title?.trim()) texts.add(r.window_title)
+      if (r.summary?.trim()) texts.add(r.summary)
+      if (includeOcr && r.ocr_text?.trim()) texts.add(r.ocr_text.slice(0, 6000))
+    }
+    return [...texts].slice(0, cap)
+  } finally {
+    db.close()
+  }
+}
+
+interface CliArgs {
+  scrubbers: string[]
+  threshold: number
+  devDbDay: string | null
+  dbPath: string
+  includeOcr: boolean
+  out: string | null
+  maxDbTexts: number
+}
+
+function parseArgs(): CliArgs {
+  const args = process.argv.slice(2)
+  const a: CliArgs = {
+    scrubbers: ALL_SCRUBBERS,
+    threshold: 0.5,
+    devDbDay: null,
+    dbPath: getDefaultDbPath(),
+    includeOcr: false,
+    out: null,
+    maxDbTexts: 400,
+  }
+  for (let i = 0; i < args.length; i++) {
+    const next = args[i + 1]
+    switch (args[i]) {
+      case '--scrubber':
+        if (next) {
+          a.scrubbers = next === 'all' ? ALL_SCRUBBERS : next.split(',')
+          i++
+        }
+        break
+      case '--threshold':
+        if (next) {
+          a.threshold = parseFloat(next)
+          i++
+        }
+        break
+      case '--dev-db-day':
+        if (next) {
+          a.devDbDay = next
+          i++
+        }
+        break
+      case '--db-path':
+        if (next) {
+          a.dbPath = path.resolve(next)
+          i++
+        }
+        break
+      case '--include-ocr':
+        a.includeOcr = true
+        break
+      case '--max-db-texts':
+        if (next) {
+          a.maxDbTexts = parseInt(next, 10)
+          i++
+        }
+        break
+      case '--out':
+        if (next) {
+          a.out = path.resolve(next)
+          i++
+        }
+        break
+      default:
+        console.error(`Unknown argument: ${args[i]}`)
+        process.exit(1)
+    }
+  }
+  return a
+}
+
+function renderReport(results: FixtureResult[], dbResults: DbResult[], args: CliArgs): string {
+  const lines: string[] = []
+  lines.push('## Recall per category (caught/planted)')
+  lines.push('')
+  const header = [
+    'scrubber',
+    ...CATEGORIES.map((c) => CATEGORY_LABELS[c]),
+    'total',
+    'FP',
+    'ms/text',
+  ]
+  lines.push(`| ${header.join(' | ')} |`)
+  lines.push(`|${header.map(() => '---').join('|')}|`)
+  for (const r of results) {
+    const cells = CATEGORIES.map((c) => {
+      const { caught, total } = r.byCategory[c]
+      return caught === total ? `**${caught}/${total}**` : `${caught}/${total}`
+    })
+    lines.push(
+      `| ${r.name} | ${cells.join(' | ')} | ${r.caughtTotal}/${r.plantTotal} | ${r.falsePositives.length} | ${r.msPerText.toFixed(1)} |`,
+    )
+  }
+  lines.push('')
+
+  lines.push('## Load time and footprint')
+  lines.push('')
+  lines.push('| scrubber | load ms | footprint |')
+  lines.push('|---|---|---|')
+  for (const r of results) lines.push(`| ${r.name} | ${r.loadMs} | ${r.footprint} |`)
+  lines.push('')
+
+  const withFps = results.filter((r) => r.falsePositives.length > 0)
+  if (withFps.length) {
+    lines.push('## False positives on clean controls')
+    lines.push('')
+    for (const r of withFps) {
+      lines.push(`### ${r.name} (${r.falsePositives.length})`)
+      lines.push('')
+      for (const fp of r.falsePositives) {
+        lines.push(`- \`${fp.id}\` (${fp.kind}): \`${fp.before}\` → \`${fp.after}\``)
+      }
+      lines.push('')
+    }
+  }
+
+  const withMisses = results.filter((r) => r.caughtTotal < r.plantTotal)
+  if (withMisses.length) {
+    lines.push('## Missed plants')
+    lines.push('')
+    for (const r of withMisses) {
+      const missed = CATEGORIES.flatMap((c) => r.byCategory[c].missed)
+      lines.push(`### ${r.name} (${missed.length})`)
+      lines.push('')
+      lines.push(missed.map((m) => `\`${m.id}\``).join(', '))
+      lines.push('')
+    }
+  }
+
+  const withUnmapped = results.filter((r) => r.unmappedLabels.length > 0)
+  if (withUnmapped.length) {
+    lines.push('## Unmapped NER labels seen')
+    lines.push('')
+    for (const r of withUnmapped) lines.push(`- ${r.name}: ${r.unmappedLabels.join(', ')}`)
+    lines.push('')
+  }
+
+  if (dbResults.length) {
+    lines.push(
+      `## Dev-DB day ${args.devDbDay} (${dbResults[0]?.total} texts, no ground truth — eyeball TP vs FP)`,
+    )
+    lines.push('')
+    lines.push('| scrubber | altered |')
+    lines.push('|---|---|')
+    for (const r of dbResults) lines.push(`| ${r.name} | ${r.altered}/${r.total} |`)
+    lines.push('')
+    for (const r of dbResults) {
+      if (!r.samples.length) continue
+      lines.push(`### ${r.name} samples`)
+      lines.push('')
+      for (const s of r.samples) {
+        lines.push(`- \`${s.before}\``)
+        lines.push(`  → \`${s.after}\``)
+      }
+      lines.push('')
+    }
+  }
+
+  return lines.join('\n')
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs()
+  const cache = new Map<string, Scrubber>()
+  const results: FixtureResult[] = []
+  const dbResults: DbResult[] = []
+
+  let dbTexts: string[] = []
+  if (args.devDbDay) {
+    dbTexts = loadDayTexts(args.dbPath, args.devDbDay, args.includeOcr, args.maxDbTexts)
+    console.log(`Loaded ${dbTexts.length} texts from ${args.devDbDay} (${args.dbPath})`)
+  }
+
+  for (const spec of args.scrubbers) {
+    const scrubber = buildScrubber(spec, args.threshold, cache)
+    process.stdout.write(`[${spec}] init… `)
+    await scrubber.init()
+    process.stdout.write(`${scrubber.loadMs}ms. fixture… `)
+    results.push(await runOnFixture(scrubber))
+    if (dbTexts.length) {
+      process.stdout.write('dev-db… ')
+      dbResults.push(await runOnDbTexts(scrubber, dbTexts))
+    }
+    console.log('done')
+  }
+
+  const report = renderReport(results, dbResults, args)
+  console.log('')
+  console.log(report)
+  if (args.out) {
+    fs.writeFileSync(args.out, report + '\n', 'utf8')
+    console.log(`\nWritten to ${args.out}`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/main/eval/pii-fixture.ts
+++ b/src/main/eval/pii-fixture.ts
@@ -1,0 +1,613 @@
+/**
+ * Synthetic PII eval fixture (DEU-205). Planted values are fictional or public
+ * test data (555-01xx phones, test card numbers, AWS docs keys). Every `pii`
+ * string must be gone from a scrubber's output; every control must survive
+ * unchanged. Secret-shaped strings are concatenated so push protection and
+ * secret scanners don't flag the repo.
+ */
+
+export type PiiCategory =
+  | 'name'
+  | 'email'
+  | 'phone'
+  | 'address'
+  | 'ssn'
+  | 'dob'
+  | 'credit_card'
+  | 'bank'
+  | 'employee_id'
+  | 'username'
+  | 'password'
+  | 'secret'
+
+export type TextShape = 'window_title' | 'summary' | 'ocr'
+
+export interface PiiPlant {
+  id: string
+  category: PiiCategory
+  shape: TextShape
+  text: string
+  pii: string
+}
+
+export interface CleanControl {
+  id: string
+  kind: string
+  text: string
+}
+
+const OPENAI_KEY = 'sk-' + 'proj-Ab3dEfGh1jKlMnOpQrStUvWxYz0123456789AbCd'
+const GH_TOKEN = 'ghp_' + 'x7Q9rT2mNv4bL8cJ5wY1zA3eD6fH0iKwPqRs'
+const GH_PAT = 'github_pat_' + '11AABBCCD0x9Y8z7W6v5U4t3S2r1Q0pOnMlKjIhGfEdCbA98765'
+const AWS_KEY_ID = 'AKIA' + 'IOSFODNN7EXAMPLE'
+const AWS_SECRET = 'wJalrXUtnFEMI/K7MDENG/' + 'bPxRfiCYEXAMPLEKEY'
+const JWT =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+  'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.' +
+  'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+
+function plant(
+  id: string,
+  category: PiiCategory,
+  shape: TextShape,
+  text: string,
+  pii: string,
+): PiiPlant {
+  return { id, category, shape, text, pii }
+}
+
+export const PII_PLANTS: PiiPlant[] = [
+  plant(
+    'name-01',
+    'name',
+    'window_title',
+    '1:1 with Marcus Delgado - Google Meet',
+    'Marcus Delgado',
+  ),
+  plant(
+    'name-02',
+    'name',
+    'window_title',
+    'Re: Offer letter — Angela Whitfield - Outlook',
+    'Angela Whitfield',
+  ),
+  plant(
+    'name-03',
+    'name',
+    'window_title',
+    'Patient: Dorothy Simmons | Chart Review - Epic',
+    'Dorothy Simmons',
+  ),
+  plant(
+    'name-04',
+    'name',
+    'summary',
+    'Drafted a performance review for Samuel Adeyemi in Workday, focusing on Q2 goals and peer feedback.',
+    'Samuel Adeyemi',
+  ),
+  plant(
+    'name-05',
+    'name',
+    'ocr',
+    'Candidate Name: Priya Raghunathan\nPosition: Senior Analyst\nStage: Onsite',
+    'Priya Raghunathan',
+  ),
+  plant('name-06', 'name', 'window_title', 'Slack | DM with Grace Liu', 'Grace Liu'),
+  plant(
+    'name-07',
+    'name',
+    'window_title',
+    'Tamara Jenkins-Cole — LinkedIn Profile',
+    'Tamara Jenkins-Cole',
+  ),
+  plant(
+    'name-08',
+    'name',
+    'summary',
+    'Called Luis Fernando Ortega about the Q3 renewal and updated the opportunity stage in Salesforce.',
+    'Luis Fernando Ortega',
+  ),
+  plant(
+    'name-09',
+    'name',
+    'summary',
+    "Worked through Rachel Goldberg's onboarding checklist in Asana and assigned the IT provisioning subtasks.",
+    'Rachel Goldberg',
+  ),
+  plant(
+    'name-10',
+    'name',
+    'ocr',
+    'Interviewer: Kevin O’Brien\nPanel: Engineering\nRoom: 4B',
+    'Kevin O’Brien',
+  ),
+  plant(
+    'name-11',
+    'name',
+    'ocr',
+    'Approved by: Whitney Castellanos\nDate: pending\nDepartment: Finance',
+    'Whitney Castellanos',
+  ),
+  plant(
+    'name-12',
+    'name',
+    'summary',
+    'Reviewed the escalation from Deshawn Mitchell about a delayed refund and drafted a response in Zendesk.',
+    'Deshawn Mitchell',
+  ),
+
+  plant(
+    'email-01',
+    'email',
+    'window_title',
+    'Inbox (14) - rgoldberg@corporatemail.com - Outlook',
+    'rgoldberg@corporatemail.com',
+  ),
+  plant(
+    'email-02',
+    'email',
+    'summary',
+    'Sent the revised contract to angela.whitfield@gmail.com and CCed the legal alias.',
+    'angela.whitfield@gmail.com',
+  ),
+  plant(
+    'email-03',
+    'email',
+    'ocr',
+    'From: marcus.delgado1987@yahoo.com\nSubject: Re: invoice dispute',
+    'marcus.delgado1987@yahoo.com',
+  ),
+  plant(
+    'email-04',
+    'email',
+    'ocr',
+    'Contact\nEmail: d.simmons@outlook.com\nPreferred: email',
+    'd.simmons@outlook.com',
+  ),
+  plant(
+    'email-05',
+    'email',
+    'summary',
+    'Forwarded the benefits enrollment form to priya.r@acmehealth.org for signature.',
+    'priya.r@acmehealth.org',
+  ),
+  plant(
+    'email-06',
+    'email',
+    'window_title',
+    'Compose: kevin.obrien@umich.edu - Gmail',
+    'kevin.obrien@umich.edu',
+  ),
+  plant(
+    'email-07',
+    'email',
+    'ocr',
+    'Login\nEmail address\ntgreene91@protonmail.com\nContinue',
+    'tgreene91@protonmail.com',
+  ),
+  plant(
+    'email-08',
+    'email',
+    'summary',
+    'Added grace.liu+vendor@fastmail.com to the supplier contact list in NetSuite.',
+    'grace.liu+vendor@fastmail.com',
+  ),
+  plant(
+    'email-09',
+    'email',
+    'ocr',
+    'Reply-To: luis.ortega@sunbeltlogistics.com\nSent: Monday 9:14 AM',
+    'luis.ortega@sunbeltlogistics.com',
+  ),
+  plant(
+    'email-10',
+    'email',
+    'window_title',
+    'Password reset for dwhite.home@icloud.com - Mail',
+    'dwhite.home@icloud.com',
+  ),
+
+  plant(
+    'phone-01',
+    'phone',
+    'summary',
+    'Called the client back at (415) 555-0173 to confirm the delivery window.',
+    '(415) 555-0173',
+  ),
+  plant(
+    'phone-02',
+    'phone',
+    'ocr',
+    'Customer callback\nPhone: 415-555-0198\nPriority: high',
+    '415-555-0198',
+  ),
+  plant('phone-03', 'phone', 'ocr', 'Mobile: 415.555.0142\nWork: n/a', '415.555.0142'),
+  plant(
+    'phone-04',
+    'phone',
+    'summary',
+    'Texted +1 (202) 555-0161 about rescheduling the site visit.',
+    '+1 (202) 555-0161',
+  ),
+  plant(
+    'phone-05',
+    'phone',
+    'ocr',
+    'Emergency contact\n202-555-0117\nRelation: spouse',
+    '202-555-0117',
+  ),
+  plant('phone-06', 'phone', 'ocr', 'Tel 6505550109\nFax none', '6505550109'),
+  plant(
+    'phone-07',
+    'phone',
+    'summary',
+    'Left a voicemail at +1 650 555 0129 regarding the overdue invoice.',
+    '+1 650 555 0129',
+  ),
+  plant(
+    'phone-08',
+    'phone',
+    'window_title',
+    'Missed call from (312) 555-0186 - Teams',
+    '(312) 555-0186',
+  ),
+  plant(
+    'phone-09',
+    'phone',
+    'ocr',
+    'Verify your number\nWe sent a code to 917-555-0134',
+    '917-555-0134',
+  ),
+  plant(
+    'phone-10',
+    'phone',
+    'summary',
+    'Updated the CRM record with the new direct line 646 555 0151 for the buyer.',
+    '646 555 0151',
+  ),
+
+  plant(
+    'addr-01',
+    'address',
+    'ocr',
+    'Ship to:\n1847 Maplewood Ave\nColumbus, OH 43215',
+    '1847 Maplewood Ave',
+  ),
+  plant(
+    'addr-02',
+    'address',
+    'summary',
+    'Updated the delivery address to 742 Evergreen Terrace, Springfield, IL 62704 in the order system.',
+    '742 Evergreen Terrace',
+  ),
+  plant(
+    'addr-03',
+    'address',
+    'ocr',
+    'Billing address\n98 Bleecker St Apt 4B\nNew York, NY 10012',
+    '98 Bleecker St Apt 4B',
+  ),
+  plant(
+    'addr-04',
+    'address',
+    'summary',
+    'Scheduled the inspection at 5501 Rosewood Drive, Plano, TX 75024 for Thursday morning.',
+    '5501 Rosewood Drive',
+  ),
+  plant('addr-05', 'address', 'ocr', 'Mailing: PO Box 1123, Reno, NV 89501', 'PO Box 1123'),
+  plant(
+    'addr-06',
+    'address',
+    'summary',
+    'Booked the client meeting at 330 W 42nd St, 15th floor, and sent calendar invites.',
+    '330 W 42nd St',
+  ),
+  plant(
+    'addr-07',
+    'address',
+    'ocr',
+    'Deliver to: 2214 Harborview Ln, Tampa, FL 33602\nLeave at door',
+    '2214 Harborview Ln',
+  ),
+  plant(
+    'addr-08',
+    'address',
+    'ocr',
+    'Home address\n6 Birchwood Ct\nBellevue, WA 98004',
+    '6 Birchwood Ct',
+  ),
+  plant(
+    'addr-09',
+    'address',
+    'summary',
+    'Corrected the W-2 mailing address to 1930 Alder Grove Blvd, Sacramento, CA 95815.',
+    '1930 Alder Grove Blvd',
+  ),
+  plant(
+    'addr-10',
+    'address',
+    'window_title',
+    '4406 Sunnybrook Rd, Austin, TX 78745 - Zillow',
+    '4406 Sunnybrook Rd',
+  ),
+
+  plant(
+    'ssn-01',
+    'ssn',
+    'ocr',
+    'Applicant SSN: 416-72-8395\nStatus: pending verification',
+    '416-72-8395',
+  ),
+  plant('ssn-02', 'ssn', 'ocr', 'Social Security Number\n545-86-2194\nConfirm', '545-86-2194'),
+  plant(
+    'ssn-03',
+    'ssn',
+    'summary',
+    'Entered the SSN 217-40-9068 into the payroll onboarding form for the new hire.',
+    '217-40-9068',
+  ),
+  plant('ssn-04', 'ssn', 'ocr', 'SSN: 078-05-1120\nDOB: on file', '078-05-1120'),
+  plant('ssn-05', 'ssn', 'ocr', 'Taxpayer ID (SSN) 362518377', '362518377'),
+  plant(
+    'ssn-06',
+    'ssn',
+    'summary',
+    'Verified the last four of the SSN 545862194 against the benefits record.',
+    '545862194',
+  ),
+  plant('ssn-07', 'ssn', 'ocr', 'SSN 416 72 8395\nSignature required', '416 72 8395'),
+  plant('ssn-08', 'ssn', 'window_title', 'W-9 Form - SSN 217-40-9068 - Preview', '217-40-9068'),
+
+  plant('dob-01', 'dob', 'ocr', 'Date of Birth: 03/14/1987\nGender: F', '03/14/1987'),
+  plant('dob-02', 'dob', 'ocr', 'DOB\n1987-03-14\nMember since 2019', '1987-03-14'),
+  plant(
+    'dob-03',
+    'dob',
+    'summary',
+    'Corrected the patient date of birth to June 12, 1979 in the intake record.',
+    'June 12, 1979',
+  ),
+  plant('dob-04', 'dob', 'ocr', 'Born: 11/02/1962\nPlace: Ohio', '11/02/1962'),
+  plant(
+    'dob-05',
+    'dob',
+    'summary',
+    'Confirmed the dependent DOB 07/04/1991 while updating the insurance enrollment.',
+    '07/04/1991',
+  ),
+  plant(
+    'dob-06',
+    'dob',
+    'ocr',
+    'Passenger details\nDate of birth 09/23/1975\nSeat 14C',
+    '09/23/1975',
+  ),
+
+  plant(
+    'cc-01',
+    'credit_card',
+    'ocr',
+    'Card number\n4111 1111 1111 1111\nExp 09/28',
+    '4111 1111 1111 1111',
+  ),
+  plant(
+    'cc-02',
+    'credit_card',
+    'ocr',
+    'Payment method\n4012888888881881\nVisa',
+    '4012888888881881',
+  ),
+  plant(
+    'cc-03',
+    'credit_card',
+    'ocr',
+    'Card: 5555-5555-5555-4444\nCVV: ***',
+    '5555-5555-5555-4444',
+  ),
+  plant(
+    'cc-04',
+    'credit_card',
+    'summary',
+    'Charged the deposit to the card 5105105105105100 after confirming the amount with the guest.',
+    '5105105105105100',
+  ),
+  plant('cc-05', 'credit_card', 'ocr', 'AMEX ending\n378282246310005', '378282246310005'),
+  plant(
+    'cc-06',
+    'credit_card',
+    'ocr',
+    'Corporate Amex\n3714 496353 98431\nActive',
+    '3714 496353 98431',
+  ),
+  plant('cc-07', 'credit_card', 'ocr', 'Discover 6011111111111117\nAutopay on', '6011111111111117'),
+  plant(
+    'cc-08',
+    'credit_card',
+    'summary',
+    'Updated the card on file to 6011 0009 9013 9424 for the recurring subscription.',
+    '6011 0009 9013 9424',
+  ),
+  plant('cc-09', 'credit_card', 'ocr', 'Visa 4222222222222\nExpired', '4222222222222'),
+  plant(
+    'cc-10',
+    'credit_card',
+    'window_title',
+    'Refund card 5200 8282 8282 8210 - Stripe Dashboard',
+    '5200 8282 8282 8210',
+  ),
+
+  plant('bank-01', 'bank', 'ocr', 'Routing number: 021000021\nAccount type: checking', '021000021'),
+  plant('bank-02', 'bank', 'ocr', 'ABA 026009593\nWire instructions', '026009593'),
+  plant(
+    'bank-03',
+    'bank',
+    'summary',
+    'Set up direct deposit with routing 121000358 and confirmed the first payment date.',
+    '121000358',
+  ),
+  plant('bank-04', 'bank', 'ocr', 'Routing: 121042882\nAccount: on file', '121042882'),
+  plant('bank-05', 'bank', 'ocr', 'Account number\n4830112957\nSavings', '4830112957'),
+  plant(
+    'bank-06',
+    'bank',
+    'summary',
+    'Entered the beneficiary account number 00812734655 for the vendor payout.',
+    '00812734655',
+  ),
+  plant(
+    'bank-07',
+    'bank',
+    'ocr',
+    'IBAN GB82WEST12345698765432\nSWIFT on request',
+    'GB82WEST12345698765432',
+  ),
+
+  plant('emp-01', 'employee_id', 'ocr', 'Employee ID: EMP-04481\nDepartment: Ops', 'EMP-04481'),
+  plant('emp-02', 'employee_id', 'ocr', 'Badge #88213\nAccess level 2', '88213'),
+  plant(
+    'emp-03',
+    'employee_id',
+    'summary',
+    'Looked up employee ID 7734902 in Workday to correct the cost center assignment.',
+    '7734902',
+  ),
+  plant('emp-04', 'employee_id', 'ocr', 'Emp No. E-118245\nShift: night', 'E-118245'),
+  plant('emp-05', 'employee_id', 'ocr', 'Worker ID 00482913\nContractor', '00482913'),
+  plant('emp-06', 'employee_id', 'window_title', 'Timesheet — EMP-04481 - ADP', 'EMP-04481'),
+
+  plant('user-01', 'username', 'ocr', 'Username: jsmith84\nRemember me', 'jsmith84'),
+  plant('user-02', 'username', 'ocr', 'Login\nmrivera22\nForgot username?', 'mrivera22'),
+  plant(
+    'user-03',
+    'username',
+    'summary',
+    'Reset the account for the username dwhite_admin after the lockout was reported.',
+    'dwhite_admin',
+  ),
+  plant('user-04', 'username', 'ocr', 'Signed in as tgreene91', 'tgreene91'),
+  plant(
+    'user-05',
+    'username',
+    'summary',
+    'Granted repo access to the user kpatel-dev and confirmed the invitation was accepted.',
+    'kpatel-dev',
+  ),
+  plant('user-06', 'username', 'ocr', 'User ID\ncjohnson_ops\nNext', 'cjohnson_ops'),
+
+  plant('pass-01', 'password', 'ocr', 'Password: Tr0ub4dor&3\nSign in', 'Tr0ub4dor&3'),
+  plant(
+    'pass-02',
+    'password',
+    'ocr',
+    'Temporary password\nSumm3r!2026\nChange on first login',
+    'Summ3r!2026',
+  ),
+  plant('pass-03', 'password', 'ocr', 'pass: hunter2!\nlogin: admin', 'hunter2!'),
+  plant(
+    'pass-04',
+    'password',
+    'summary',
+    'Shared the temporary password P@ssw0rd123 with the contractor over Slack before the rotation.',
+    'P@ssw0rd123',
+  ),
+  plant('pass-05', 'password', 'ocr', 'Wi-Fi password: Xk9#mQ2$vL', 'Xk9#mQ2$vL'),
+  plant(
+    'pass-06',
+    'password',
+    'ocr',
+    'New password\nBlueHorizon#77\nConfirm password\nBlueHorizon#77',
+    'BlueHorizon#77',
+  ),
+
+  plant('secret-01', 'secret', 'ocr', `OPENAI_API_KEY=${OPENAI_KEY}`, OPENAI_KEY),
+  plant('secret-02', 'secret', 'ocr', `export GITHUB_TOKEN=${GH_TOKEN}`, GH_TOKEN),
+  plant(
+    'secret-03',
+    'secret',
+    'summary',
+    `Rotated the fine-grained token ${GH_PAT} in the deploy workflow secrets.`,
+    GH_PAT,
+  ),
+  plant(
+    'secret-04',
+    'secret',
+    'ocr',
+    `aws_access_key_id = ${AWS_KEY_ID}\nregion = us-east-1`,
+    AWS_KEY_ID,
+  ),
+  plant('secret-05', 'secret', 'ocr', `aws_secret_access_key = ${AWS_SECRET}`, AWS_SECRET),
+  plant('secret-06', 'secret', 'ocr', `Authorization: Bearer ${JWT}`, JWT),
+  plant(
+    'secret-07',
+    'secret',
+    'summary',
+    `Pasted the API key ${OPENAI_KEY} into the staging environment config during the integration test.`,
+    OPENAI_KEY,
+  ),
+  plant(
+    'secret-08',
+    'secret',
+    'window_title',
+    `${GH_TOKEN} - Search results - 1Password`,
+    GH_TOKEN,
+  ),
+]
+
+function control(id: string, kind: string, text: string): CleanControl {
+  return { id, kind, text }
+}
+
+export const CLEAN_CONTROLS: CleanControl[] = [
+  control('date-01', 'date', 'Sprint review 07/24/2026 - Calendar'),
+  control('date-02', 'date', 'Deadline moved to 12/31/2026 per the revised SOW.'),
+  control('date-03', 'date', '2026-07-27 standup notes - Notion'),
+  control('date-04', 'date', 'Compared the 2024-2025 archive against the current fiscal year.'),
+  control('date-05', 'date', 'Q3 2026 roadmap draft - Google Slides'),
+  control('money-01', 'money', 'Budget approved at $250,000 for the pilot rollout.'),
+  control('money-02', 'money', 'Revenue target $1,000,000 ARR - Board deck'),
+  control('money-03', 'money', 'Processed 1,250,000 rows in the nightly ETL job.'),
+  control('money-04', 'money', 'Invoice total 84 250 USD after the volume discount.'),
+  control('version-01', 'version', 'v1.5.4-alpha.1 release notes - GitHub'),
+  control('version-02', 'version', 'Upgraded the runtime to node 22.14.0 across all services.'),
+  control('version-03', 'version', 'electron 40.9.2 changelog review'),
+  control('version-04', 'version', 'Pinned typescript 5.7.3 in the monorepo.'),
+  control('ipv4-01', 'ipv4', 'ssh deploy@192.168.1.100 failed with a timeout.'),
+  control('ipv4-02', 'ipv4', 'curl http://10.0.0.5:8080/health returned 200.'),
+  control('ipv4-03', 'ipv4', 'Switched the resolver to 8.8.8.8 while debugging DNS.'),
+  control('uuid-01', 'uuid', 'activity 550e8400-e29b-41d4-a716-446655440000 missing embedding'),
+  control(
+    'uuid-02',
+    'uuid',
+    'GET /api/clusters/3f2a9c81-77de-4b02-9e41-c05a12ef88a3 returned 404.',
+  ),
+  control('sha-01', 'sha', 'git checkout a1b2c3d4e5f6 to bisect the regression'),
+  control('sha-02', 'sha', 'Cherry-picked commit 8dffde5 onto the release branch.'),
+  control('order-01', 'order', 'Invoice INV-2026-0148 sent to the client portal.'),
+  control('order-02', 'order', 'Order #112-9384756-1029384 shipped - Amazon'),
+  control('order-03', 'order', 'UPS tracking 1Z999AA10123456784 out for delivery'),
+  control('order-04', 'order', 'PO 4500012877 pending approval in SAP.'),
+  control('ticket-01', 'ticket', 'Fix login flow (#4821) - Pull Request'),
+  control('ticket-02', 'ticket', 'DEU-205 add PII filtering - Linear'),
+  control('ticket-03', 'ticket', 'Merged PR #243 after the second review pass.'),
+  control('ticket-04', 'ticket', 'JIRA OPS-11842: rotate the staging certificates'),
+  control('path-01', 'path', 'src/main/utils/paths.ts:104 - Visual Studio Code'),
+  control(
+    'path-02',
+    'path',
+    'Opened https://github.com/acme/platform/pull/247/files in the browser.',
+  ),
+  control('timestamp-01', 'timestamp', 'Build finished at 14:05:33 after 212 seconds.'),
+  control('timestamp-02', 'timestamp', 'Cron fired at 2026-07-27T09:15:00Z as scheduled.'),
+  control('count-01', 'count', 'Processed 48213 activities during the backfill.'),
+  control('count-02', 'count', 'The table now holds 1048576 rows after the import.'),
+  control('count-03', 'count', 'Benchmark completed 100000 iterations in 4.2s.'),
+  control('zip-01', 'zip', 'Warehouse coverage map for ZIP 43215 - Tableau'),
+  control('room-01', 'misc', 'Room 4155 reserved for the offsite workshop.'),
+  control('ext-01', 'misc', 'Reach the desk at ext. 8842 during business hours.'),
+  control('port-01', 'misc', 'The dev server listens on localhost:5173 by default.'),
+  control('hex-01', 'misc', 'Trace id 7f3c9a2b1d8e4f60 logged at warn level.'),
+  control('math-01', 'misc', 'Split the dataset 80/20 for the holdout evaluation.'),
+  control('phone-like-01', 'misc', 'Error code 0x80070005 during the update rollback.'),
+  control('title-01', 'misc', 'Quarterly business review agenda - Google Docs'),
+  control('title-02', 'misc', 'Untitled spreadsheet - Google Sheets'),
+]


### PR DESCRIPTION
First of the DEU-205 PR series — the evaluation that decides the PII scrub stack before anything ships to egress paths.

## What's here

- `src/main/eval/pii-fixture.ts` — synthetic US-focused fixture: 99 planted PII values across 12 categories (names, emails, US phones, addresses, SSN, DOB, Luhn-valid cards, ABA routing, employee IDs, usernames, passwords, API keys/JWTs) in realistic window-title/summary/OCR shapes, plus 45 clean controls that must survive (dates, versions, UUIDs, SHAs, counts, order numbers…). All values fictional or public test data; secret-shaped strings concatenated so scanners don't flag the repo.
- `scripts/eval-pii-scrub.ts` (`npm run eval-pii-scrub`) — matrix runner: existing `scrubPII`, `@coffeeandfun/remove-pii`, `redact-pii`, Rampart (14MB q4), Piiranha (318MB int8), layered combos, `name@threshold` variants. Reports recall per category, control FPs, ms/text, footprint; optional `--dev-db-day` pass over a real day's titles/summaries. NER runs via plain transformers.js `token-classification` with span reconstruction (models return null char offsets).
- Full results + decision live in the private evals repo (`memorylane-evals` `findings/pii-scrub-eval.md`) — the dev-DB sample section contains real titles/summaries.

## Decision

**Rampart NER + extended `scrubPII` backstop; no regex lib.**

| stack | recall | control FPs |
|---|---|---|
| current `scrubPII` | 51/99 | 10 |
| remove-pii | 61/99 | 12 |
| redact-pii | 83/99 | 24 |
| piiranha (0.2–0.5) | 30–32/99 | 3 |
| rampart | 78/99 | 22 |
| **rampart+current** | **84/99** | 23 |

- Rampart gets what regex can't: names 12/12, addresses 10/10, most usernames/passwords — at 14MB / ~3ms/text CPU. Piiranha loses on every axis.
- Both regex libs are out: remove-pii's gains come from nuking every date; redact-pii FPs on all digit runs and product names ("Claude" → PERSON_NAME) and hard-depends on `@google-cloud/dlp`. They stay devDependencies for the eval only.
- No candidate catches API keys/JWTs (0–2/8) → our own `[redacted secret]` class is mandatory (step 2).
- Step-2/4 guidance recorded in findings: PHONE_LIKE guard for timestamp filenames, labeled-DOB/password context regexes, NER type policy + device-local app-name allowlist for the two FP classes threshold tuning can't fix.

## Testing

- `npm test` (1242 passed), `npm run typecheck`, lint clean
- Full matrix run on fixture + dev-DB day 2026-07-03 (report in the private evals repo)

Part of DEU-205 (plan: eval → scrub+egress seams → login gate → NER productionization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
