### PR TITLE
Short id handles for the cluster review calls

### DIFF
--- a/src/main/llm/id-codec.test.ts
+++ b/src/main/llm/id-codec.test.ts
@@ -69,11 +69,11 @@ describe('PositionalAliases', () => {
     })
   })
 
-  it('separates an empty list from one that is not a list at all', () => {
+  it('reads an empty list as nothing lost and a non-list as one lost reference', () => {
     const aliases = new PositionalAliases('a')
     expect(aliases.decodeMany([])).toEqual({ ids: [], unmapped: 0 })
-    expect(aliases.decodeMany(undefined)).toBeNull()
-    expect(aliases.decodeMany('a1')).toBeNull()
-    expect(aliases.decodeMany({ a1: true })).toBeNull()
+    expect(aliases.decodeMany(undefined)).toEqual({ ids: [], unmapped: 1 })
+    expect(aliases.decodeMany('a1')).toEqual({ ids: [], unmapped: 1 })
+    expect(aliases.decodeMany({ a1: true })).toEqual({ ids: [], unmapped: 1 })
   })
 })

--- a/src/main/llm/id-codec.test.ts
+++ b/src/main/llm/id-codec.test.ts
@@ -69,9 +69,11 @@ describe('PositionalAliases', () => {
     })
   })
 
-  it('reports a non-array id list as unmapped instead of throwing', () => {
+  it('separates an empty list from one that is not a list at all', () => {
     const aliases = new PositionalAliases('a')
-    expect(aliases.decodeMany(undefined)).toEqual({ ids: [], unmapped: 1 })
-    expect(aliases.decodeMany({ a1: true } as never)).toEqual({ ids: [], unmapped: 1 })
+    expect(aliases.decodeMany([])).toEqual({ ids: [], unmapped: 0 })
+    expect(aliases.decodeMany(undefined)).toBeNull()
+    expect(aliases.decodeMany('a1')).toBeNull()
+    expect(aliases.decodeMany({ a1: true })).toBeNull()
   })
 })

--- a/src/main/llm/id-codec.test.ts
+++ b/src/main/llm/id-codec.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { PositionalAliases } from './id-codec'
+
+describe('PositionalAliases', () => {
+  it('numbers per prefix and mints on first encode', () => {
+    const aliases = new PositionalAliases()
+    expect(aliases.encode('c', 'cluster-uuid')).toBe('c1')
+    expect(aliases.encode('s', 'sighting-uuid')).toBe('s1')
+    expect(aliases.encode('c', 'other-cluster')).toBe('c2')
+  })
+
+  it('returns the same handle for a repeated id', () => {
+    const aliases = new PositionalAliases()
+    const first = aliases.encode('a', 'activity-uuid')
+    expect(aliases.encode('a', 'activity-uuid')).toBe(first)
+    expect(aliases.encode('a', 'another')).toBe('a2')
+  })
+
+  it('round-trips across prefixes without collision', () => {
+    const aliases = new PositionalAliases()
+    aliases.encode('c', 'cluster-uuid')
+    aliases.encode('s', 'sighting-uuid')
+    expect(aliases.decode('c1')).toBe('cluster-uuid')
+    expect(aliases.decode('s1')).toBe('sighting-uuid')
+  })
+
+  it('decodes unknown and malformed handles as undefined', () => {
+    const aliases = new PositionalAliases()
+    aliases.encode('c', 'cluster-uuid')
+    expect(aliases.decode('c2')).toBeUndefined()
+    expect(aliases.decode('nonsense')).toBeUndefined()
+    expect(aliases.decode('')).toBeUndefined()
+  })
+
+  it('tolerates surrounding whitespace on decode', () => {
+    const aliases = new PositionalAliases()
+    aliases.encode('a', 'activity-uuid')
+    expect(aliases.decode(' a1 ')).toBe('activity-uuid')
+  })
+
+  it('counts unmapped ids and keeps the order of those that resolved', () => {
+    const aliases = new PositionalAliases()
+    aliases.encode('a', 'first')
+    aliases.encode('a', 'second')
+    expect(aliases.decodeMany(['a2', 'a9', 'a1'])).toEqual({
+      ids: ['second', 'first'],
+      unmapped: 1,
+    })
+  })
+
+  it('exposes a prefix-bound IdCodec view over the same table', () => {
+    const aliases = new PositionalAliases()
+    const activities = aliases.namespace('a')
+    expect(activities.encode('activity-uuid')).toBe('a1')
+    expect(aliases.decode('a1')).toBe('activity-uuid')
+    expect(activities.decode('a1')).toBe('activity-uuid')
+  })
+})

