### PR TITLE
fix(scripts): don't abort onnxruntime teardown when an enode run is interrupted

### DIFF
--- a/scripts/enode.js
+++ b/scripts/enode.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { spawn } = require('node:child_process')
+const path = require('node:path')
 
 const args = process.argv.slice(2)
 
@@ -11,13 +12,24 @@ if (args.length === 0) {
 
 const electronPath = require('electron')
 
+// Via NODE_OPTIONS rather than a --require flag so it also reaches the process
+// tsx spawns for the script itself.
+const exitOnSignal = `--require ${path.join(__dirname, 'exit-on-signal.cjs')}`
+
 const child = spawn(electronPath, args, {
   stdio: 'inherit',
   env: {
     ...process.env,
     ELECTRON_RUN_AS_NODE: '1',
+    NODE_OPTIONS: process.env.NODE_OPTIONS
+      ? `${process.env.NODE_OPTIONS} ${exitOnSignal}`
+      : exitOnSignal,
   },
 })
+
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(signal, () => child.kill('SIGKILL'))
+}
 
 child.on('error', (error) => {
   console.error(`[enode] Failed to start Electron runtime: ${error.message}`)

--- a/scripts/exit-on-signal.cjs
+++ b/scripts/exit-on-signal.cjs
@@ -1,0 +1,6 @@
+// Interrupting a script that has loaded onnxruntime aborts (SIGABRT) in the C++
+// static destructors, which files a macOS crash report for what is just a
+// cancelled run. SIGKILL skips that teardown entirely.
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(signal, () => process.kill(process.pid, 'SIGKILL'))
+}


### PR DESCRIPTION
Cancelling an `enode` script that has loaded onnxruntime — `eval-tasks`, `mine-tasks`, `db-search` — files a macOS crash report:

```
EXC_CRASH (SIGABRT) · abort() called
node::Exit → exit() → __cxa_finalize_ranges → std::terminate → abort
```

The work is already done at that point; the process just dies dirty on the way out. ORT's thread pool is still parked in `condition_variable::wait` when C++ static destructors run, and the teardown aborts.

Two crash reports showed up during a task-mining eval session today, both landing exactly on kill moments (a stash/branch switch and a wrapper shell being killed) — never on runs that completed.

## Change

- `scripts/exit-on-signal.cjs` — on SIGINT/SIGTERM/SIGHUP, `SIGKILL` self, skipping static teardown.
- `scripts/enode.js` — inject it via `NODE_OPTIONS` rather than a `--require` flag, because tsx spawns a second process for the script and only `NODE_OPTIONS` is inherited by it. Also kills the child on those signals instead of orphaning it.

## Verification

Probe: load the embedding model, embed in a loop, `SIGTERM` mid-run, count new reports in `~/Library/Logs/DiagnosticReports`.

| Case | Before | After |
|---|---|---|
| kill the script process | new crash report | none |
| kill the enode wrapper | child orphaned, crashes later | none, child reaped |
| normal completion | clean | clean |

`npm test` — 122 files / 1253 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)