### PR TITLE
Retire Gemini 2.5 from the baked model defaults

### DIFF
--- a/src/main/semantic/constants.ts
+++ b/src/main/semantic/constants.ts
@@ -60,6 +60,10 @@ export const MODEL_PRICING_USD_PER_MILLION: Record<
     input_tokens_per_million: 0.3,
     completion_tokens_per_million: 2.5,
   },
+  'google/gemini-3.5-flash': {
+    input_tokens_per_million: 1.5,
+    completion_tokens_per_million: 9,
+  },
   'moonshotai/kimi-k3': {
     input_tokens_per_million: 3,
     completion_tokens_per_million: 15,

--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -13,7 +13,7 @@ export interface ModelPreset {
  * are authoritative — an upgrade replaces stale/retired ids rather than
  * stranding a seat on them.
  */
-export const MODEL_DEFAULTS_VERSION = 2
+export const MODEL_DEFAULTS_VERSION = 3
 
 export interface VendorPresets {
   /** Presets for each model slot. The first entry is the vendor's default. */
@@ -40,19 +40,18 @@ interface VendorModelDefaults {
 export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
   openrouter: {
     // GA ids only — preview ids resolve on Google AI Studio but 404 on
-    // Vertex-pinned (ZDR) keys, and are the class that gets retired. All four
-    // verified available under the ZDR OpenRouter key (2026-07-10), ordered by
-    // cost-efficiency: gemini-3.1-flash-lite (~60 tok/frame, $0.25/M) heads it;
-    // gemini-2.5-flash is the quality-max floor.
+    // Vertex-pinned (ZDR) keys, and are the class that gets retired. Gemini 2.5
+    // is discontinued on Vertex 2026-10-20. Ordered by cost-efficiency:
+    // gemini-3.1-flash-lite (~60 tok/frame, $0.25/M) heads it;
+    // gemini-3.5-flash is the quality-max floor.
     semanticVideo: [
       { id: 'google/gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
-      { id: 'google/gemini-3-flash-preview', label: 'Gemini 3 Flash' },
-      { id: 'google/gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
-      { id: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+      { id: 'google/gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite' },
+      { id: 'google/gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
     ],
     semanticSnapshot: [
       { id: 'mistralai/mistral-small-3.2-24b-instruct', label: 'Mistral Small 3.2' },
-      { id: 'google/gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
+      { id: 'google/gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite' },
     ],
     // Task-miner models, ordered by the 2026-07-03 sweep
     // (findings/task-mining-benchmark.md); first entry is the default and heads
@@ -60,18 +59,18 @@ export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
     // (tencent/hy3-preview, 78% @ $0.006) is deliberately excluded because it
     // has NO ZDR endpoints on OpenRouter and fails under a zero-data-retention
     // key policy. minimax-m3 won on recall (84% @ ~$0.04/day); mimo-v2.5 is the
-    // value pick (82% @ $0.015); gemini-2.5-flash is the reliable lower-recall
-    // fallback (the previous default).
+    // value pick (82% @ $0.015); gemini-3.5-flash is the reliable lower-recall
+    // fallback (succeeds the retired gemini-2.5-flash).
     patternDetection: [
       { id: 'minimax/minimax-m3', label: 'MiniMax M3' },
       { id: 'xiaomi/mimo-v2.5', label: 'MiMo V2.5' },
-      { id: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+      { id: 'google/gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
     ],
   },
   google: {
-    semanticVideo: [{ id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' }],
-    semanticSnapshot: [{ id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' }],
-    patternDetection: [{ id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' }],
+    semanticVideo: [{ id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite' }],
+    semanticSnapshot: [{ id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite' }],
+    patternDetection: [{ id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite' }],
   },
   // Local OpenAI-compatible endpoints (Ollama, LM Studio, vLLM) ship no
   // defaults — the user's local catalog varies per machine, so any preset

--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -39,11 +39,7 @@ interface VendorModelDefaults {
  */
 export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
   openrouter: {
-    // GA ids only — preview ids resolve on Google AI Studio but 404 on
-    // Vertex-pinned (ZDR) keys, and are the class that gets retired. Gemini 2.5
-    // is discontinued on Vertex 2026-10-20. Ordered by cost-efficiency:
-    // gemini-3.1-flash-lite (~60 tok/frame, $0.25/M) heads it;
-    // gemini-3.5-flash is the quality-max floor.
+    // GA ids only, ordered by cost-efficiency.
     semanticVideo: [
       { id: 'google/gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
       { id: 'google/gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite' },
@@ -53,14 +49,7 @@ export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
       { id: 'mistralai/mistral-small-3.2-24b-instruct', label: 'Mistral Small 3.2' },
       { id: 'google/gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite' },
     ],
-    // Task-miner models, ordered by the 2026-07-03 sweep
-    // (findings/task-mining-benchmark.md); first entry is the default and heads
-    // the fallback chain. ZDR-capable models only — the sweep's cheapest option
-    // (tencent/hy3-preview, 78% @ $0.006) is deliberately excluded because it
-    // has NO ZDR endpoints on OpenRouter and fails under a zero-data-retention
-    // key policy. minimax-m3 won on recall (84% @ ~$0.04/day); mimo-v2.5 is the
-    // value pick (82% @ $0.015); gemini-3.5-flash is the reliable lower-recall
-    // fallback (succeeds the retired gemini-2.5-flash).
+    // ZDR-capable only, ordered by findings/task-mining-benchmark.md.
     patternDetection: [
       { id: 'minimax/minimax-m3', label: 'MiniMax M3' },
       { id: 'xiaomi/mimo-v2.5', label: 'MiMo V2.5' },

--- a/src/shared/vendor-defaults.ts
+++ b/src/shared/vendor-defaults.ts
@@ -42,6 +42,7 @@ export const VENDOR_PRESETS: Record<Vendor, VendorPresets> = {
     // GA ids only, ordered by cost-efficiency.
     semanticVideo: [
       { id: 'google/gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
+      { id: 'google/gemini-3-flash-preview', label: 'Gemini 3 Flash' },
       { id: 'google/gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite' },
       { id: 'google/gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
     ],


### PR DESCRIPTION
Google discontinues Gemini 2.5 Flash Lite / Flash / Pro on **Vertex AI endpoints on 2026-10-20**.

**This repo is the one surface with a real deadline.** `VENDOR_PRESETS.google` was bare `gemini-2.5-flash` ×3 — precisely what gets retired — and non-managed / BYOK installs never poll the remote model config, so no server-side push would have rescued them.

## What changed

**`src/shared/vendor-defaults.ts`**

| row / slot | before | after |
| --- | --- | --- |
| `google` (Vertex) — all three slots | **`gemini-2.5-flash`** | **`gemini-3.5-flash-lite`** |
| `openrouter.semanticVideo` | `3.1-flash-lite` → `3-flash-preview` → **`2.5-flash-lite`** → **`2.5-flash`** | `3.1-flash-lite` → `3-flash-preview` → **`3.5-flash-lite`** → **`3.5-flash`** |
| `openrouter.semanticSnapshot` | `mistral-small-3.2` → **`2.5-flash-lite`** | `mistral-small-3.2` → **`3.5-flash-lite`** |
| `openrouter.patternDetection` | `minimax-m3` → `mimo-v2.5` → **`2.5-flash`** | `minimax-m3` → `mimo-v2.5` → **`3.5-flash`** |

`gemini-3.5-flash-lite` for the Vertex row because it's GA on Vertex, on Google's own recommended-target list for 2.5 Flash, video-capable, and at `$0.30 / $2.50` an exact list-price match for the ID it replaces.

The `openrouter` row mirrors the backends' v2 chains. Only the retiring 2.5 ids move; chain lengths and ordering are otherwise untouched.

**`MODEL_DEFAULTS_VERSION` 2 → 3** — required, this is what overwrites remembered picks on existing installs. Without it, BYOK seats stay stranded on retired IDs.

**`src/main/semantic/constants.ts`** — adds `google/gemini-3.5-flash` to `MODEL_PRICING_USD_PER_MILLION` (`$1.50 / $9.00`). The new chains introduce it and the table had no entry, so every call that fell through to it would have silently reported **$0** in usage tracking. The 2.5 entries stay — historical usage rows still reference them.

The verbose preset comments are trimmed while we're in here.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- Model-related suites pass: `vendor-defaults`, `apply-models`, `model-settings`, `vendor-switch`, `capture-settings-manager`, `remote-model-config-store`, `activity-semantic-service`, `summary-reason`, `report`, `golden-md`
- Wider run matches `main` before and after. Remaining failures are pre-existing native-module issues (`better-sqlite3` built against `NODE_MODULE_VERSION 143`, runtime wants `147`) in `strip-database-for-upload`, `task-miner/*`, `cluster-view`, … — unrelated to this change.
- Every ID in the new `openrouter` presets confirmed present in the pricing table
- New IDs verified live on OpenRouter and video-capable (`text,image,video,file,audio`)

No test changes were needed: the suites derive expectations from `VENDOR_PRESETS` and `MODEL_DEFAULTS_VERSION` symbolically, and the `gemini-2.5-*` strings in `capture-settings-manager.test.ts` are arbitrary stored-pick fixtures rather than assertions about the defaults.

## Companion PRs

- `memorylane-enterprise-admin` — served config, `version` 1 → 2
- `memorylane-private` — same chains, kept in sync

> An earlier revision of this PR also dropped `google/gemini-3-flash-preview`, on the strength of this file's unverified "preview ids 404 on ZDR keys" claim plus a misreading of the device logs. That was wrong and has been reverted — see the correction comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)