--- a/src/main/llm/id-codec.test.ts
+++ b/src/main/llm/id-codec.test.ts
@@ -2,75 +2,76 @@ import { describe, it, expect } from 'vitest'
 import { PositionalAliases } from './id-codec'
 
 describe('PositionalAliases', () => {
-  it('numbers per prefix and mints on first encode', () => {
-    const aliases = new PositionalAliases()
-    expect(aliases.encode('c', 'cluster-uuid')).toBe('c1')
-    expect(aliases.encode('s', 'sighting-uuid')).toBe('s1')
-    expect(aliases.encode('c', 'other-cluster')).toBe('c2')
+  it('numbers from one and mints on first encode', () => {
+    const clusters = new PositionalAliases('c')
+    expect(clusters.encode('cluster-uuid')).toBe('c1')
+    expect(clusters.encode('other-cluster')).toBe('c2')
+  })
+
+  it('numbers independently per instance', () => {
+    const clusters = new PositionalAliases('c')
+    const sightings = new PositionalAliases('s')
+    expect(clusters.encode('cluster-uuid')).toBe('c1')
+    expect(sightings.encode('sighting-uuid')).toBe('s1')
+    expect(clusters.encode('other-cluster')).toBe('c2')
   })
 
   it('returns the same handle for a repeated id', () => {
-    const aliases = new PositionalAliases()
-    const first = aliases.encode('a', 'activity-uuid')
-    expect(aliases.encode('a', 'activity-uuid')).toBe(first)
-    expect(aliases.encode('a', 'another')).toBe('a2')
+    const aliases = new PositionalAliases('a')
+    const first = aliases.encode('activity-uuid')
+    expect(aliases.encode('activity-uuid')).toBe(first)
+    expect(aliases.encode('another')).toBe('a2')
   })
 
-  it('gives one id encoded under two prefixes a handle per prefix', () => {
-    const aliases = new PositionalAliases()
-    expect(aliases.encode('c', 'shared')).toBe('c1')
-    expect(aliases.encode('s', 'shared')).toBe('s1')
-    expect(aliases.decode('c', 'c1')).toBe('shared')
-    expect(aliases.decode('s', 's1')).toBe('shared')
+  it('gives one id encoded by two instances a handle per instance', () => {
+    const clusters = new PositionalAliases('c')
+    const sightings = new PositionalAliases('s')
+    expect(clusters.encode('shared')).toBe('c1')
+    expect(sightings.encode('shared')).toBe('s1')
+    expect(clusters.decode('c1')).toBe('shared')
+    expect(sightings.decode('s1')).toBe('shared')
   })
 
-  it('round-trips across prefixes without collision', () => {
-    const aliases = new PositionalAliases()
-    aliases.encode('c', 'cluster-uuid')
-    aliases.encode('s', 'sighting-uuid')
-    expect(aliases.decode('c', 'c1')).toBe('cluster-uuid')
-    expect(aliases.decode('s', 's1')).toBe('sighting-uuid')
-  })
-
-  it('refuses a handle minted under another prefix', () => {
-    const aliases = new PositionalAliases()
-    aliases.encode('c', 'cluster-uuid')
-    aliases.encode('s', 'sighting-uuid')
-    expect(aliases.decode('c', 's1')).toBeUndefined()
-    expect(aliases.decode('s', 'c1')).toBeUndefined()
+  it('refuses a handle minted by another instance', () => {
+    const clusters = new PositionalAliases('c')
+    const sightings = new PositionalAliases('s')
+    clusters.encode('cluster-uuid')
+    sightings.encode('sighting-uuid')
+    expect(clusters.decode('s1')).toBeUndefined()
+    expect(sightings.decode('c1')).toBeUndefined()
   })
 
   it('decodes unknown, malformed and non-string handles as undefined', () => {
-    const aliases = new PositionalAliases()
-    aliases.encode('c', 'cluster-uuid')
-    expect(aliases.decode('c', 'c2')).toBeUndefined()
-    expect(aliases.decode('c', 'nonsense')).toBeUndefined()
-    expect(aliases.decode('c', 'c1x')).toBeUndefined()
-    expect(aliases.decode('c', '')).toBeUndefined()
-    expect(aliases.decode('c', 1)).toBeUndefined()
-    expect(aliases.decode('c', undefined)).toBeUndefined()
-    expect(aliases.decode('c', { id: 'c1' })).toBeUndefined()
+    const aliases = new PositionalAliases('c')
+    aliases.encode('cluster-uuid')
+    expect(aliases.decode('c2')).toBeUndefined()
+    expect(aliases.decode('nonsense')).toBeUndefined()
+    expect(aliases.decode('c1x')).toBeUndefined()
+    expect(aliases.decode('')).toBeUndefined()
+    expect(aliases.decode(1)).toBeUndefined()
+    expect(aliases.decode(undefined)).toBeUndefined()
+    expect(aliases.decode({ id: 'c1' })).toBeUndefined()
   })
 
   it('tolerates surrounding whitespace on decode', () => {
-    const aliases = new PositionalAliases()
-    aliases.encode('a', 'activity-uuid')
-    expect(aliases.decode('a', ' a1 ')).toBe('activity-uuid')
+    const aliases = new PositionalAliases('a')
+    aliases.encode('activity-uuid')
+    expect(aliases.decode(' a1 ')).toBe('activity-uuid')
   })
 
   it('counts unmapped ids and keeps the order of those that resolved', () => {
-    const aliases = new PositionalAliases()
-    aliases.encode('a', 'first')
-    aliases.encode('a', 'second')
-    expect(aliases.decodeMany('a', ['a2', 'a9', 'a1', 7])).toEqual({
+    const aliases = new PositionalAliases('a')
+    aliases.encode('first')
+    aliases.encode('second')
+    expect(aliases.decodeMany(['a2', 'a9', 'a1', 7])).toEqual({
       ids: ['second', 'first'],
       unmapped: 2,
     })
   })
 
   it('reports a non-array id list as unmapped instead of throwing', () => {
-    const aliases = new PositionalAliases()
-    expect(aliases.decodeMany('a', undefined)).toEqual({ ids: [], unmapped: 1 })
-    expect(aliases.decodeMany('a', { a1: true } as never)).toEqual({ ids: [], unmapped: 1 })
+    const aliases = new PositionalAliases('a')
+    expect(aliases.decodeMany(undefined)).toEqual({ ids: [], unmapped: 1 })
+    expect(aliases.decodeMany({ a1: true } as never)).toEqual({ ids: [], unmapped: 1 })
   })
 })

--- a/src/main/llm/id-codec.test.ts
+++ b/src/main/llm/id-codec.test.ts
@@ -16,43 +16,61 @@ describe('PositionalAliases', () => {
     expect(aliases.encode('a', 'another')).toBe('a2')
   })
 
+  it('gives one id encoded under two prefixes a handle per prefix', () => {
+    const aliases = new PositionalAliases()
+    expect(aliases.encode('c', 'shared')).toBe('c1')
+    expect(aliases.encode('s', 'shared')).toBe('s1')
+    expect(aliases.decode('c', 'c1')).toBe('shared')
+    expect(aliases.decode('s', 's1')).toBe('shared')
+  })
+
   it('round-trips across prefixes without collision', () => {
     const aliases = new PositionalAliases()
     aliases.encode('c', 'cluster-uuid')
     aliases.encode('s', 'sighting-uuid')
-    expect(aliases.decode('c1')).toBe('cluster-uuid')
-    expect(aliases.decode('s1')).toBe('sighting-uuid')
+    expect(aliases.decode('c', 'c1')).toBe('cluster-uuid')
+    expect(aliases.decode('s', 's1')).toBe('sighting-uuid')
   })
 
-  it('decodes unknown and malformed handles as undefined', () => {
+  it('refuses a handle minted under another prefix', () => {
     const aliases = new PositionalAliases()
     aliases.encode('c', 'cluster-uuid')
-    expect(aliases.decode('c2')).toBeUndefined()
-    expect(aliases.decode('nonsense')).toBeUndefined()
-    expect(aliases.decode('')).toBeUndefined()
+    aliases.encode('s', 'sighting-uuid')
+    expect(aliases.decode('c', 's1')).toBeUndefined()
+    expect(aliases.decode('s', 'c1')).toBeUndefined()
+  })
+
+  it('decodes unknown, malformed and non-string handles as undefined', () => {
+    const aliases = new PositionalAliases()
+    aliases.encode('c', 'cluster-uuid')
+    expect(aliases.decode('c', 'c2')).toBeUndefined()
+    expect(aliases.decode('c', 'nonsense')).toBeUndefined()
+    expect(aliases.decode('c', 'c1x')).toBeUndefined()
+    expect(aliases.decode('c', '')).toBeUndefined()
+    expect(aliases.decode('c', 1)).toBeUndefined()
+    expect(aliases.decode('c', undefined)).toBeUndefined()
+    expect(aliases.decode('c', { id: 'c1' })).toBeUndefined()
   })
 
   it('tolerates surrounding whitespace on decode', () => {
     const aliases = new PositionalAliases()
     aliases.encode('a', 'activity-uuid')
-    expect(aliases.decode(' a1 ')).toBe('activity-uuid')
+    expect(aliases.decode('a', ' a1 ')).toBe('activity-uuid')
   })
 
   it('counts unmapped ids and keeps the order of those that resolved', () => {
     const aliases = new PositionalAliases()
     aliases.encode('a', 'first')
     aliases.encode('a', 'second')
-    expect(aliases.decodeMany(['a2', 'a9', 'a1'])).toEqual({
+    expect(aliases.decodeMany('a', ['a2', 'a9', 'a1', 7])).toEqual({
       ids: ['second', 'first'],
-      unmapped: 1,
+      unmapped: 2,
     })
   })
 
-  it('exposes a prefix-bound IdCodec view over the same table', () => {
+  it('reports a non-array id list as unmapped instead of throwing', () => {
     const aliases = new PositionalAliases()
-    const activities = aliases.namespace('a')
-    expect(activities.encode('activity-uuid')).toBe('a1')
-    expect(aliases.decode('a1')).toBe('activity-uuid')
-    expect(activities.decode('a1')).toBe('activity-uuid')
+    expect(aliases.decodeMany('a', undefined)).toEqual({ ids: [], unmapped: 1 })
+    expect(aliases.decodeMany('a', { a1: true } as never)).toEqual({ ids: [], unmapped: 1 })
   })
 })

--- a/src/main/llm/id-codec.ts
+++ b/src/main/llm/id-codec.ts
@@ -1,52 +1,38 @@
-/**
- * Short handles for the opaque ids we put in front of a model. Models mangle
- * long UUIDs when citing them back — dropping whole findings — and each one
- * costs 15-20 tokens against 2-3 for a handle.
- */
-export interface IdCodec {
-  encode(realId: string): string
-  decode(short: string): string | undefined
-}
+const HANDLE_SUFFIX = /^\d+$/
 
-/**
- * Request-scoped handles: `a1`, `c2`, `s37`. Numbering runs per prefix and
- * handles are minted on first encode, so a payload can carry several id kinds
- * and a caller can hand back an id the original snapshot never contained.
- *
- * Only usable where one payload's response comes back before the table is
- * discarded. A surface whose ids outlive the call (MCP) needs a stateless
- * IdCodec instead.
- */
 export class PositionalAliases {
   private readonly realOf = new Map<string, string>()
   private readonly shortOf = new Map<string, string>()
   private readonly counters = new Map<string, number>()
 
   encode(prefix: string, realId: string): string {
-    const existing = this.shortOf.get(realId)
+    const key = `${prefix} ${realId}`
+    const existing = this.shortOf.get(key)
     if (existing) return existing
     const next = (this.counters.get(prefix) ?? 0) + 1
     this.counters.set(prefix, next)
     const short = `${prefix}${next}`
-    this.shortOf.set(realId, short)
+    this.shortOf.set(key, short)
     this.realOf.set(short, realId)
     return short
   }
 
-  decode(short: string): string | undefined {
-    return this.realOf.get(short.trim())
+  decode(prefix: string, short: unknown): string | undefined {
+    if (typeof short !== 'string') return undefined
+    const trimmed = short.trim()
+    if (!trimmed.startsWith(prefix)) return undefined
+    if (!HANDLE_SUFFIX.test(trimmed.slice(prefix.length))) return undefined
+    return this.realOf.get(trimmed)
   }
 
-  decodeMany(shorts: readonly string[]): { ids: string[]; unmapped: number } {
-    const ids = shorts.map((s) => this.decode(s)).filter((id): id is string => id !== undefined)
+  decodeMany(
+    prefix: string,
+    shorts: readonly unknown[] | undefined,
+  ): { ids: string[]; unmapped: number } {
+    if (!Array.isArray(shorts)) return { ids: [], unmapped: 1 }
+    const ids = shorts
+      .map((short) => this.decode(prefix, short))
+      .filter((id): id is string => id !== undefined)
     return { ids, unmapped: shorts.length - ids.length }
-  }
-
-  /** A view bound to one prefix, for callers that deal in a single id kind. */
-  namespace(prefix: string): IdCodec {
-    return {
-      encode: (realId) => this.encode(prefix, realId),
-      decode: (short) => this.decode(short),
-    }
   }
 }

--- a/src/main/llm/id-codec.ts
+++ b/src/main/llm/id-codec.ts
@@ -19,8 +19,9 @@ export class PositionalAliases {
     return this.realOf.get(short.trim())
   }
 
-  decodeMany(shorts: readonly unknown[] | undefined): { ids: string[]; unmapped: number } {
-    if (!Array.isArray(shorts)) return { ids: [], unmapped: 1 }
+  /** null = not a list of handles at all, which is not the same as a list none of whose handles resolved. */
+  decodeMany(shorts: unknown): { ids: string[]; unmapped: number } | null {
+    if (!Array.isArray(shorts)) return null
     const ids = shorts
       .map((short) => this.decode(short))
       .filter((id): id is string => id !== undefined)

--- a/src/main/llm/id-codec.ts
+++ b/src/main/llm/id-codec.ts
@@ -1,37 +1,28 @@
-const HANDLE_SUFFIX = /^\d+$/
-
 export class PositionalAliases {
   private readonly realOf = new Map<string, string>()
   private readonly shortOf = new Map<string, string>()
-  private readonly counters = new Map<string, number>()
+  private counter = 0
 
-  encode(prefix: string, realId: string): string {
-    const key = `${prefix} ${realId}`
-    const existing = this.shortOf.get(key)
+  constructor(private readonly prefix: string) {}
+
+  encode(realId: string): string {
+    const existing = this.shortOf.get(realId)
     if (existing) return existing
-    const next = (this.counters.get(prefix) ?? 0) + 1
-    this.counters.set(prefix, next)
-    const short = `${prefix}${next}`
-    this.shortOf.set(key, short)
+    const short = `${this.prefix}${++this.counter}`
+    this.shortOf.set(realId, short)
     this.realOf.set(short, realId)
     return short
   }
 
-  decode(prefix: string, short: unknown): string | undefined {
+  decode(short: unknown): string | undefined {
     if (typeof short !== 'string') return undefined
-    const trimmed = short.trim()
-    if (!trimmed.startsWith(prefix)) return undefined
-    if (!HANDLE_SUFFIX.test(trimmed.slice(prefix.length))) return undefined
-    return this.realOf.get(trimmed)
+    return this.realOf.get(short.trim())
   }
 
-  decodeMany(
-    prefix: string,
-    shorts: readonly unknown[] | undefined,
-  ): { ids: string[]; unmapped: number } {
+  decodeMany(shorts: readonly unknown[] | undefined): { ids: string[]; unmapped: number } {
     if (!Array.isArray(shorts)) return { ids: [], unmapped: 1 }
     const ids = shorts
-      .map((short) => this.decode(prefix, short))
+      .map((short) => this.decode(short))
       .filter((id): id is string => id !== undefined)
     return { ids, unmapped: shorts.length - ids.length }
   }

--- a/src/main/llm/id-codec.ts
+++ b/src/main/llm/id-codec.ts
@@ -1,14 +1,13 @@
 export class PositionalAliases {
   private readonly realOf = new Map<string, string>()
   private readonly shortOf = new Map<string, string>()
-  private counter = 0
 
   constructor(private readonly prefix: string) {}
 
   encode(realId: string): string {
     const existing = this.shortOf.get(realId)
     if (existing) return existing
-    const short = `${this.prefix}${++this.counter}`
+    const short = `${this.prefix}${this.realOf.size + 1}`
     this.shortOf.set(realId, short)
     this.realOf.set(short, realId)
     return short
@@ -19,9 +18,8 @@ export class PositionalAliases {
     return this.realOf.get(short.trim())
   }
 
-  /** null = not a list of handles at all, which is not the same as a list none of whose handles resolved. */
-  decodeMany(shorts: unknown): { ids: string[]; unmapped: number } | null {
-    if (!Array.isArray(shorts)) return null
+  decodeMany(shorts: unknown): { ids: string[]; unmapped: number } {
+    if (!Array.isArray(shorts)) return { ids: [], unmapped: 1 }
     const ids = shorts
       .map((short) => this.decode(short))
       .filter((id): id is string => id !== undefined)

--- a/src/main/llm/id-codec.ts
+++ b/src/main/llm/id-codec.ts
@@ -1,0 +1,52 @@
+/**
+ * Short handles for the opaque ids we put in front of a model. Models mangle
+ * long UUIDs when citing them back — dropping whole findings — and each one
+ * costs 15-20 tokens against 2-3 for a handle.
+ */
+export interface IdCodec {
+  encode(realId: string): string
+  decode(short: string): string | undefined
+}
+
+/**
+ * Request-scoped handles: `a1`, `c2`, `s37`. Numbering runs per prefix and
+ * handles are minted on first encode, so a payload can carry several id kinds
+ * and a caller can hand back an id the original snapshot never contained.
+ *
+ * Only usable where one payload's response comes back before the table is
+ * discarded. A surface whose ids outlive the call (MCP) needs a stateless
+ * IdCodec instead.
+ */
+export class PositionalAliases {
+  private readonly realOf = new Map<string, string>()
+  private readonly shortOf = new Map<string, string>()
+  private readonly counters = new Map<string, number>()
+
+  encode(prefix: string, realId: string): string {
+    const existing = this.shortOf.get(realId)
+    if (existing) return existing
+    const next = (this.counters.get(prefix) ?? 0) + 1
+    this.counters.set(prefix, next)
+    const short = `${prefix}${next}`
+    this.shortOf.set(realId, short)
+    this.realOf.set(short, realId)
+    return short
+  }
+
+  decode(short: string): string | undefined {
+    return this.realOf.get(short.trim())
+  }
+
+  decodeMany(shorts: readonly string[]): { ids: string[]; unmapped: number } {
+    const ids = shorts.map((s) => this.decode(s)).filter((id): id is string => id !== undefined)
+    return { ids, unmapped: shorts.length - ids.length }
+  }
+
+  /** A view bound to one prefix, for callers that deal in a single id kind. */
+  namespace(prefix: string): IdCodec {
+    return {
+      encode: (realId) => this.encode(prefix, realId),
+      decode: (short) => this.decode(short),
+    }
+  }
+}

--- a/src/main/services/task-miner/clustering/apply-review.test.ts
+++ b/src/main/services/task-miner/clustering/apply-review.test.ts
@@ -237,6 +237,26 @@ describe('applyStructure', () => {
     expect(storage.clusters.getActiveMergeDeclines(0).size).toBe(0)
   })
 
+  it('applies readable merges but declines nothing when the merge list is incomplete', () => {
+    seedCluster('a', 100, ['s1'])
+    seedCluster('b', 200, ['s2'])
+    seedCluster('c', 300, ['s3'])
+
+    // One proposal was unreadable, so the absence of (a, c) is not a verdict.
+    const result = applyStructure(
+      storage,
+      { merges: [{ merge: ['a', 'b'] }], mergesComplete: false },
+      guards({
+        reviewableIds: new Set(['a', 'b', 'c']),
+        mergeCandidatePairs: new Set([mergePairKey('a', 'b'), mergePairKey('a', 'c')]),
+      }),
+      5000,
+    )
+
+    expect(result.merged).toBe(1)
+    expect(storage.clusters.getActiveMergeDeclines(0).size).toBe(0)
+  })
+
   it('declines nothing on a degenerate response without a merges array', () => {
     seedCluster('a', 100, ['s1'])
     seedCluster('b', 200, ['s2'])

--- a/src/main/services/task-miner/clustering/apply-review.test.ts
+++ b/src/main/services/task-miner/clustering/apply-review.test.ts
@@ -74,6 +74,7 @@ describe('applyStructure', () => {
     reviewableIds: overrides.reviewableIds ?? new Set(),
     splittableIds: overrides.splittableIds ?? new Set(),
     mergeCandidatePairs: overrides.mergeCandidatePairs ?? new Set(),
+    declinesInferable: overrides.declinesInferable ?? true,
   })
 
   it('merges candidate pairs into the oldest cluster regardless of LLM order', () => {
@@ -242,13 +243,13 @@ describe('applyStructure', () => {
     seedCluster('b', 200, ['s2'])
     seedCluster('c', 300, ['s3'])
 
-    // One proposal was unreadable, so the absence of (a, c) is not a verdict.
     const result = applyStructure(
       storage,
-      { merges: [{ merge: ['a', 'b'] }], mergesComplete: false },
+      { merges: [{ merge: ['a', 'b'] }] },
       guards({
         reviewableIds: new Set(['a', 'b', 'c']),
         mergeCandidatePairs: new Set([mergePairKey('a', 'b'), mergePairKey('a', 'c')]),
+        declinesInferable: false,
       }),
       5000,
     )

--- a/src/main/services/task-miner/clustering/apply-review.ts
+++ b/src/main/services/task-miner/clustering/apply-review.ts
@@ -23,6 +23,7 @@ export interface StructureGuards {
   splittableIds: Set<string>
   /** Merge candidate pairs as mergePairKey()s. */
   mergeCandidatePairs: Set<string>
+  declinesInferable: boolean
 }
 
 /**
@@ -126,11 +127,9 @@ export function applyStructure(
     // Candidate pairs the LLM saw and did not propose merging are declines.
     // Pairs it proposed but validation dropped are NOT — it said yes. The
     // prompt requires an explicit "merges" array even when empty; a response
-    // without one is degenerate and declines nothing, and one whose proposals
-    // were only partly readable (mergesComplete false) cannot be read as
-    // silence either. Pairs touching a just-deleted cluster are skipped so no
-    // rows reference dead ids.
-    if (Array.isArray(review.merges) && review.mergesComplete !== false) {
+    // without one is degenerate and declines nothing. Pairs touching a
+    // just-deleted cluster are skipped so no rows reference dead ids.
+    if (Array.isArray(review.merges) && guards.declinesInferable) {
       for (const key of guards.mergeCandidatePairs) {
         if (proposedPairs.has(key)) continue
         const [a, b] = key.split('|')

--- a/src/main/services/task-miner/clustering/apply-review.ts
+++ b/src/main/services/task-miner/clustering/apply-review.ts
@@ -126,9 +126,11 @@ export function applyStructure(
     // Candidate pairs the LLM saw and did not propose merging are declines.
     // Pairs it proposed but validation dropped are NOT — it said yes. The
     // prompt requires an explicit "merges" array even when empty; a response
-    // without one is degenerate and declines nothing. Pairs touching a
-    // just-deleted cluster are skipped so no rows reference dead ids.
-    if (Array.isArray(review.merges)) {
+    // without one is degenerate and declines nothing, and one whose proposals
+    // were only partly readable (mergesComplete false) cannot be read as
+    // silence either. Pairs touching a just-deleted cluster are skipped so no
+    // rows reference dead ids.
+    if (Array.isArray(review.merges) && review.mergesComplete !== false) {
       for (const key of guards.mergeCandidatePairs) {
         if (proposedPairs.has(key)) continue
         const [a, b] = key.split('|')

--- a/src/main/services/task-miner/clustering/id-alias.test.ts
+++ b/src/main/services/task-miner/clustering/id-alias.test.ts
@@ -91,6 +91,24 @@ describe('resolveReviewOutput', () => {
     expect(unresolved).toBe(1)
   })
 
+  it('drops both verdicts when two claim the same cluster', () => {
+    const { aliases } = aliasReviewInput(input)
+
+    const { output, unresolved } = resolveReviewOutput(
+      {
+        clusters: [
+          { id: 'c1', label: 'Process invoice' },
+          { id: 'c1', label: 'Reconcile payouts' },
+          { id: 'c2', label: 'Other' },
+        ],
+      },
+      aliases,
+    )
+
+    expect(output?.clusters).toEqual([{ id: UUID_B, label: 'Other', split: undefined }])
+    expect(unresolved).toBe(2)
+  })
+
   it('drops a verdict citing a sighting handle as its cluster id', () => {
     const { aliases } = aliasReviewInput(input)
 
@@ -124,41 +142,44 @@ describe('resolveReviewOutput', () => {
   it('drops only the unreadable merge proposal and marks the list incomplete', () => {
     const { aliases } = aliasReviewInput(input)
 
-    const { output, unresolved } = resolveReviewOutput(
+    const { output, unresolved, mergesIncomplete } = resolveReviewOutput(
       { clusters: [], merges: [{ merge: ['c1', 'c2'] }, { merge: ['c1', 'c7'] }] },
       aliases,
     )
 
     expect(output?.merges).toEqual([{ merge: [UUID_A, UUID_B] }])
-    expect(output?.mergesComplete).toBe(false)
+    expect(mergesIncomplete).toBe(true)
     expect(unresolved).toBe(1)
   })
 
   it('keeps the cluster verdicts when a merge proposal is dropped', () => {
     const { aliases } = aliasReviewInput(input)
 
-    const { output } = resolveReviewOutput(
+    const { output, mergesIncomplete } = resolveReviewOutput(
       { clusters: [{ id: 'c1', label: 'Process invoice' }], merges: [{ merge: ['c1', 'c7'] }] },
       aliases,
     )
 
     expect(output?.clusters).toEqual([{ id: UUID_A, label: 'Process invoice' }])
     expect(output?.merges).toEqual([])
-    expect(output?.mergesComplete).toBe(false)
+    expect(mergesIncomplete).toBe(true)
   })
 
   it('leaves a fully readable merge list complete', () => {
     const { aliases } = aliasReviewInput(input)
-    const { output } = resolveReviewOutput({ merges: [{ merge: ['c1', 'c2'] }] }, aliases)
+    const { output, mergesIncomplete } = resolveReviewOutput(
+      { merges: [{ merge: ['c1', 'c2'] }] },
+      aliases,
+    )
     expect(output?.merges).toEqual([{ merge: [UUID_A, UUID_B] }])
-    expect(output?.mergesComplete).toBeUndefined()
+    expect(mergesIncomplete).toBe(false)
   })
 
   it('keeps an empty merges array — it is a real answer that declines candidates', () => {
     const { aliases } = aliasReviewInput(input)
-    const { output } = resolveReviewOutput({ clusters: [], merges: [] }, aliases)
+    const { output, mergesIncomplete } = resolveReviewOutput({ clusters: [], merges: [] }, aliases)
     expect(output?.merges).toEqual([])
-    expect(output?.mergesComplete).toBeUndefined()
+    expect(mergesIncomplete).toBe(false)
   })
 
   it('leaves an absent merges key absent', () => {
@@ -182,7 +203,7 @@ describe('resolveReviewOutput', () => {
     expect(malformed({ clusters: {} }).output).toBeNull()
     expect(malformed({ merges: {} }).output).toBeNull()
     expect(malformed({ merges: ['c1'] }).output?.merges).toEqual([])
-    expect(malformed({ merges: ['c1'] }).output?.mergesComplete).toBe(false)
+    expect(malformed({ merges: ['c1'] }).mergesIncomplete).toBe(true)
     expect(malformed({ clusters: [null, 3, { id: 5 }] }).output?.clusters).toEqual([])
 
     const badSplit = malformed({ clusters: [{ id: 'c1', label: 'Keep', split: {} }] })

--- a/src/main/services/task-miner/clustering/id-alias.test.ts
+++ b/src/main/services/task-miner/clustering/id-alias.test.ts
@@ -60,7 +60,7 @@ describe('resolveReviewOutput', () => {
   it('round-trips verdicts, splits and merges back to real ids', () => {
     const { aliases } = aliasReviewInput(input)
 
-    const output = resolveReviewOutput(
+    const { output, unresolved } = resolveReviewOutput(
       {
         clusters: [
           { id: 'c1', label: 'Process invoice', split: [{ sighting_ids: ['s1'] }] },
@@ -71,28 +71,41 @@ describe('resolveReviewOutput', () => {
       aliases,
     )
 
-    expect(output.clusters?.[0].id).toBe(UUID_A)
-    expect(output.clusters?.[0].split).toEqual([{ sighting_ids: ['s-a1'] }])
-    expect(output.clusters?.[1].id).toBe(UUID_B)
-    expect(output.merges).toEqual([{ merge: [UUID_A, UUID_B] }])
+    expect(unresolved).toBe(0)
+    expect(output?.clusters?.[0].id).toBe(UUID_A)
+    expect(output?.clusters?.[0].split).toEqual([{ sighting_ids: ['s-a1'] }])
+    expect(output?.clusters?.[1].id).toBe(UUID_B)
+    expect(output?.merges).toEqual([{ merge: [UUID_A, UUID_B] }])
   })
 
   it('drops a verdict whose own id will not decode, keeping its siblings', () => {
     const { aliases } = aliasReviewInput(input)
 
-    const output = resolveReviewOutput(
+    const { output, unresolved } = resolveReviewOutput(
       { clusters: [{ id: 'c9', label: 'Invented' }, { id: 'c2' }] },
       aliases,
     )
 
-    expect(output.clusters).toHaveLength(1)
-    expect(output.clusters?.[0].id).toBe(UUID_B)
+    expect(output?.clusters).toHaveLength(1)
+    expect(output?.clusters?.[0].id).toBe(UUID_B)
+    expect(unresolved).toBe(1)
+  })
+
+  it('drops a verdict citing a sighting handle as its cluster id', () => {
+    const { aliases } = aliasReviewInput(input)
+
+    const { output } = resolveReviewOutput(
+      { clusters: [{ id: 's1', label: 'Wrong kind' }] },
+      aliases,
+    )
+
+    expect(output?.clusters).toEqual([])
   })
 
   it('drops undecodable sighting ids from a split, keeping the rest', () => {
     const { aliases } = aliasReviewInput(input)
 
-    const output = resolveReviewOutput(
+    const { output, unresolved } = resolveReviewOutput(
       {
         clusters: [
           { id: 'c1', split: [{ sighting_ids: ['s1', 's99'] }, { sighting_ids: ['s2'] }] },
@@ -101,28 +114,53 @@ describe('resolveReviewOutput', () => {
       aliases,
     )
 
-    expect(output.clusters?.[0].split).toEqual([
+    expect(output?.clusters?.[0].split).toEqual([
       { sighting_ids: ['s-a1'] },
       { sighting_ids: ['s-a2'] },
     ])
+    expect(unresolved).toBe(1)
   })
 
-  it('drops the merges key entirely when any id will not decode', () => {
+  it('rejects the whole response when a merge id will not decode', () => {
     const { aliases } = aliasReviewInput(input)
 
-    const output = resolveReviewOutput(
+    const { output } = resolveReviewOutput(
       { clusters: [], merges: [{ merge: ['c1', 'c2'] }, { merge: ['c1', 'c7'] }] },
       aliases,
     )
 
-    // Absent, not empty: applyStructure reads a missing "merges" as degenerate
-    // and declines nothing. An empty array would decline every candidate pair.
-    expect('merges' in output).toBe(false)
+    expect(output).toBeNull()
   })
 
   it('keeps an empty merges array — it is a real answer that declines candidates', () => {
     const { aliases } = aliasReviewInput(input)
-    const output = resolveReviewOutput({ clusters: [], merges: [] }, aliases)
-    expect(output.merges).toEqual([])
+    const { output } = resolveReviewOutput({ clusters: [], merges: [] }, aliases)
+    expect(output?.merges).toEqual([])
+  })
+
+  it('leaves an absent merges key absent', () => {
+    const { aliases } = aliasReviewInput(input)
+    const { output } = resolveReviewOutput({ clusters: [] }, aliases)
+    expect(output && 'merges' in output).toBe(false)
+  })
+
+  it('tolerates malformed shapes instead of throwing', () => {
+    const { aliases } = aliasReviewInput(input)
+    const malformed = (value: unknown) => resolveReviewOutput(value as never, aliases)
+
+    expect(malformed({ clusters: {} }).output).toBeNull()
+    expect(malformed({ merges: {} }).output).toBeNull()
+    expect(malformed({ merges: ['c1'] }).output).toBeNull()
+    expect(malformed({ clusters: [null, 3, { id: 5 }] }).output?.clusters).toEqual([])
+
+    const badSplit = malformed({ clusters: [{ id: 'c1', label: 'Keep', split: {} }] })
+    expect(badSplit.output?.clusters).toEqual([{ id: UUID_A, label: 'Keep' }])
+    expect(badSplit.unresolved).toBe(1)
+
+    const badGroup = malformed({ clusters: [{ id: 'c1', split: [{ sighting_ids: 's1' }, 4] }] })
+    expect(badGroup.output?.clusters?.[0].split).toEqual([
+      { sighting_ids: [] },
+      { sighting_ids: [] },
+    ])
   })
 })

--- a/src/main/services/task-miner/clustering/id-alias.test.ts
+++ b/src/main/services/task-miner/clustering/id-alias.test.ts
@@ -121,15 +121,28 @@ describe('resolveReviewOutput', () => {
     expect(unresolved).toBe(1)
   })
 
-  it('rejects the whole response when a merge id will not decode', () => {
+  it('drops the whole merges key when any merge id will not decode', () => {
     const { aliases } = aliasReviewInput(input)
 
-    const { output } = resolveReviewOutput(
+    const { output, unresolved } = resolveReviewOutput(
       { clusters: [], merges: [{ merge: ['c1', 'c2'] }, { merge: ['c1', 'c7'] }] },
       aliases,
     )
 
-    expect(output).toBeNull()
+    expect(output && 'merges' in output).toBe(false)
+    expect(unresolved).toBe(1)
+  })
+
+  it('keeps the cluster verdicts when the merges key is dropped', () => {
+    const { aliases } = aliasReviewInput(input)
+
+    const { output } = resolveReviewOutput(
+      { clusters: [{ id: 'c1', label: 'Process invoice' }], merges: [{ merge: ['c1', 'c7'] }] },
+      aliases,
+    )
+
+    expect(output?.clusters).toEqual([{ id: UUID_A, label: 'Process invoice' }])
+    expect(output && 'merges' in output).toBe(false)
   })
 
   it('keeps an empty merges array — it is a real answer that declines candidates', () => {
@@ -150,7 +163,7 @@ describe('resolveReviewOutput', () => {
 
     expect(malformed({ clusters: {} }).output).toBeNull()
     expect(malformed({ merges: {} }).output).toBeNull()
-    expect(malformed({ merges: ['c1'] }).output).toBeNull()
+    expect(malformed({ merges: ['c1'] }).output?.merges).toBeUndefined()
     expect(malformed({ clusters: [null, 3, { id: 5 }] }).output?.clusters).toEqual([])
 
     const badSplit = malformed({ clusters: [{ id: 'c1', label: 'Keep', split: {} }] })

--- a/src/main/services/task-miner/clustering/id-alias.test.ts
+++ b/src/main/services/task-miner/clustering/id-alias.test.ts
@@ -121,7 +121,7 @@ describe('resolveReviewOutput', () => {
     expect(unresolved).toBe(1)
   })
 
-  it('drops the whole merges key when any merge id will not decode', () => {
+  it('drops only the unreadable merge proposal and marks the list incomplete', () => {
     const { aliases } = aliasReviewInput(input)
 
     const { output, unresolved } = resolveReviewOutput(
@@ -129,11 +129,12 @@ describe('resolveReviewOutput', () => {
       aliases,
     )
 
-    expect(output && 'merges' in output).toBe(false)
+    expect(output?.merges).toEqual([{ merge: [UUID_A, UUID_B] }])
+    expect(output?.mergesComplete).toBe(false)
     expect(unresolved).toBe(1)
   })
 
-  it('keeps the cluster verdicts when the merges key is dropped', () => {
+  it('keeps the cluster verdicts when a merge proposal is dropped', () => {
     const { aliases } = aliasReviewInput(input)
 
     const { output } = resolveReviewOutput(
@@ -142,13 +143,22 @@ describe('resolveReviewOutput', () => {
     )
 
     expect(output?.clusters).toEqual([{ id: UUID_A, label: 'Process invoice' }])
-    expect(output && 'merges' in output).toBe(false)
+    expect(output?.merges).toEqual([])
+    expect(output?.mergesComplete).toBe(false)
+  })
+
+  it('leaves a fully readable merge list complete', () => {
+    const { aliases } = aliasReviewInput(input)
+    const { output } = resolveReviewOutput({ merges: [{ merge: ['c1', 'c2'] }] }, aliases)
+    expect(output?.merges).toEqual([{ merge: [UUID_A, UUID_B] }])
+    expect(output?.mergesComplete).toBeUndefined()
   })
 
   it('keeps an empty merges array — it is a real answer that declines candidates', () => {
     const { aliases } = aliasReviewInput(input)
     const { output } = resolveReviewOutput({ clusters: [], merges: [] }, aliases)
     expect(output?.merges).toEqual([])
+    expect(output?.mergesComplete).toBeUndefined()
   })
 
   it('leaves an absent merges key absent', () => {
@@ -157,13 +167,22 @@ describe('resolveReviewOutput', () => {
     expect(output && 'merges' in output).toBe(false)
   })
 
+  it('rejects a response that is not a JSON object', () => {
+    const { aliases } = aliasReviewInput(input)
+
+    expect(resolveReviewOutput(null, aliases).output).toBeNull()
+    expect(resolveReviewOutput('{"clusters":[]}', aliases).output).toBeNull()
+    expect(resolveReviewOutput([{ id: 'c1' }], aliases).output).toBeNull()
+  })
+
   it('tolerates malformed shapes instead of throwing', () => {
     const { aliases } = aliasReviewInput(input)
-    const malformed = (value: unknown) => resolveReviewOutput(value as never, aliases)
+    const malformed = (value: unknown) => resolveReviewOutput(value, aliases)
 
     expect(malformed({ clusters: {} }).output).toBeNull()
     expect(malformed({ merges: {} }).output).toBeNull()
-    expect(malformed({ merges: ['c1'] }).output?.merges).toBeUndefined()
+    expect(malformed({ merges: ['c1'] }).output?.merges).toEqual([])
+    expect(malformed({ merges: ['c1'] }).output?.mergesComplete).toBe(false)
     expect(malformed({ clusters: [null, 3, { id: 5 }] }).output?.clusters).toEqual([])
 
     const badSplit = malformed({ clusters: [{ id: 'c1', label: 'Keep', split: {} }] })
@@ -175,5 +194,6 @@ describe('resolveReviewOutput', () => {
       { sighting_ids: [] },
       { sighting_ids: [] },
     ])
+    expect(badGroup.unresolved).toBe(2)
   })
 })

--- a/src/main/services/task-miner/clustering/id-alias.test.ts
+++ b/src/main/services/task-miner/clustering/id-alias.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { aliasReviewInput, resolveReviewOutput } from './id-alias'
+import type { ReviewCluster, ReviewInput, ReviewSighting } from './types'
+
+const UUID_A = '11111111-1111-4111-8111-111111111111'
+const UUID_B = '22222222-2222-4222-8222-222222222222'
+
+function sighting(id: string): ReviewSighting {
+  return {
+    sighting_id: id,
+    title: 'Process invoice',
+    subject: 'Invoice #4471',
+    description: 'd',
+    apps: ['app.example.com'],
+    active_min: 5,
+    date: '2026-07-30',
+  }
+}
+
+function cluster(id: string, memberIds: string[]): ReviewCluster {
+  return {
+    id,
+    splittable: true,
+    label: '',
+    stats: { times_seen: memberIds.length, span_days: 3, median_active_min: 5 },
+    members: memberIds.map(sighting),
+  }
+}
+
+const input: ReviewInput = {
+  clusters: [cluster(UUID_A, ['s-a1', 's-a2']), cluster(UUID_B, ['s-b1'])],
+  mergeCandidates: [[UUID_A, UUID_B]],
+}
+
+describe('aliasReviewInput', () => {
+  it('replaces every uuid with a short handle', () => {
+    const { input: aliased } = aliasReviewInput(input)
+    const serialized = JSON.stringify(aliased)
+
+    expect(serialized).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/)
+    expect(aliased.clusters[0].id).toBe('c1')
+    expect(aliased.clusters[1].id).toBe('c2')
+    expect(aliased.mergeCandidates).toEqual([['c1', 'c2']])
+  })
+
+  it('numbers sightings across the whole payload, not per cluster', () => {
+    const { input: aliased } = aliasReviewInput(input)
+    expect(aliased.clusters[0].members.map((m) => m.sighting_id)).toEqual(['s1', 's2'])
+    expect(aliased.clusters[1].members.map((m) => m.sighting_id)).toEqual(['s3'])
+  })
+
+  it('leaves everything but the ids alone', () => {
+    const { input: aliased } = aliasReviewInput(input)
+    expect(aliased.clusters[0].stats).toEqual(input.clusters[0].stats)
+    expect(aliased.clusters[0].members[0].subject).toBe('Invoice #4471')
+  })
+})
+
+describe('resolveReviewOutput', () => {
+  it('round-trips verdicts, splits and merges back to real ids', () => {
+    const { aliases } = aliasReviewInput(input)
+
+    const output = resolveReviewOutput(
+      {
+        clusters: [
+          { id: 'c1', label: 'Process invoice', split: [{ sighting_ids: ['s1'] }] },
+          { id: 'c2', label: 'Other' },
+        ],
+        merges: [{ merge: ['c1', 'c2'] }],
+      },
+      aliases,
+    )
+
+    expect(output.clusters?.[0].id).toBe(UUID_A)
+    expect(output.clusters?.[0].split).toEqual([{ sighting_ids: ['s-a1'] }])
+    expect(output.clusters?.[1].id).toBe(UUID_B)
+    expect(output.merges).toEqual([{ merge: [UUID_A, UUID_B] }])
+  })
+
+  it('drops a verdict whose own id will not decode, keeping its siblings', () => {
+    const { aliases } = aliasReviewInput(input)
+
+    const output = resolveReviewOutput(
+      { clusters: [{ id: 'c9', label: 'Invented' }, { id: 'c2' }] },
+      aliases,
+    )
+
+    expect(output.clusters).toHaveLength(1)
+    expect(output.clusters?.[0].id).toBe(UUID_B)
+  })
+
+  it('drops undecodable sighting ids from a split, keeping the rest', () => {
+    const { aliases } = aliasReviewInput(input)
+
+    const output = resolveReviewOutput(
+      {
+        clusters: [
+          { id: 'c1', split: [{ sighting_ids: ['s1', 's99'] }, { sighting_ids: ['s2'] }] },
+        ],
+      },
+      aliases,
+    )
+
+    expect(output.clusters?.[0].split).toEqual([
+      { sighting_ids: ['s-a1'] },
+      { sighting_ids: ['s-a2'] },
+    ])
+  })
+
+  it('drops the merges key entirely when any id will not decode', () => {
+    const { aliases } = aliasReviewInput(input)
+
+    const output = resolveReviewOutput(
+      { clusters: [], merges: [{ merge: ['c1', 'c2'] }, { merge: ['c1', 'c7'] }] },
+      aliases,
+    )
+
+    // Absent, not empty: applyStructure reads a missing "merges" as degenerate
+    // and declines nothing. An empty array would decline every candidate pair.
+    expect('merges' in output).toBe(false)
+  })
+
+  it('keeps an empty merges array — it is a real answer that declines candidates', () => {
+    const { aliases } = aliasReviewInput(input)
+    const output = resolveReviewOutput({ clusters: [], merges: [] }, aliases)
+    expect(output.merges).toEqual([])
+  })
+})

--- a/src/main/services/task-miner/clustering/id-alias.ts
+++ b/src/main/services/task-miner/clustering/id-alias.ts
@@ -29,7 +29,7 @@ export function aliasReviewInput(input: ReviewInput): {
 }
 
 export interface ResolvedReview {
-  /** null = the response cannot be acted on; the caller retries. */
+  /** null = the response's shape is unusable; the caller retries. */
   output: ReviewOutput | null
   unresolved: number
 }
@@ -67,8 +67,8 @@ export function resolveReviewOutput(
     if (!Array.isArray(output.merges)) return { output: null, unresolved: unresolved + 1 }
     const merges = output.merges.map((proposal) => aliases.decodeMany(CLUSTER, proposal?.merge))
     const unmapped = merges.reduce((sum, m) => sum + m.unmapped, 0)
-    if (unmapped > 0) return { output: null, unresolved: unresolved + unmapped }
-    resolved.merges = merges.map((m) => ({ merge: m.ids }))
+    unresolved += unmapped
+    if (unmapped === 0) resolved.merges = merges.map((m) => ({ merge: m.ids }))
   }
 
   return { output: resolved, unresolved }

--- a/src/main/services/task-miner/clustering/id-alias.ts
+++ b/src/main/services/task-miner/clustering/id-alias.ts
@@ -1,0 +1,74 @@
+import { PositionalAliases } from '@main/llm/id-codec'
+import type { ReviewInput, ReviewOutput } from './types'
+
+const CLUSTER = 'c'
+const SIGHTING = 's'
+
+/** Swap every cluster and sighting uuid in the payload for a short handle. */
+export function aliasReviewInput(input: ReviewInput): {
+  input: ReviewInput
+  aliases: PositionalAliases
+} {
+  const aliases = new PositionalAliases()
+  return {
+    aliases,
+    input: {
+      clusters: input.clusters.map((cluster) => ({
+        ...cluster,
+        id: aliases.encode(CLUSTER, cluster.id),
+        members: cluster.members.map((member) => ({
+          ...member,
+          sighting_id: aliases.encode(SIGHTING, member.sighting_id),
+        })),
+      })),
+      mergeCandidates: input.mergeCandidates.map(([a, b]): [string, string] => [
+        aliases.encode(CLUSTER, a),
+        aliases.encode(CLUSTER, b),
+      ]),
+    },
+  }
+}
+
+/**
+ * Map the response back to real ids. A verdict whose own id won't decode is
+ * dropped — it can't be attributed to a cluster. Undecodable sighting ids fall
+ * out of their split group, leaving the degenerate-split guard to handle it.
+ *
+ * A merges array holding any undecodable id loses the whole key: applyStructure
+ * reads a response without "merges" as degenerate and declines nothing, which
+ * is what an unreadable id should mean. Recording declines off a response we
+ * can only half-read would suppress the very pairs the model asked to merge,
+ * for the full decline TTL.
+ */
+export function resolveReviewOutput(
+  output: ReviewOutput,
+  aliases: PositionalAliases,
+): ReviewOutput {
+  const resolved: ReviewOutput = {}
+
+  if (output.clusters) {
+    resolved.clusters = output.clusters.flatMap((verdict) => {
+      const id = aliases.decode(verdict.id ?? '')
+      if (!id) return []
+      if (!verdict.split) return [{ ...verdict, id }]
+      return [
+        {
+          ...verdict,
+          id,
+          split: verdict.split.map((group) => ({
+            sighting_ids: aliases.decodeMany(group.sighting_ids ?? []).ids,
+          })),
+        },
+      ]
+    })
+  }
+
+  if (output.merges) {
+    const merges = output.merges.map((proposal) => aliases.decodeMany(proposal.merge ?? []))
+    if (!merges.some((m) => m.unmapped > 0)) {
+      resolved.merges = merges.map((m) => ({ merge: m.ids }))
+    }
+  }
+
+  return resolved
+}

--- a/src/main/services/task-miner/clustering/id-alias.ts
+++ b/src/main/services/task-miner/clustering/id-alias.ts
@@ -1,28 +1,33 @@
 import { PositionalAliases } from '@main/llm/id-codec'
 import type { ReviewInput, ReviewOutput } from './types'
 
-const CLUSTER = 'c'
-const SIGHTING = 's'
+export interface ReviewAliases {
+  clusters: PositionalAliases
+  sightings: PositionalAliases
+}
 
 export function aliasReviewInput(input: ReviewInput): {
   input: ReviewInput
-  aliases: PositionalAliases
+  aliases: ReviewAliases
 } {
-  const aliases = new PositionalAliases()
+  const aliases: ReviewAliases = {
+    clusters: new PositionalAliases('c'),
+    sightings: new PositionalAliases('s'),
+  }
   return {
     aliases,
     input: {
       clusters: input.clusters.map((cluster) => ({
         ...cluster,
-        id: aliases.encode(CLUSTER, cluster.id),
+        id: aliases.clusters.encode(cluster.id),
         members: cluster.members.map((member) => ({
           ...member,
-          sighting_id: aliases.encode(SIGHTING, member.sighting_id),
+          sighting_id: aliases.sightings.encode(member.sighting_id),
         })),
       })),
       mergeCandidates: input.mergeCandidates.map(([a, b]): [string, string] => [
-        aliases.encode(CLUSTER, a),
-        aliases.encode(CLUSTER, b),
+        aliases.clusters.encode(a),
+        aliases.clusters.encode(b),
       ]),
     },
   }
@@ -34,17 +39,14 @@ export interface ResolvedReview {
   unresolved: number
 }
 
-export function resolveReviewOutput(
-  output: ReviewOutput,
-  aliases: PositionalAliases,
-): ResolvedReview {
+export function resolveReviewOutput(output: ReviewOutput, aliases: ReviewAliases): ResolvedReview {
   const resolved: ReviewOutput = {}
   let unresolved = 0
 
   if (output.clusters !== undefined) {
     if (!Array.isArray(output.clusters)) return { output: null, unresolved: unresolved + 1 }
     resolved.clusters = output.clusters.flatMap((verdict) => {
-      const id = verdict && typeof verdict === 'object' ? aliases.decode(CLUSTER, verdict.id) : null
+      const id = verdict && typeof verdict === 'object' ? aliases.clusters.decode(verdict.id) : null
       if (!id) {
         unresolved++
         return []
@@ -55,7 +57,7 @@ export function resolveReviewOutput(
         return [{ ...verdict, id, split: undefined }]
       }
       const split = verdict.split.map((group) => {
-        const decoded = aliases.decodeMany(SIGHTING, group?.sighting_ids)
+        const decoded = aliases.sightings.decodeMany(group?.sighting_ids)
         unresolved += decoded.unmapped
         return { sighting_ids: decoded.ids }
       })
@@ -65,7 +67,7 @@ export function resolveReviewOutput(
 
   if (output.merges !== undefined) {
     if (!Array.isArray(output.merges)) return { output: null, unresolved: unresolved + 1 }
-    const merges = output.merges.map((proposal) => aliases.decodeMany(CLUSTER, proposal?.merge))
+    const merges = output.merges.map((proposal) => aliases.clusters.decodeMany(proposal?.merge))
     const unmapped = merges.reduce((sum, m) => sum + m.unmapped, 0)
     unresolved += unmapped
     if (unmapped === 0) resolved.merges = merges.map((m) => ({ merge: m.ids }))

--- a/src/main/services/task-miner/clustering/id-alias.ts
+++ b/src/main/services/task-miner/clustering/id-alias.ts
@@ -4,7 +4,6 @@ import type { ReviewInput, ReviewOutput } from './types'
 const CLUSTER = 'c'
 const SIGHTING = 's'
 
-/** Swap every cluster and sighting uuid in the payload for a short handle. */
 export function aliasReviewInput(input: ReviewInput): {
   input: ReviewInput
   aliases: PositionalAliases
@@ -29,46 +28,48 @@ export function aliasReviewInput(input: ReviewInput): {
   }
 }
 
-/**
- * Map the response back to real ids. A verdict whose own id won't decode is
- * dropped — it can't be attributed to a cluster. Undecodable sighting ids fall
- * out of their split group, leaving the degenerate-split guard to handle it.
- *
- * A merges array holding any undecodable id loses the whole key: applyStructure
- * reads a response without "merges" as degenerate and declines nothing, which
- * is what an unreadable id should mean. Recording declines off a response we
- * can only half-read would suppress the very pairs the model asked to merge,
- * for the full decline TTL.
- */
+export interface ResolvedReview {
+  /** null = the response cannot be acted on; the caller retries. */
+  output: ReviewOutput | null
+  unresolved: number
+}
+
 export function resolveReviewOutput(
   output: ReviewOutput,
   aliases: PositionalAliases,
-): ReviewOutput {
+): ResolvedReview {
   const resolved: ReviewOutput = {}
+  let unresolved = 0
 
-  if (output.clusters) {
+  if (output.clusters !== undefined) {
+    if (!Array.isArray(output.clusters)) return { output: null, unresolved: unresolved + 1 }
     resolved.clusters = output.clusters.flatMap((verdict) => {
-      const id = aliases.decode(verdict.id ?? '')
-      if (!id) return []
-      if (!verdict.split) return [{ ...verdict, id }]
-      return [
-        {
-          ...verdict,
-          id,
-          split: verdict.split.map((group) => ({
-            sighting_ids: aliases.decodeMany(group.sighting_ids ?? []).ids,
-          })),
-        },
-      ]
+      const id = verdict && typeof verdict === 'object' ? aliases.decode(CLUSTER, verdict.id) : null
+      if (!id) {
+        unresolved++
+        return []
+      }
+      if (verdict.split === undefined) return [{ ...verdict, id }]
+      if (!Array.isArray(verdict.split)) {
+        unresolved++
+        return [{ ...verdict, id, split: undefined }]
+      }
+      const split = verdict.split.map((group) => {
+        const decoded = aliases.decodeMany(SIGHTING, group?.sighting_ids)
+        unresolved += decoded.unmapped
+        return { sighting_ids: decoded.ids }
+      })
+      return [{ ...verdict, id, split }]
     })
   }
 
-  if (output.merges) {
-    const merges = output.merges.map((proposal) => aliases.decodeMany(proposal.merge ?? []))
-    if (!merges.some((m) => m.unmapped > 0)) {
-      resolved.merges = merges.map((m) => ({ merge: m.ids }))
-    }
+  if (output.merges !== undefined) {
+    if (!Array.isArray(output.merges)) return { output: null, unresolved: unresolved + 1 }
+    const merges = output.merges.map((proposal) => aliases.decodeMany(CLUSTER, proposal?.merge))
+    const unmapped = merges.reduce((sum, m) => sum + m.unmapped, 0)
+    if (unmapped > 0) return { output: null, unresolved: unresolved + unmapped }
+    resolved.merges = merges.map((m) => ({ merge: m.ids }))
   }
 
-  return resolved
+  return { output: resolved, unresolved }
 }

--- a/src/main/services/task-miner/clustering/id-alias.ts
+++ b/src/main/services/task-miner/clustering/id-alias.ts
@@ -1,5 +1,5 @@
 import { PositionalAliases } from '@main/llm/id-codec'
-import type { ReviewInput, ReviewMerge, ReviewOutput } from './types'
+import type { ReviewInput, ReviewMerge, ReviewOutput, ReviewSplitGroup } from './types'
 
 export interface ReviewAliases {
   clusters: PositionalAliases
@@ -34,60 +34,64 @@ export function aliasReviewInput(input: ReviewInput): {
 }
 
 export interface ResolvedReview {
-  /** null = the response's shape is unusable; the caller retries. */
   output: ReviewOutput | null
-  /** Id references that could not be read back. */
   unresolved: number
+  mergesIncomplete: boolean
 }
 
 export function resolveReviewOutput(output: unknown, aliases: ReviewAliases): ResolvedReview {
   let unresolved = 0
-  if (!output || typeof output !== 'object' || Array.isArray(output)) {
-    return { output: null, unresolved }
-  }
+  const unusable = () => ({ output: null, unresolved, mergesIncomplete: false })
+  if (!output || typeof output !== 'object' || Array.isArray(output)) return unusable()
 
   const raw = output as ReviewOutput
   const resolved: ReviewOutput = {}
 
-  if (raw.clusters !== undefined) {
-    if (!Array.isArray(raw.clusters)) return { output: null, unresolved }
-    resolved.clusters = raw.clusters.flatMap((verdict) => {
-      const id =
-        verdict && typeof verdict === 'object' ? aliases.clusters.decode(verdict.id) : undefined
-      if (!id) {
-        unresolved++
-        return []
-      }
-      if (verdict.split === undefined) return [{ ...verdict, id }]
-      if (!Array.isArray(verdict.split)) {
-        unresolved++
-        return [{ ...verdict, id, split: undefined }]
-      }
-      const split = verdict.split.map((group) => {
-        const decoded = aliases.sightings.decodeMany(group?.sighting_ids)
-        unresolved += decoded ? decoded.unmapped : 1
-        return { sighting_ids: decoded?.ids ?? [] }
-      })
-      return [{ ...verdict, id, split }]
+  const resolveSplit = (split: unknown): ReviewSplitGroup[] | undefined => {
+    if (split === undefined) return undefined
+    if (!Array.isArray(split)) {
+      unresolved++
+      return undefined
+    }
+    return split.map((group) => {
+      const { ids, unmapped } = aliases.sightings.decodeMany(group?.sighting_ids)
+      unresolved += unmapped
+      return { sighting_ids: ids }
     })
   }
 
-  if (raw.merges !== undefined) {
-    if (!Array.isArray(raw.merges)) return { output: null, unresolved }
-    const merges: ReviewMerge[] = []
-    let complete = true
-    for (const proposal of raw.merges) {
-      const decoded = aliases.clusters.decodeMany(proposal?.merge)
-      if (!decoded || decoded.unmapped > 0) {
-        unresolved += decoded ? decoded.unmapped : 1
-        complete = false
-        continue
+  if (raw.clusters !== undefined) {
+    if (!Array.isArray(raw.clusters)) return unusable()
+    const decoded = raw.clusters.map((verdict) =>
+      verdict && typeof verdict === 'object' ? aliases.clusters.decode(verdict.id) : undefined,
+    )
+    const claims = new Map<string, number>()
+    for (const id of decoded) if (id) claims.set(id, (claims.get(id) ?? 0) + 1)
+    resolved.clusters = raw.clusters.flatMap((verdict, i) => {
+      const id = decoded[i]
+      if (!id || (claims.get(id) ?? 0) > 1) {
+        unresolved++
+        return []
       }
-      merges.push({ merge: decoded.ids })
-    }
-    resolved.merges = merges
-    if (!complete) resolved.mergesComplete = false
+      return [{ ...verdict, id, split: resolveSplit(verdict.split) }]
+    })
   }
 
-  return { output: resolved, unresolved }
+  let mergesIncomplete = false
+  if (raw.merges !== undefined) {
+    if (!Array.isArray(raw.merges)) return unusable()
+    const merges: ReviewMerge[] = []
+    for (const proposal of raw.merges) {
+      const { ids, unmapped } = aliases.clusters.decodeMany(proposal?.merge)
+      if (unmapped > 0) {
+        unresolved += unmapped
+        continue
+      }
+      merges.push({ merge: ids })
+    }
+    resolved.merges = merges
+    mergesIncomplete = merges.length !== raw.merges.length
+  }
+
+  return { output: resolved, unresolved, mergesIncomplete }
 }

--- a/src/main/services/task-miner/clustering/id-alias.ts
+++ b/src/main/services/task-miner/clustering/id-alias.ts
@@ -1,5 +1,5 @@
 import { PositionalAliases } from '@main/llm/id-codec'
-import type { ReviewInput, ReviewOutput } from './types'
+import type { ReviewInput, ReviewMerge, ReviewOutput } from './types'
 
 export interface ReviewAliases {
   clusters: PositionalAliases
@@ -36,17 +36,24 @@ export function aliasReviewInput(input: ReviewInput): {
 export interface ResolvedReview {
   /** null = the response's shape is unusable; the caller retries. */
   output: ReviewOutput | null
+  /** Id references that could not be read back. */
   unresolved: number
 }
 
-export function resolveReviewOutput(output: ReviewOutput, aliases: ReviewAliases): ResolvedReview {
-  const resolved: ReviewOutput = {}
+export function resolveReviewOutput(output: unknown, aliases: ReviewAliases): ResolvedReview {
   let unresolved = 0
+  if (!output || typeof output !== 'object' || Array.isArray(output)) {
+    return { output: null, unresolved }
+  }
 
-  if (output.clusters !== undefined) {
-    if (!Array.isArray(output.clusters)) return { output: null, unresolved: unresolved + 1 }
-    resolved.clusters = output.clusters.flatMap((verdict) => {
-      const id = verdict && typeof verdict === 'object' ? aliases.clusters.decode(verdict.id) : null
+  const raw = output as ReviewOutput
+  const resolved: ReviewOutput = {}
+
+  if (raw.clusters !== undefined) {
+    if (!Array.isArray(raw.clusters)) return { output: null, unresolved }
+    resolved.clusters = raw.clusters.flatMap((verdict) => {
+      const id =
+        verdict && typeof verdict === 'object' ? aliases.clusters.decode(verdict.id) : undefined
       if (!id) {
         unresolved++
         return []
@@ -58,19 +65,28 @@ export function resolveReviewOutput(output: ReviewOutput, aliases: ReviewAliases
       }
       const split = verdict.split.map((group) => {
         const decoded = aliases.sightings.decodeMany(group?.sighting_ids)
-        unresolved += decoded.unmapped
-        return { sighting_ids: decoded.ids }
+        unresolved += decoded ? decoded.unmapped : 1
+        return { sighting_ids: decoded?.ids ?? [] }
       })
       return [{ ...verdict, id, split }]
     })
   }
 
-  if (output.merges !== undefined) {
-    if (!Array.isArray(output.merges)) return { output: null, unresolved: unresolved + 1 }
-    const merges = output.merges.map((proposal) => aliases.clusters.decodeMany(proposal?.merge))
-    const unmapped = merges.reduce((sum, m) => sum + m.unmapped, 0)
-    unresolved += unmapped
-    if (unmapped === 0) resolved.merges = merges.map((m) => ({ merge: m.ids }))
+  if (raw.merges !== undefined) {
+    if (!Array.isArray(raw.merges)) return { output: null, unresolved }
+    const merges: ReviewMerge[] = []
+    let complete = true
+    for (const proposal of raw.merges) {
+      const decoded = aliases.clusters.decodeMany(proposal?.merge)
+      if (!decoded || decoded.unmapped > 0) {
+        unresolved += decoded ? decoded.unmapped : 1
+        complete = false
+        continue
+      }
+      merges.push({ merge: decoded.ids })
+    }
+    resolved.merges = merges
+    if (!complete) resolved.mergesComplete = false
   }
 
   return { output: resolved, unresolved }

--- a/src/main/services/task-miner/clustering/index.ts
+++ b/src/main/services/task-miner/clustering/index.ts
@@ -181,6 +181,7 @@ export async function runClustering(deps: ClusteringDeps): Promise<ClusteringRun
           reviewableIds: new Set(input.clusters.map((c) => c.id)),
           splittableIds: new Set(input.clusters.filter((c) => c.splittable).map((c) => c.id)),
           mergeCandidatePairs: new Set(input.mergeCandidates.map(([a, b]) => mergePairKey(a, b))),
+          declinesInferable: !review.mergesIncomplete,
         }
         // Re-split linkage precomputed here so it can ride the ml-worker —
         // applyStructure's transaction can't await. Nothing mutates membership

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -78,6 +78,39 @@ describe('id aliasing', () => {
     expect(prompt).not.toContain(clusterId)
     expect(result.output?.clusters?.[0].id).toBe(clusterId)
   })
+
+  it('retries a response whose merge ids do not resolve', async () => {
+    mockedGenerateText
+      .mockResolvedValueOnce({
+        text: '{"clusters":[],"merges":[{"merge":["c1","c9"]}]}',
+        usage: { inputTokens: 10, outputTokens: 5 },
+      } as never)
+      .mockResolvedValue({
+        text: '{"clusters":[],"merges":[]}',
+        usage: { inputTokens: 10, outputTokens: 5 },
+      } as never)
+
+    const progress = vi.fn()
+    const result = await runStructureReview(provider, 'model', emptyInput, progress)
+
+    expect(mockedGenerateText).toHaveBeenCalledTimes(2)
+    expect(result.output).toEqual({ clusters: [], merges: [] })
+    expect(progress).toHaveBeenCalledWith(expect.stringContaining('did not resolve'))
+  })
+
+  it('reports dropped handles without failing the response', async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: '{"clusters":[{"id":"c9","label":"Invented"}],"merges":[]}',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    } as never)
+
+    const progress = vi.fn()
+    const result = await runStructureReview(provider, 'model', emptyInput, progress)
+
+    expect(mockedGenerateText).toHaveBeenCalledTimes(1)
+    expect(result.output).toEqual({ clusters: [], merges: [] })
+    expect(progress).toHaveBeenCalledWith(expect.stringContaining('1 id handle(s)'))
+  })
 })
 
 describe('runContentReview', () => {

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -79,22 +79,34 @@ describe('id aliasing', () => {
     expect(result.output?.clusters?.[0].id).toBe(clusterId)
   })
 
-  it('retries a response whose merge ids do not resolve', async () => {
-    mockedGenerateText
-      .mockResolvedValueOnce({
-        text: '{"clusters":[],"merges":[{"merge":["c1","c9"]}]}',
-        usage: { inputTokens: 10, outputTokens: 5 },
-      } as never)
-      .mockResolvedValue({
-        text: '{"clusters":[],"merges":[]}',
-        usage: { inputTokens: 10, outputTokens: 5 },
-      } as never)
+  it('keeps the verdicts and drops merges when a merge id does not resolve', async () => {
+    const clusterId = '11111111-1111-4111-8111-111111111111'
+    mockedGenerateText.mockResolvedValue({
+      text: '{"clusters":[{"id":"c1","label":"Process invoice"}],"merges":[{"merge":["c1","c9"]}]}',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    } as never)
 
     const progress = vi.fn()
-    const result = await runStructureReview(provider, 'model', emptyInput, progress)
+    const result = await runStructureReview(
+      provider,
+      'model',
+      {
+        clusters: [
+          {
+            id: clusterId,
+            splittable: false,
+            label: '',
+            stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
+            members: [],
+          },
+        ],
+        mergeCandidates: [],
+      },
+      progress,
+    )
 
-    expect(mockedGenerateText).toHaveBeenCalledTimes(2)
-    expect(result.output).toEqual({ clusters: [], merges: [] })
+    expect(mockedGenerateText).toHaveBeenCalledTimes(1)
+    expect(result.output).toEqual({ clusters: [{ id: clusterId, label: 'Process invoice' }] })
     expect(progress).toHaveBeenCalledWith(expect.stringContaining('did not resolve'))
   })
 

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -2,10 +2,15 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { InferenceProvider } from '@main/llm'
 import { generateText } from 'ai'
 import { runStructureReview, runContentReview } from './llm-review'
+import log from '@main/utils/logger'
 
 vi.mock('ai', () => ({ generateText: vi.fn() }))
+vi.mock('@main/utils/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
 
 const mockedGenerateText = vi.mocked(generateText)
+const mockedWarn = vi.mocked(log.warn)
 
 const languageModel: InferenceProvider['languageModel'] = () => 'model'
 const provider = {
@@ -17,6 +22,7 @@ const emptyInput = { clusters: [], mergeCandidates: [] }
 
 beforeEach(() => {
   mockedGenerateText.mockReset()
+  mockedWarn.mockReset()
 })
 
 describe('runStructureReview', () => {
@@ -86,28 +92,22 @@ describe('id aliasing', () => {
       usage: { inputTokens: 10, outputTokens: 5 },
     } as never)
 
-    const progress = vi.fn()
-    const result = await runStructureReview(
-      provider,
-      'model',
-      {
-        clusters: [
-          {
-            id: clusterId,
-            splittable: false,
-            label: '',
-            stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
-            members: [],
-          },
-        ],
-        mergeCandidates: [],
-      },
-      progress,
-    )
+    const result = await runStructureReview(provider, 'model', {
+      clusters: [
+        {
+          id: clusterId,
+          splittable: false,
+          label: '',
+          stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
+          members: [],
+        },
+      ],
+      mergeCandidates: [],
+    })
 
     expect(mockedGenerateText).toHaveBeenCalledTimes(1)
     expect(result.output).toEqual({ clusters: [{ id: clusterId, label: 'Process invoice' }] })
-    expect(progress).toHaveBeenCalledWith(expect.stringContaining('did not resolve'))
+    expect(mockedWarn).toHaveBeenCalledWith(expect.stringContaining('did not resolve'))
   })
 
   it('reports dropped handles without failing the response', async () => {
@@ -116,12 +116,11 @@ describe('id aliasing', () => {
       usage: { inputTokens: 10, outputTokens: 5 },
     } as never)
 
-    const progress = vi.fn()
-    const result = await runStructureReview(provider, 'model', emptyInput, progress)
+    const result = await runStructureReview(provider, 'model', emptyInput)
 
     expect(mockedGenerateText).toHaveBeenCalledTimes(1)
     expect(result.output).toEqual({ clusters: [], merges: [] })
-    expect(progress).toHaveBeenCalledWith(expect.stringContaining('1 id handle(s)'))
+    expect(mockedWarn).toHaveBeenCalledWith(expect.stringContaining('1 id handle(s)'))
   })
 })
 

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -2,15 +2,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { InferenceProvider } from '@main/llm'
 import { generateText } from 'ai'
 import { runStructureReview, runContentReview } from './llm-review'
-import log from '@main/utils/logger'
+import type { ReviewCluster } from './types'
 
 vi.mock('ai', () => ({ generateText: vi.fn() }))
-vi.mock('@main/utils/logger', () => ({
-  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-}))
 
 const mockedGenerateText = vi.mocked(generateText)
-const mockedWarn = vi.mocked(log.warn)
 
 const languageModel: InferenceProvider['languageModel'] = () => 'model'
 const provider = {
@@ -20,17 +16,34 @@ const provider = {
 
 const emptyInput = { clusters: [], mergeCandidates: [] }
 
+const UUID_A = '11111111-1111-4111-8111-111111111111'
+const UUID_B = '22222222-2222-4222-8222-222222222222'
+
+function cluster(id: string): ReviewCluster {
+  return {
+    id,
+    splittable: false,
+    label: '',
+    stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
+    members: [],
+  }
+}
+
+function respond(text: string) {
+  return { text, usage: { inputTokens: 10, outputTokens: 5 } } as never
+}
+
+function promptOf(call: number): string {
+  return (mockedGenerateText.mock.calls[call][0] as unknown as { prompt: string }).prompt
+}
+
 beforeEach(() => {
   mockedGenerateText.mockReset()
-  mockedWarn.mockReset()
 })
 
 describe('runStructureReview', () => {
   it('disables SDK retries — the mining ledger owns retry pacing', async () => {
-    mockedGenerateText.mockResolvedValue({
-      text: '{"clusters":[],"merges":[]}',
-      usage: { inputTokens: 10, outputTokens: 5 },
-    } as never)
+    mockedGenerateText.mockResolvedValue(respond('{"clusters":[],"merges":[]}'))
 
     const result = await runStructureReview(provider, 'model', emptyInput)
 
@@ -39,10 +52,9 @@ describe('runStructureReview', () => {
   })
 
   it('retries a thrown call within the attempt budget', async () => {
-    mockedGenerateText.mockRejectedValueOnce(new Error('timeout')).mockResolvedValue({
-      text: '{"clusters":[],"merges":[]}',
-      usage: { inputTokens: 10, outputTokens: 5 },
-    } as never)
+    mockedGenerateText
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValue(respond('{"clusters":[],"merges":[]}'))
 
     const result = await runStructureReview(provider, 'model', emptyInput)
 
@@ -60,81 +72,104 @@ describe('runStructureReview', () => {
 
 describe('id aliasing', () => {
   it('sends short handles and returns real ids', async () => {
-    const clusterId = '11111111-1111-4111-8111-111111111111'
-    mockedGenerateText.mockResolvedValue({
-      text: '{"clusters":[{"id":"c1","label":"Process invoice"}],"merges":[]}',
-      usage: { inputTokens: 10, outputTokens: 5 },
-    } as never)
+    mockedGenerateText.mockResolvedValue(
+      respond('{"clusters":[{"id":"c1","label":"Process invoice"}],"merges":[]}'),
+    )
 
     const result = await runStructureReview(provider, 'model', {
-      clusters: [
-        {
-          id: clusterId,
-          splittable: false,
-          label: '',
-          stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
-          members: [],
-        },
-      ],
+      clusters: [cluster(UUID_A)],
       mergeCandidates: [],
     })
 
-    const { prompt } = mockedGenerateText.mock.calls[0][0] as unknown as { prompt: string }
-    expect(prompt).toContain('"c1"')
-    expect(prompt).not.toContain(clusterId)
-    expect(result.output?.clusters?.[0].id).toBe(clusterId)
+    expect(promptOf(0)).toContain('"c1"')
+    expect(promptOf(0)).not.toContain(UUID_A)
+    expect(result.output?.clusters?.[0].id).toBe(UUID_A)
   })
 
-  it('keeps the verdicts and drops merges when a merge id does not resolve', async () => {
-    const clusterId = '11111111-1111-4111-8111-111111111111'
-    mockedGenerateText.mockResolvedValue({
-      text: '{"clusters":[{"id":"c1","label":"Process invoice"}],"merges":[{"merge":["c1","c9"]}]}',
-      usage: { inputTokens: 10, outputTokens: 5 },
-    } as never)
+  it('aliases the content call too', async () => {
+    mockedGenerateText.mockResolvedValue(
+      respond('{"clusters":[{"id":"c1","label":"Process invoice"}]}'),
+    )
 
-    const result = await runStructureReview(provider, 'model', {
-      clusters: [
-        {
-          id: clusterId,
-          splittable: false,
-          label: '',
-          stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
-          members: [],
-        },
-      ],
+    const result = await runContentReview(provider, 'model', {
+      clusters: [cluster(UUID_A)],
       mergeCandidates: [],
     })
+
+    expect(promptOf(0)).not.toContain(UUID_A)
+    expect(result.output?.clusters?.[0].id).toBe(UUID_A)
+  })
+
+  it('keeps handles stable across retries so a second attempt can still be read', async () => {
+    mockedGenerateText
+      .mockResolvedValueOnce(respond('not json at all'))
+      .mockResolvedValueOnce(respond('{"clusters":[{"id":"c1","label":"Process invoice"}]}'))
+
+    const result = await runStructureReview(provider, 'model', {
+      clusters: [cluster(UUID_A)],
+      mergeCandidates: [],
+    })
+
+    expect(promptOf(1)).toBe(promptOf(0))
+    expect(result.output?.clusters?.[0].id).toBe(UUID_A)
+  })
+
+  it('keeps the readable merges and the verdicts when one merge id does not resolve', async () => {
+    mockedGenerateText.mockResolvedValue(
+      respond(
+        '{"clusters":[{"id":"c1","label":"Process invoice"}],' +
+          '"merges":[{"merge":["c1","c2"]},{"merge":["c1","c9"]}]}',
+      ),
+    )
+    const progress = vi.fn()
+
+    const result = await runStructureReview(
+      provider,
+      'model',
+      { clusters: [cluster(UUID_A), cluster(UUID_B)], mergeCandidates: [[UUID_A, UUID_B]] },
+      progress,
+    )
 
     expect(mockedGenerateText).toHaveBeenCalledTimes(1)
-    expect(result.output).toEqual({ clusters: [{ id: clusterId, label: 'Process invoice' }] })
-    expect(mockedWarn).toHaveBeenCalledWith(expect.stringContaining('did not resolve'))
+    expect(result.output).toEqual({
+      clusters: [{ id: UUID_A, label: 'Process invoice' }],
+      merges: [{ merge: [UUID_A, UUID_B] }],
+      mergesComplete: false,
+    })
+    expect(progress).toHaveBeenCalledWith(expect.stringContaining('could not be read'))
   })
 
-  it('reports dropped handles without failing the response', async () => {
-    mockedGenerateText.mockResolvedValue({
-      text: '{"clusters":[{"id":"c9","label":"Invented"}],"merges":[]}',
-      usage: { inputTokens: 10, outputTokens: 5 },
-    } as never)
+  it('reports dropped handles through progress without failing the response', async () => {
+    mockedGenerateText.mockResolvedValue(
+      respond('{"clusters":[{"id":"c9","label":"Invented"}],"merges":[]}'),
+    )
+    const progress = vi.fn()
 
-    const result = await runStructureReview(provider, 'model', emptyInput)
+    const result = await runStructureReview(provider, 'model', emptyInput, progress)
 
     expect(mockedGenerateText).toHaveBeenCalledTimes(1)
     expect(result.output).toEqual({ clusters: [], merges: [] })
-    expect(mockedWarn).toHaveBeenCalledWith(expect.stringContaining('1 id handle(s)'))
+    expect(progress).toHaveBeenCalledWith(expect.stringContaining('1 id reference(s)'))
+  })
+
+  it('reports an unusable shape as a parse failure, not as unread ids', async () => {
+    mockedGenerateText.mockResolvedValue(respond('{"clusters":{}}'))
+    const progress = vi.fn()
+
+    const result = await runStructureReview(provider, 'model', emptyInput, progress)
+
+    expect(result.output).toBeNull()
+    expect(mockedGenerateText).toHaveBeenCalledTimes(2)
+    expect(progress).toHaveBeenCalledWith(expect.stringContaining('Could not use review response'))
+    expect(progress).not.toHaveBeenCalledWith(expect.stringContaining('could not be read'))
   })
 })
 
 describe('runContentReview', () => {
   it('retries an unparseable response and returns the parsed second attempt', async () => {
     mockedGenerateText
-      .mockResolvedValueOnce({
-        text: 'not json at all',
-        usage: { inputTokens: 10, outputTokens: 5 },
-      } as never)
-      .mockResolvedValueOnce({
-        text: '{"clusters":[]}',
-        usage: { inputTokens: 10, outputTokens: 5 },
-      } as never)
+      .mockResolvedValueOnce(respond('not json at all'))
+      .mockResolvedValueOnce(respond('{"clusters":[]}'))
 
     const result = await runContentReview(provider, 'model', emptyInput)
 

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -134,8 +134,8 @@ describe('id aliasing', () => {
     expect(result.output).toEqual({
       clusters: [{ id: UUID_A, label: 'Process invoice' }],
       merges: [{ merge: [UUID_A, UUID_B] }],
-      mergesComplete: false,
     })
+    expect(result.mergesIncomplete).toBe(true)
     expect(progress).toHaveBeenCalledWith(expect.stringContaining('could not be read'))
   })
 

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -52,6 +52,34 @@ describe('runStructureReview', () => {
   })
 })
 
+describe('id aliasing', () => {
+  it('sends short handles and returns real ids', async () => {
+    const clusterId = '11111111-1111-4111-8111-111111111111'
+    mockedGenerateText.mockResolvedValue({
+      text: '{"clusters":[{"id":"c1","label":"Process invoice"}],"merges":[]}',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    } as never)
+
+    const result = await runStructureReview(provider, 'model', {
+      clusters: [
+        {
+          id: clusterId,
+          splittable: false,
+          label: '',
+          stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
+          members: [],
+        },
+      ],
+      mergeCandidates: [],
+    })
+
+    const { prompt } = mockedGenerateText.mock.calls[0][0] as unknown as { prompt: string }
+    expect(prompt).toContain('"c1"')
+    expect(prompt).not.toContain(clusterId)
+    expect(result.output?.clusters?.[0].id).toBe(clusterId)
+  })
+})
+
 describe('runContentReview', () => {
   it('retries an unparseable response and returns the parsed second attempt', async () => {
     mockedGenerateText

--- a/src/main/services/task-miner/clustering/llm-review.ts
+++ b/src/main/services/task-miner/clustering/llm-review.ts
@@ -15,6 +15,7 @@ import type { ProgressCallback } from '../types'
 export interface ReviewCallResult {
   output: ReviewOutput | null
   tokenUsage: { input: number; output: number }
+  mergesIncomplete?: boolean
 }
 
 /**
@@ -53,7 +54,7 @@ async function callReview(
             `[Clustering] ${resolved.unresolved} id reference(s) in the review response could not be read`,
           )
         }
-        return { output: resolved.output, tokenUsage }
+        return { output: resolved.output, tokenUsage, mergesIncomplete: resolved.mergesIncomplete }
       }
       progress?.(
         `[Clustering] Could not use review response` +

--- a/src/main/services/task-miner/clustering/llm-review.ts
+++ b/src/main/services/task-miner/clustering/llm-review.ts
@@ -9,6 +9,7 @@ import {
   buildContentReviewSystemPrompt,
   serializeReviewInput,
 } from './prompts'
+import { aliasReviewInput, resolveReviewOutput } from './id-alias'
 import type { ProgressCallback } from '../types'
 
 export interface ReviewCallResult {
@@ -29,7 +30,8 @@ async function callReview(
   describe: (attempt: number) => string,
   progress?: ProgressCallback,
 ): Promise<ReviewCallResult> {
-  const prompt = serializeReviewInput(input)
+  const { input: aliased, aliases } = aliasReviewInput(input)
+  const prompt = serializeReviewInput(aliased)
   const tokenUsage = { input: 0, output: 0 }
 
   for (let attempt = 1; attempt <= CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS; attempt++) {
@@ -45,7 +47,7 @@ async function callReview(
       tokenUsage.output += result.usage.outputTokens ?? 0
 
       const parsed = extractJsonObject<ReviewOutput>(result.text)
-      if (parsed) return { output: parsed, tokenUsage }
+      if (parsed) return { output: resolveReviewOutput(parsed, aliases), tokenUsage }
       progress?.(
         `[Clustering] Could not parse review response` +
           (attempt < CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS ? ' — retrying' : ''),

--- a/src/main/services/task-miner/clustering/llm-review.ts
+++ b/src/main/services/task-miner/clustering/llm-review.ts
@@ -10,6 +10,7 @@ import {
   serializeReviewInput,
 } from './prompts'
 import { aliasReviewInput, resolveReviewOutput } from './id-alias'
+import log from '@main/utils/logger'
 import type { ProgressCallback } from '../types'
 
 export interface ReviewCallResult {
@@ -49,8 +50,8 @@ async function callReview(
       const parsed = extractJsonObject<ReviewOutput>(result.text)
       const resolved = parsed ? resolveReviewOutput(parsed, aliases) : null
       if (resolved && resolved.unresolved > 0) {
-        progress?.(
-          `[Clustering] ${resolved.unresolved} id handle(s) in the review response did not resolve`,
+        log.warn(
+          `[TaskMiner] [Clustering] ${resolved.unresolved} id handle(s) in the review response did not resolve`,
         )
       }
       if (resolved?.output) return { output: resolved.output, tokenUsage }

--- a/src/main/services/task-miner/clustering/llm-review.ts
+++ b/src/main/services/task-miner/clustering/llm-review.ts
@@ -10,7 +10,6 @@ import {
   serializeReviewInput,
 } from './prompts'
 import { aliasReviewInput, resolveReviewOutput } from './id-alias'
-import log from '@main/utils/logger'
 import type { ProgressCallback } from '../types'
 
 export interface ReviewCallResult {
@@ -47,14 +46,15 @@ async function callReview(
       tokenUsage.input += result.usage.inputTokens ?? 0
       tokenUsage.output += result.usage.outputTokens ?? 0
 
-      const parsed = extractJsonObject<ReviewOutput>(result.text)
-      const resolved = parsed ? resolveReviewOutput(parsed, aliases) : null
-      if (resolved && resolved.unresolved > 0) {
-        log.warn(
-          `[TaskMiner] [Clustering] ${resolved.unresolved} id handle(s) in the review response did not resolve`,
-        )
+      const resolved = resolveReviewOutput(extractJsonObject(result.text), aliases)
+      if (resolved.output) {
+        if (resolved.unresolved > 0) {
+          progress?.(
+            `[Clustering] ${resolved.unresolved} id reference(s) in the review response could not be read`,
+          )
+        }
+        return { output: resolved.output, tokenUsage }
       }
-      if (resolved?.output) return { output: resolved.output, tokenUsage }
       progress?.(
         `[Clustering] Could not use review response` +
           (attempt < CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS ? ' — retrying' : ''),

--- a/src/main/services/task-miner/clustering/llm-review.ts
+++ b/src/main/services/task-miner/clustering/llm-review.ts
@@ -47,9 +47,15 @@ async function callReview(
       tokenUsage.output += result.usage.outputTokens ?? 0
 
       const parsed = extractJsonObject<ReviewOutput>(result.text)
-      if (parsed) return { output: resolveReviewOutput(parsed, aliases), tokenUsage }
+      const resolved = parsed ? resolveReviewOutput(parsed, aliases) : null
+      if (resolved && resolved.unresolved > 0) {
+        progress?.(
+          `[Clustering] ${resolved.unresolved} id handle(s) in the review response did not resolve`,
+        )
+      }
+      if (resolved?.output) return { output: resolved.output, tokenUsage }
       progress?.(
-        `[Clustering] Could not parse review response` +
+        `[Clustering] Could not use review response` +
           (attempt < CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS ? ' — retrying' : ''),
       )
     } catch (error) {

--- a/src/main/services/task-miner/clustering/prompts.ts
+++ b/src/main/services/task-miner/clustering/prompts.ts
@@ -24,7 +24,7 @@ Your tasks:
 3. FLAG: if a cluster marked "splittable": true mixes unrelated processes and you cannot split it cleanly, output { "id": ..., "incoherent": true } instead of a split — it will be re-grouped automatically.
 
 Rules:
-- Never invent cluster ids or sighting ids not present in the input.
+- Cluster and sighting ids are short handles ("c1", "s7"). Copy them back exactly as given — never invent, renumber, or reformat one. A mis-copied id discards that verdict.
 - When unsure whether two clusters are the same process, do NOT merge; leaving them apart is recoverable, merging is not.
 - Always output both keys, even when empty: no merges → "merges": [], no splits or flags → "clusters": [].
 
@@ -69,7 +69,7 @@ Output a verdict for EVERY cluster listed — a cluster missing from your output
 3. RECIPE: every verdict MUST carry "steps" and "variables" — this applies equally when the cluster already has a label. "steps" is an ordered, generalized how-to for the process: 3 to 12 short lines, each starting with an app identity from the member sightings' apps, then a colon and the imperative action. For a website, a recognizable product name may precede the host in parentheses — "Gmail (mail.google.com): open the client thread" — otherwise use the host alone: "dashboard.stripe.com: locate the customer profile". For a desktop app use its name: "Ghostty: run the deploy command". Never use a browser name as the app. Steps describe only actions the member sightings evidence; consolidate from the members' observed "steps" first — they are raw single runs: generalize across them and move their specifics into "variables". When runs used different mechanisms, generalize to the recurring one — do not canonicalize one run's incidental flow. "variables" lists the things that differ from run to run, named generically (e.g. "customer name", "invoice number", "search term"). This recipe is copied into outside automation tools, so it MUST be fully de-identified: never write a real person, company, email, phone number, account number, or url-with-id. Write "enter the customer name", never "enter ACME Inc"; move every changing specific into "variables" as a generic label.
 
 Rules:
-- Never invent cluster ids not present in the input.
+- Cluster ids are short handles ("c1"). Copy them back exactly as given — never invent, renumber, or reformat one. A mis-copied id discards that verdict.
 - Do not mention counts, frequencies, or durations in labels/descriptions — those are computed separately.
 - When unsure of the kind, choose the non-eliminable reading — a wrongly promised automation costs more than a missed one.
 - steps and variables carry NO personal data: no real names, companies, emails, phone numbers, ids, or PII/PHI. When in doubt, replace the specific with a generic variable.

--- a/src/main/services/task-miner/clustering/types.ts
+++ b/src/main/services/task-miner/clustering/types.ts
@@ -155,9 +155,4 @@ export interface ReviewMerge {
 export interface ReviewOutput {
   clusters?: ReviewClusterVerdict[]
   merges?: ReviewMerge[]
-  /**
-   * Set by id resolution, not by the model: false = some merge proposals were
-   * unreadable, so a candidate pair's absence from "merges" is not a decline.
-   */
-  mergesComplete?: boolean
 }

--- a/src/main/services/task-miner/clustering/types.ts
+++ b/src/main/services/task-miner/clustering/types.ts
@@ -155,4 +155,9 @@ export interface ReviewMerge {
 export interface ReviewOutput {
   clusters?: ReviewClusterVerdict[]
   merges?: ReviewMerge[]
+  /**
+   * Set by id resolution, not by the model: false = some merge proposals were
+   * unreadable, so a candidate pair's absence from "merges" is not a decline.
+   */
+  mergesComplete?: boolean
 }

--- a/src/main/services/task-miner/prompts.test.ts
+++ b/src/main/services/task-miner/prompts.test.ts
@@ -43,25 +43,32 @@ describe('buildScanSystemPrompt', () => {
 })
 
 describe('buildGroundingSystemPrompt', () => {
+  const UUID = '11111111-1111-4111-8111-111111111111'
   const candidate: Candidate = {
     title: 'Provision test tenant',
     subject: 'Acme staging tenant',
     description: 'Did the thing. Replace with: a script.',
     steps: ['admin.acme.com: create the tenant'],
-    activity_ids: ['a1', 'a2'],
+    activity_ids: [UUID],
   }
 
   it('carries subject through the keep-JSON so scanOnly=false persists it', () => {
-    expect(buildGroundingSystemPrompt(candidate, ['admin.acme.com'])).toContain('"subject"')
+    expect(buildGroundingSystemPrompt(candidate, ['admin.acme.com'], ['a1'])).toContain('"subject"')
   })
 
   it('asks for corrected steps in the keep-JSON', () => {
-    expect(buildGroundingSystemPrompt(candidate, ['admin.acme.com'])).toContain('"steps"')
+    expect(buildGroundingSystemPrompt(candidate, ['admin.acme.com'], ['a1'])).toContain('"steps"')
   })
 
   it('shows derived app identities and asks for no apps back', () => {
-    const prompt = buildGroundingSystemPrompt(candidate, ['admin.acme.com', 'Ghostty'])
+    const prompt = buildGroundingSystemPrompt(candidate, ['admin.acme.com', 'Ghostty'], ['a1'])
     expect(prompt).toContain('- Apps: admin.acme.com, Ghostty')
     expect(prompt).not.toContain('"apps"')
+  })
+
+  it('lists the handles it is given, never the candidate uuids', () => {
+    const prompt = buildGroundingSystemPrompt(candidate, ['admin.acme.com'], ['a1', 'a2'])
+    expect(prompt).toContain('- Activity IDs from scan: a1, a2')
+    expect(prompt).not.toContain(UUID)
   })
 })

--- a/src/main/services/task-miner/prompts.ts
+++ b/src/main/services/task-miner/prompts.ts
@@ -72,9 +72,13 @@ Quality over volume: a few findings I would actually build beat a long list. Man
 // Phase 2: Grounding prompt — confirm a candidate is a real, discrete task
 // ---------------------------------------------------------------------------
 
-export function buildGroundingSystemPrompt(candidate: Candidate, apps: readonly string[]): string {
+export function buildGroundingSystemPrompt(
+  candidate: Candidate,
+  apps: readonly string[],
+  activityIds: readonly string[],
+): string {
   const appList = formatList(apps, 'Unknown')
-  const activityIdList = formatList(candidate.activity_ids, 'None provided')
+  const activityIdList = formatList(activityIds, 'None provided')
 
   return `You are verifying ONE candidate run of a repeatable task, found by a scan of my day. Confirm it is real, grounded in the evidence on screen, and correctly scoped to this single run.
 

--- a/src/main/services/task-miner/run-detection.test.ts
+++ b/src/main/services/task-miner/run-detection.test.ts
@@ -196,6 +196,44 @@ describe('runDetection day commit', () => {
     expect(storage.sightings.getAll()[0].steps).toEqual(['TestApp: scan step'])
   })
 
+  it('grounds with short handles and reads the keep verdict back to real ids', async () => {
+    storage.activities.add({
+      id: 'act-3',
+      appName: 'TestApp',
+      windowTitle: 'w',
+      tld: null,
+      startTimestamp: dayStart(1) + 3000,
+      endTimestamp: dayStart(1) + 3500,
+      summary: 's',
+      summaryModel: '',
+      ocrText: '',
+      vector: v(0.1),
+    })
+    mockedGenerateText
+      .mockResolvedValueOnce(
+        scanResponse(
+          `\`\`\`json
+[{"title":"Do the thing","subject":"thing","description":"d","activity_ids":["a1","a2","a3"]}]
+\`\`\``,
+        ),
+      )
+      .mockResolvedValueOnce(
+        scanResponse(`\`\`\`json
+{"verdict":"keep","title":"Do the thing","description":"d","activity_ids":["a1","a3"]}
+\`\`\``),
+      )
+
+    await runDetection(provider, storage, embedder, { lookbackDays: 1, scanOnly: false })
+
+    const groundCall = mockedGenerateText.mock.calls[1][0]
+    expect(groundCall.system).toContain('- Activity IDs from scan: a1, a2, a3')
+    expect(groundCall.system).not.toContain('act-1')
+    expect(groundCall.prompt).not.toContain('act-1')
+    expect(groundCall.prompt).toContain('"a1"')
+    // Not the scan's three — proof the verdict's handles decoded, not fell back.
+    expect(storage.sightings.getAll()[0].activityIds).toEqual(['act-1', 'act-3'])
+  })
+
   it('persists no sightings when the commit callback throws (atomic day)', async () => {
     mockedGenerateText.mockResolvedValue(
       scanResponse(

--- a/src/main/services/task-miner/run-detection.ts
+++ b/src/main/services/task-miner/run-detection.ts
@@ -30,7 +30,6 @@ import { getKnownProcedureTitles } from './known-procedures'
 
 const GROUNDING_MAX_STEPS = 8
 const MIN_RUN_ACTIVITIES = 2
-const ACTIVITY = 'a'
 // A malformed scan response — no parseable JSON, or candidates that all fail
 // validation / cite unknown ids — silently loses the whole day, so retry it.
 // A response that parses to `[]` is a legitimate empty day, not a failure.
@@ -128,10 +127,10 @@ export async function runDetection(
   // Serve compact positional ids (a1..aN) to the scan instead of raw UUIDs —
   // models mangle long opaque ids when citing them (dropping whole findings),
   // and short handles cut prompt tokens. Mapped back right after parsing.
-  const activityIds = new PositionalAliases()
+  const activityIds = new PositionalAliases('a')
   const serialized = serializeActivities(activities).map((row, i) => ({
     ...row,
-    id: activityIds.encode(ACTIVITY, activities[i].id),
+    id: activityIds.encode(activities[i].id),
   }))
   const scanPrompt = buildScanSystemPrompt(label, userContextStr, knownProcedures)
   const scanUserMessage = `Here are all ${activities.length} activities from ${label}:\n\n\`\`\`json\n${JSON.stringify(serialized, null, 2)}\n\`\`\``
@@ -150,7 +149,7 @@ export async function runDetection(
     let unmappedIds = 0
     const candidates: Candidate[] = normalizedCandidates
       .map((c) => {
-        const { ids, unmapped } = activityIds.decodeMany(ACTIVITY, c.activity_ids)
+        const { ids, unmapped } = activityIds.decodeMany(c.activity_ids)
         unmappedIds += unmapped
         return { ...c, activity_ids: ids }
       })

--- a/src/main/services/task-miner/run-detection.ts
+++ b/src/main/services/task-miner/run-detection.ts
@@ -149,7 +149,7 @@ export async function runDetection(
     let unmappedIds = 0
     const candidates: Candidate[] = normalizedCandidates
       .map((c) => {
-        const { ids, unmapped } = activityIds.decodeMany(c.activity_ids) ?? { ids: [], unmapped: 0 }
+        const { ids, unmapped } = activityIds.decodeMany(c.activity_ids)
         unmappedIds += unmapped
         return { ...c, activity_ids: ids }
       })
@@ -239,7 +239,7 @@ export async function runDetection(
 
   const tools = cfg.scanOnly
     ? undefined
-    : buildVerificationTools(storage, embeddingService, start, end, progress)
+    : buildVerificationTools(storage, embeddingService, start, end, progress, activityIds)
   // The grounding tools (search/browse) can surface activities from other days;
   // a sighting must stay inside the day being mined, so its final ids are
   // intersected with this window before the duration is computed.
@@ -262,10 +262,11 @@ export async function runDetection(
         const groundPrompt = buildGroundingSystemPrompt(
           candidate,
           deriveSightingApps(candidateActivities),
+          candidate.activity_ids.map((id) => activityIds.encode(id)),
         )
 
         const enrichedActivities = candidateActivities.map((a) => ({
-          id: a.id,
+          id: activityIds.encode(a.id),
           app: a.appName,
           window_title: a.windowTitle,
           time: new Date(a.startTimestamp).toISOString(),
@@ -316,9 +317,15 @@ export async function runDetection(
 
       // Finalize activity_ids and resolve them to real activities. The window
       // and interaction time are computed from these — never LLM-estimated.
-      const requestedIds = (parsed.activity_ids as string[] | undefined)?.length
-        ? (parsed.activity_ids as string[])
-        : candidate.activity_ids
+      const cited = parsed.activity_ids
+      const gaveIds = Array.isArray(cited) && cited.length > 0
+      const decoded = activityIds.decodeMany(cited)
+      if (gaveIds && decoded.unmapped > 0) {
+        progress(
+          `[Phase 2] "${candidate.title}": dropped ${decoded.unmapped} unreadable activity id(s)`,
+        )
+      }
+      const requestedIds = gaveIds ? decoded.ids : candidate.activity_ids
       // Keep only ids inside the day being mined — a sighting can't span days,
       // and an out-of-window id would inflate the computed duration.
       const finalIds = requestedIds.filter((id) => dayActivityIds.has(id))

--- a/src/main/services/task-miner/run-detection.ts
+++ b/src/main/services/task-miner/run-detection.ts
@@ -5,6 +5,7 @@ import type { StorageService } from '../../storage'
 import type { Sighting } from '../../storage/sighting-repository'
 import type { ActivityEmbeddingService } from '@main/activity/activity-transformer-types'
 import type { InferenceProvider } from '../../llm'
+import { PositionalAliases } from '@main/llm/id-codec'
 import log from '@main/utils/logger'
 import type {
   TaskMinerConfig,
@@ -126,12 +127,11 @@ export async function runDetection(
   // Serve compact positional ids (a1..aN) to the scan instead of raw UUIDs —
   // models mangle long opaque ids when citing them (dropping whole findings),
   // and short handles cut prompt tokens. Mapped back right after parsing.
-  const realIdOf = new Map<string, string>()
-  const serialized = serializeActivities(activities).map((row, i) => {
-    const shortId = `a${i + 1}`
-    realIdOf.set(shortId, activities[i].id)
-    return { ...row, id: shortId }
-  })
+  const activityIds = new PositionalAliases().namespace('a')
+  const serialized = serializeActivities(activities).map((row, i) => ({
+    ...row,
+    id: activityIds.encode(activities[i].id),
+  }))
   const scanPrompt = buildScanSystemPrompt(label, userContextStr, knownProcedures)
   const scanUserMessage = `Here are all ${activities.length} activities from ${label}:\n\n\`\`\`json\n${JSON.stringify(serialized, null, 2)}\n\`\`\``
 
@@ -150,7 +150,7 @@ export async function runDetection(
     const candidates: Candidate[] = normalizedCandidates
       .map((c) => {
         const ids = c.activity_ids
-          .map((sid) => realIdOf.get(sid.trim()))
+          .map((sid) => activityIds.decode(sid))
           .filter((id): id is string => Boolean(id))
         unmappedIds += c.activity_ids.length - ids.length
         return { ...c, activity_ids: ids }

--- a/src/main/services/task-miner/run-detection.ts
+++ b/src/main/services/task-miner/run-detection.ts
@@ -149,7 +149,7 @@ export async function runDetection(
     let unmappedIds = 0
     const candidates: Candidate[] = normalizedCandidates
       .map((c) => {
-        const { ids, unmapped } = activityIds.decodeMany(c.activity_ids)
+        const { ids, unmapped } = activityIds.decodeMany(c.activity_ids) ?? { ids: [], unmapped: 0 }
         unmappedIds += unmapped
         return { ...c, activity_ids: ids }
       })

--- a/src/main/services/task-miner/run-detection.ts
+++ b/src/main/services/task-miner/run-detection.ts
@@ -30,6 +30,7 @@ import { getKnownProcedureTitles } from './known-procedures'
 
 const GROUNDING_MAX_STEPS = 8
 const MIN_RUN_ACTIVITIES = 2
+const ACTIVITY = 'a'
 // A malformed scan response — no parseable JSON, or candidates that all fail
 // validation / cite unknown ids — silently loses the whole day, so retry it.
 // A response that parses to `[]` is a legitimate empty day, not a failure.
@@ -127,10 +128,10 @@ export async function runDetection(
   // Serve compact positional ids (a1..aN) to the scan instead of raw UUIDs —
   // models mangle long opaque ids when citing them (dropping whole findings),
   // and short handles cut prompt tokens. Mapped back right after parsing.
-  const activityIds = new PositionalAliases().namespace('a')
+  const activityIds = new PositionalAliases()
   const serialized = serializeActivities(activities).map((row, i) => ({
     ...row,
-    id: activityIds.encode(activities[i].id),
+    id: activityIds.encode(ACTIVITY, activities[i].id),
   }))
   const scanPrompt = buildScanSystemPrompt(label, userContextStr, knownProcedures)
   const scanUserMessage = `Here are all ${activities.length} activities from ${label}:\n\n\`\`\`json\n${JSON.stringify(serialized, null, 2)}\n\`\`\``
@@ -149,10 +150,8 @@ export async function runDetection(
     let unmappedIds = 0
     const candidates: Candidate[] = normalizedCandidates
       .map((c) => {
-        const ids = c.activity_ids
-          .map((sid) => activityIds.decode(sid))
-          .filter((id): id is string => Boolean(id))
-        unmappedIds += c.activity_ids.length - ids.length
+        const { ids, unmapped } = activityIds.decodeMany(ACTIVITY, c.activity_ids)
+        unmappedIds += unmapped
         return { ...c, activity_ids: ids }
       })
       .filter((c) => c.activity_ids.length > 0)

--- a/src/main/services/task-miner/task-miner.test.ts
+++ b/src/main/services/task-miner/task-miner.test.ts
@@ -93,6 +93,14 @@ describe('TaskMiner sweep', () => {
     return new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysBack).getTime()
   }
 
+  // Pinned to local noon: these tests advance the clock by up to 90 minutes, and
+  // a run starting near midnight would recompute every day label a day later.
+  const useFakeClockAtNoon = (): void => {
+    const now = new Date()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12))
+  }
+
   // One activity per day, `days` days back through yesterday, so ensureEnqueued
   // bounds the window to exactly those days.
   const seedDays = (days: number): void => {
@@ -204,7 +212,7 @@ describe('TaskMiner sweep', () => {
   })
 
   it('skips past a failed day, keeps mining, and retries it after its cooldown', async () => {
-    vi.useFakeTimers()
+    useFakeClockAtNoon()
     seedDays(3)
     mockedRunDetection.mockRejectedValueOnce(new Error('provider down'))
 
@@ -225,7 +233,7 @@ describe('TaskMiner sweep', () => {
   })
 
   it('marks a day failed after exhausting attempts and sweeps past it', async () => {
-    vi.useFakeTimers()
+    useFakeClockAtNoon()
     seedDays(2)
     for (let i = 0; i < TASK_BACKFILL.MAX_DAY_ATTEMPTS; i++) {
       mockedRunDetection.mockRejectedValueOnce(new Error(`boom ${i + 1}`))
@@ -355,7 +363,7 @@ describe('TaskMiner sweep', () => {
   })
 
   it('the poll started by startup() triggers a sweep', async () => {
-    vi.useFakeTimers()
+    useFakeClockAtNoon()
     seedDays(2)
     seedFiller()
 
@@ -369,7 +377,7 @@ describe('TaskMiner sweep', () => {
   })
 
   it('a single day failure gates only that day, not the next sweep', async () => {
-    vi.useFakeTimers()
+    useFakeClockAtNoon()
     seedDays(2)
     seedFiller()
     mockedRunDetection.mockRejectedValueOnce(new Error('blip'))
@@ -387,7 +395,7 @@ describe('TaskMiner sweep', () => {
   })
 
   it('aborts the sweep after consecutive failures and gates the next one', async () => {
-    vi.useFakeTimers()
+    useFakeClockAtNoon()
     seedDays(5)
     seedFiller()
     mockedRunDetection.mockRejectedValue(new Error('down'))
@@ -508,7 +516,7 @@ describe('TaskMiner sweep', () => {
   })
 
   it('startup resets a stale running day so the sweep can retry it', async () => {
-    vi.useFakeTimers()
+    useFakeClockAtNoon()
     seedDays(1)
     storage.miningDays.enqueueMissing([localLabel(1)])
     storage.miningDays.claimOldestPending() // simulate a crash mid-mine

--- a/src/main/services/task-miner/tools.test.ts
+++ b/src/main/services/task-miner/tools.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as os from 'os'
+import * as path from 'path'
+import type { Tool, ToolExecutionOptions } from 'ai'
+import { StorageService } from '@main/storage'
+import { applyMigrations } from '@main/storage/migrator'
+import { deleteDbFiles, v } from '@main/storage/test-utils'
+import { PositionalAliases } from '@main/llm/id-codec'
+import type { ActivityEmbeddingService } from '@main/activity/activity-transformer-types'
+import { buildVerificationTools } from './tools'
+
+const UUID_1 = '11111111-1111-4111-8111-111111111111'
+const UUID_2 = '22222222-2222-4222-8222-222222222222'
+
+const embeddingService: ActivityEmbeddingService = { embed: async () => v(0.1) }
+
+interface Row {
+  id: string
+  app: string
+  window_title: string
+  time: string
+  summary: string
+}
+
+/** The SDK types execute as optionally absent and possibly streaming; ours is neither. */
+async function execute<IN, OUT extends Row>(target: Tool<IN, OUT[]>, params: IN): Promise<OUT[]> {
+  if (!target.execute) throw new Error('tool has no execute')
+  const result = await target.execute(params, {} as ToolExecutionOptions)
+  if (!Array.isArray(result)) throw new Error('tool streamed instead of returning rows')
+  return result
+}
+
+describe('buildVerificationTools id aliasing', () => {
+  const TEST_DB_PATH = path.join(os.tmpdir(), 'temp_miner_tools_test.db')
+  let storage: StorageService
+  let activityIds: PositionalAliases
+  let dayStart: number
+  let dayEnd: number
+
+  const build = () =>
+    buildVerificationTools(storage, embeddingService, dayStart, dayEnd, () => {}, activityIds)
+
+  beforeEach(() => {
+    deleteDbFiles(TEST_DB_PATH)
+    storage = new StorageService(TEST_DB_PATH)
+    applyMigrations(storage.getDatabase())
+    activityIds = new PositionalAliases('a')
+
+    const now = new Date()
+    dayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+    dayEnd = dayStart + 24 * 60 * 60 * 1000
+    for (const [i, id] of [UUID_1, UUID_2].entries()) {
+      storage.activities.add({
+        id,
+        appName: 'TestApp',
+        windowTitle: 'w',
+        tld: null,
+        startTimestamp: dayStart + (i + 1) * 60_000,
+        endTimestamp: dayStart + (i + 1) * 60_000 + 500,
+        summary: 's',
+        summaryModel: '',
+        ocrText: 'on screen',
+        vector: v(0.1),
+      })
+    }
+  })
+
+  afterEach(() => {
+    storage.close()
+    deleteDbFiles(TEST_DB_PATH)
+  })
+
+  it('accepts handles and returns handles, never a uuid', async () => {
+    expect(activityIds.encode(UUID_1)).toBe('a1')
+
+    const result = await execute(build().get_activity_ocr, { activity_ids: ['a1'] })
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: 'a1', ocr_text: 'on screen', app: 'TestApp' }),
+    ])
+  })
+
+  it('drops an unreadable handle instead of querying it', async () => {
+    activityIds.encode(UUID_1)
+
+    const result = await execute(build().get_activity_ocr, { activity_ids: ['a1', 'a9'] })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('a1')
+  })
+
+  it('mints handles for activities the browse tool surfaces first', async () => {
+    const result = await execute(build().browse_timeline, {
+      center_time: new Date(dayStart + 60_000).toISOString(),
+      window_minutes: 120,
+    })
+
+    expect(result.map((a) => a.id)).toEqual(['a1', 'a2'])
+    expect(activityIds.decode('a2')).toBe(UUID_2)
+  })
+
+  it('gives a browsed activity the same handle the scan already minted', async () => {
+    activityIds.encode(UUID_2)
+
+    const result = await execute(build().browse_timeline, {
+      center_time: new Date(dayStart + 60_000).toISOString(),
+      window_minutes: 120,
+    })
+
+    expect(result.map((a) => a.id)).toEqual(['a2', 'a1'])
+  })
+
+  it('returns handles from the search tool too', async () => {
+    const result = await execute(build().search_similar_activities, { query: 'anything', limit: 5 })
+
+    expect(result.length).toBeGreaterThan(0)
+    for (const a of result) expect(a.id).toMatch(/^a\d+$/)
+  })
+})

--- a/src/main/services/task-miner/tools.ts
+++ b/src/main/services/task-miner/tools.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai'
 import { z } from 'zod'
 import type { StorageService } from '../../storage'
 import type { ActivityEmbeddingService } from '@main/activity/activity-transformer-types'
+import type { PositionalAliases } from '@main/llm/id-codec'
 
 export function buildVerificationTools(
   storage: StorageService,
@@ -9,6 +10,7 @@ export function buildVerificationTools(
   dayStart: number,
   dayEnd: number,
   progress: (msg: string) => void,
+  activityIds: PositionalAliases,
 ) {
   return {
     get_activity_ocr: tool({
@@ -25,9 +27,11 @@ export function buildVerificationTools(
       }),
       execute: (params) => {
         progress(`  [tool] get_activity_ocr: ${params.activity_ids.length} IDs`)
-        const activities = storage.activities.getByIds(params.activity_ids)
+        const { ids, unmapped } = activityIds.decodeMany(params.activity_ids)
+        if (unmapped > 0) progress(`  [tool] get_activity_ocr: ${unmapped} unreadable ID(s)`)
+        const activities = storage.activities.getByIds(ids)
         return activities.map((a) => ({
-          id: a.id,
+          id: activityIds.encode(a.id),
           app: a.appName,
           window_title: a.windowTitle,
           time: new Date(a.startTimestamp).toISOString(),
@@ -52,7 +56,7 @@ export function buildVerificationTools(
           .filter((a) => a.startTimestamp >= dayStart && a.startTimestamp < dayEnd)
           .slice(0, params.limit ?? 10)
         return results.map((a) => ({
-          id: a.id,
+          id: activityIds.encode(a.id),
           app: a.appName,
           window_title: a.windowTitle,
           time: new Date(a.startTimestamp).toISOString(),
@@ -88,7 +92,7 @@ export function buildVerificationTools(
         )
         const activities = storage.activities.getForDay(rangeStart, rangeEnd)
         return activities.map((a) => ({
-          id: a.id,
+          id: activityIds.encode(a.id),
           app: a.appName,
           window_title: a.windowTitle,
           time: new Date(a.startTimestamp).toISOString(),


### PR DESCRIPTION
## Why

The cluster review calls put raw UUIDs in front of the model, in cluster ids, sighting ids and merge-candidate pairs. Models mangle long opaque ids when citing them back — a mangled cluster id drops that cluster's whole verdict — and each UUID costs 15-20 tokens against 2-3 for a short handle.

The scan already solved this locally: `runDetection` hand-rolled an `a1..aN` map over activity ids. This lifts that into a reusable codec and applies it to the review calls and the grounding phase too.

## What changed

**`src/main/llm/id-codec.ts`** — `PositionalAliases`: request-scoped `a1`, `c2`, `s37` handles, minted on first encode. One instance is bound to one prefix at construction, so a payload carrying several id kinds builds one instance per kind; a caller can hand back an id the original snapshot never contained. `decodeMany` reports how many handles did not resolve. Request-scoped only — one instance per LLM call or per day-scan, discarded with it. A shared instance would let a handle minted in an earlier call decode to a cluster this call never saw; a surface whose ids outlive the call (MCP) needs a stateless codec instead.

**`clustering/id-alias.ts`** — `aliasReviewInput` swaps every cluster and sighting uuid in the payload; `resolveReviewOutput` maps the response back. It takes `unknown` and returns `ReviewOutput`, because the body defends against arbitrary JSON — typing the parameter as `ReviewOutput` would make its own guards dead code to the compiler.

An unreadable id never costs more than its own scope:

- A verdict whose own id will not decode is dropped — it cannot be attributed to a cluster — and its siblings still apply.
- Two verdicts decoding to the same cluster mean a handle was mis-copied, and which of the two is the mis-cite is unknowable, so both are dropped. Short handles are what make this reachable: a mangled UUID resolved to nothing, a shifted `c4` resolves to a real cluster that was really shown, and `applyContent` has no member-set guard to catch it the way `applyStructure` catches a mis-cited merge. Dropping both is the cheap side of the trade — a cluster left without a verdict is re-queued by the next content round, a wrong label sticks.
- Undecodable sighting ids fall out of their split group, leaving `applyStructure`'s degenerate-split guard to handle the result.
- A merge proposal holding any undecodable id is dropped, and the rest of the list still applies. What the dropped proposal also costs is the decline inference: `applyStructure` records a candidate pair the model saw and left unmerged as a decline for the full 30-day TTL, and an incomplete list cannot be read as silence. That third state travels as `ResolvedReview.mergesIncomplete` into `StructureGuards.declinesInferable`, alongside the other "what was the model actually shown" guards — never through `ReviewOutput`, which is the model's contract and holds nothing id resolution invented. The other two states are unchanged: no merges key at all (degenerate, declines nothing) and a complete list (declines the rest). Partially readable proposals are dropped whole rather than merged as a subset: a 3-way merge read as 2-way is a different verdict than the one given.

Only an unusable *shape* — a response that is not a JSON object, or `clusters`/`merges` present but not an array — nulls the response, which is the existing "could not parse" retry.

**`clustering/prompts.ts`** — both review prompts now state the id format and that a mis-copied id costs its verdict. Under UUIDs an invented id was self-defeating; under short handles `c9` in a 12-cluster batch resolves to a real cluster, so the rule is worth a line.

**`llm-review.ts`** — aliasing happens once outside the retry loop, so handles stay stable across attempts. Unresolved handles are reported through `progress`, the same channel as every other message in the file, so they reach the MiningStatus banner and not just the log file — and only when the response is usable, so a shape failure reports as a parse failure rather than as unread ids.

**`run-detection.ts` / `tools.ts` / `prompts.ts`** — the hand-rolled `realIdOf` map is replaced by `PositionalAliases`, and phase 2 now speaks handles end to end. It previously spoke UUIDs while the scan spoke handles: the grounding prompt, its enriched activity list and all three verification tools handed the model raw ids and expected them back. They share the day's one instance, and an unreadable cited id is dropped with a progress line instead of silently failing to resolve.

## Test plan

- `npm test` — 1351 passed
- `npm run typecheck` — clean

New: `id-codec.test.ts` (per-prefix numbering, repeat encode, cross-prefix round-trip, prefix-scoped decode, unknown/malformed/non-string decode, `decodeMany` accounting), `id-alias.test.ts` (no uuid survives serialization, sighting numbering is payload-wide, verdict/split/merge round-trips, contested verdicts dropped, non-object responses rejected, and each failure path above), `tools.test.ts` (verification tools encode outgoing ids and decode cited ones), an `apply-review.test.ts` case that `declinesInferable: false` applies the readable merge while declining nothing, plus end-to-end assertions in `llm-review.test.ts` that the prompt carries `"c1"` and never the uuid while the result carries the uuid, that the prompt is byte-identical across retry attempts, that the content call aliases too, that a bad merge id costs its proposal and not the verdicts, and that a bad shape is reported as a parse failure rather than as unread ids.

## Notes

Split out of #266, which is closed — the prompt and mechanism changes there regressed on a real database. This commit is independent of both and touches no file they did.

Known trade: short handles make a corrupted id decodable. A mangled UUID essentially never resolved to a different valid entity, so corruption meant a drop; a transposed `s37` → `s73` resolves to a real sighting. Cross-cluster mis-cites are caught by `applyStructure`'s member-set guard, contested cluster verdicts by the duplicate rule above, so the residue is a within-cluster split-group mis-assignment — bounded, and the geometry re-split covers incoherent clusters. Payload-wide sighting numbering is what makes the numbers large; per-cluster numbering would shrink them if this ever shows up in practice.

Verified live against a real dev DB: 4 day-scans decoded their `a*` handles with `0 unknown ids`; three review calls round-tripped `c*`/`s*` through 5 merges, 3 splits and 20 labelled clusters with no unresolved handles, including a 2-day `--backfill` barrier pass at the 15-candidate cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
