### PR TITLE
PII filtering: two-tier scrub + login-screen capture gate (DEU-205)

### DIFF
--- a/scripts/download-model.js
+++ b/scripts/download-model.js
@@ -2,23 +2,28 @@
 const fs = require('fs')
 const path = require('path')
 
-const MODEL_ID = 'Xenova/all-MiniLM-L6-v2'
-const BASE_URL = `https://huggingface.co/${MODEL_ID}/resolve/main`
+const MODELS = [
+  {
+    id: 'Xenova/all-MiniLM-L6-v2',
+    files: ['config.json', 'tokenizer.json', 'tokenizer_config.json', 'onnx/model.onnx'],
+  },
+  {
+    id: 'nationaldesignstudio/rampart',
+    files: ['config.json', 'tokenizer.json', 'tokenizer_config.json', 'onnx/model_q4.onnx'],
+  },
+]
 
 const repoRoot = path.resolve(__dirname, '..')
-const outputDir = path.join(repoRoot, 'build', 'models', MODEL_ID)
 
-const FILES = ['config.json', 'tokenizer.json', 'tokenizer_config.json', 'onnx/model.onnx']
-
-async function downloadFile(file) {
+async function downloadFile(model, outputDir, file) {
   const dest = path.join(outputDir, file)
   if (fs.existsSync(dest)) {
-    console.log(`[build:model] Already exists, skipping: ${file}`)
+    console.log(`[build:model] Already exists, skipping: ${model.id}/${file}`)
     return
   }
 
-  const url = `${BASE_URL}/${file}`
-  console.log(`[build:model] Downloading ${file}...`)
+  const url = `https://huggingface.co/${model.id}/resolve/main/${file}`
+  console.log(`[build:model] Downloading ${model.id}/${file}...`)
 
   const res = await fetch(url)
   if (!res.ok) {
@@ -30,15 +35,18 @@ async function downloadFile(file) {
   const buffer = Buffer.from(await res.arrayBuffer())
   fs.writeFileSync(dest, buffer)
   const sizeMB = (buffer.length / 1024 / 1024).toFixed(1)
-  console.log(`[build:model] Saved ${file} (${sizeMB} MB)`)
+  console.log(`[build:model] Saved ${model.id}/${file} (${sizeMB} MB)`)
 }
 
 async function main() {
-  console.log(`[build:model] Downloading ${MODEL_ID} to ${outputDir}`)
-  fs.mkdirSync(outputDir, { recursive: true })
+  for (const model of MODELS) {
+    const outputDir = path.join(repoRoot, 'build', 'models', model.id)
+    console.log(`[build:model] Downloading ${model.id} to ${outputDir}`)
+    fs.mkdirSync(outputDir, { recursive: true })
 
-  for (const file of FILES) {
-    await downloadFile(file)
+    for (const file of model.files) {
+      await downloadFile(model, outputDir, file)
+    }
   }
 
   console.log('[build:model] Done.')

--- a/scripts/eval-pii-scrub.ts
+++ b/scripts/eval-pii-scrub.ts
@@ -16,8 +16,9 @@
 
 import * as fs from 'fs'
 import * as path from 'path'
-import Database from 'better-sqlite3'
-import { scrubPII } from '../src/shared/sanitize'
+import DatabaseConstructor from 'better-sqlite3'
+import { scrubPII, scrubPromptPII } from '../src/shared/sanitize'
+import { PiiScrubber } from '../src/main/processor/pii-scrub'
 import { getDefaultDbPath, getModelCacheDir } from '../src/main/utils/paths'
 import {
   PII_PLANTS,
@@ -63,6 +64,8 @@ const NER_MODELS: Record<string, { id: string; dtype: string }> = {
 
 const ALL_SCRUBBERS = [
   'current',
+  'prompt',
+  'shipped',
   'remove-pii',
   'redact-pii',
   'rampart',
@@ -382,6 +385,28 @@ function buildScrubber(spec: string, threshold: number, cache: Map<string, Scrub
       async () => scrubPII,
       () => '0MB (built-in)',
     )
+  } else if (spec === 'prompt') {
+    scrubber = makeSimpleScrubber(
+      'prompt',
+      async () => scrubPromptPII,
+      () => '0MB (built-in)',
+    )
+  } else if (spec === 'shipped') {
+    const shipped = new PiiScrubber()
+    scrubber = {
+      name: 'shipped',
+      loadMs: 0,
+      async init() {
+        const t0 = performance.now()
+        await shipped.scrubBatch(['warmup'])
+        this.loadMs = Math.round(performance.now() - t0)
+      },
+      async scrub(text: string) {
+        const [out] = await shipped.scrubBatch([text])
+        return out
+      },
+      footprint: () => '14MB model + 0MB (built-in)',
+    }
   } else if (spec === 'remove-pii') {
     scrubber = makeSimpleScrubber(
       'remove-pii',
@@ -508,7 +533,7 @@ function diffSample(before: string, after: string): { before: string; after: str
 function loadDayTexts(dbPath: string, day: string, includeOcr: boolean, cap: number): string[] {
   const start = new Date(`${day}T00:00:00`).getTime()
   const end = start + 24 * 60 * 60 * 1000
-  const db = new Database(dbPath, { readonly: true, fileMustExist: true })
+  const db = new DatabaseConstructor(dbPath, { readonly: true, fileMustExist: true })
   try {
     const rows = db
       .prepare(

--- a/src/main/activity/activity-transformer.test.ts
+++ b/src/main/activity/activity-transformer.test.ts
@@ -85,6 +85,17 @@ function makeDeps() {
   return { stitcher, ocr, semantic, embedder }
 }
 
+function makeLoginActivity(frameCount: number): Activity {
+  return {
+    ...makeActivity(frameCount),
+    context: {
+      appName: 'Google Chrome',
+      windowTitle: 'Okta',
+      url: 'https://login.okta.com/',
+    },
+  }
+}
+
 const OUTPUT_DIR = '/output'
 
 describe('DefaultActivityTransformer', () => {
@@ -203,6 +214,33 @@ describe('DefaultActivityTransformer', () => {
     })
     expect(ocr.extractText).not.toHaveBeenCalled()
     expect(result.ocrText).toBe('')
+  })
+
+  describe('login-screen OCR skip', () => {
+    it('skips OCR for a login-context activity', async () => {
+      const { stitcher, ocr, semantic, embedder } = makeDeps()
+      const transformer = new DefaultActivityTransformer(stitcher, ocr, semantic, embedder, {
+        outputDir: OUTPUT_DIR,
+      })
+
+      const result = await transformer.transform(makeLoginActivity(3))
+
+      expect(ocr.extractText).not.toHaveBeenCalled()
+      expect(result.ocrText).toBe('')
+    })
+
+    it('runs OCR on a login-context activity when the exclusion getter returns false', async () => {
+      const { stitcher, ocr, semantic, embedder } = makeDeps()
+      const transformer = new DefaultActivityTransformer(stitcher, ocr, semantic, embedder, {
+        outputDir: OUTPUT_DIR,
+        getExcludeLoginScreens: () => false,
+      })
+
+      const result = await transformer.transform(makeLoginActivity(3))
+
+      expect(ocr.extractText).toHaveBeenCalledTimes(1)
+      expect(result.ocrText).toBe('ocr text')
+    })
   })
 
   describe('passive view (no clicks/keys/scrolls)', () => {

--- a/src/main/activity/activity-transformer.ts
+++ b/src/main/activity/activity-transformer.ts
@@ -8,11 +8,13 @@ import type {
   ActivityEmbeddingService,
 } from './activity-transformer-types'
 import type { SemanticPipelinePreference } from '@main/semantic/activity-semantic-service'
+import { getLoginScreenMatch } from '@main/capture/capture-login-gate'
 import log from '@main/utils/logger'
 
 export interface DefaultActivityTransformerConfig {
   outputDir: string
   getPipelinePreference?: () => SemanticPipelinePreference
+  getExcludeLoginScreens?: () => boolean
 }
 
 const OCR_FRAME_POSITION_FROM_END = 5
@@ -81,6 +83,20 @@ export class DefaultActivityTransformer implements ActivityTransformer {
 
   private async extractOcrText(activity: Activity): Promise<string> {
     if (activity.frames.length === 0) return ''
+    if (this.config.getExcludeLoginScreens?.() !== false) {
+      const loginScreenMatch = getLoginScreenMatch({
+        processName: activity.context.appName,
+        bundleId: activity.context.bundleId,
+        title: activity.context.windowTitle,
+        url: activity.context.url,
+      })
+      if (loginScreenMatch !== null) {
+        log.debug(
+          `[ActivityTransformer] Skipping OCR for activity ${activity.id} (login_screen=${loginScreenMatch})`,
+        )
+        return ''
+      }
+    }
     const ocrFrame =
       activity.frames.length >= OCR_FRAME_POSITION_FROM_END
         ? activity.frames[activity.frames.length - OCR_FRAME_POSITION_FROM_END]

--- a/src/main/capture/capture-anonymous-mode.ts
+++ b/src/main/capture/capture-anonymous-mode.ts
@@ -35,11 +35,11 @@ const ANONYMOUS_MODE_MARKERS = [
   'about:incognito',
 ]
 
-function normalize(value: string | undefined): string {
+export function normalize(value: string | undefined): string {
   return value?.trim().toLowerCase() ?? ''
 }
 
-function normalizeProcessName(value: string | undefined): string {
+export function normalizeProcessName(value: string | undefined): string {
   const normalized = normalize(value)
   if (normalized.endsWith('.exe')) {
     return normalized.slice(0, -4)
@@ -52,7 +52,7 @@ function normalizeProcessName(value: string | undefined): string {
   return normalized
 }
 
-function isLikelyBrowser(window: AnonymousModeWindowContext): boolean {
+export function isLikelyBrowser(window: AnonymousModeWindowContext): boolean {
   const processName = normalizeProcessName(window.processName)
   const bundleId = normalize(window.bundleId)
 

--- a/src/main/capture/capture-blacklist-coordinator.test.ts
+++ b/src/main/capture/capture-blacklist-coordinator.test.ts
@@ -107,6 +107,7 @@ describe('capture blacklist coordinator', () => {
       apps: ['keepassxc'],
       urlPatterns: [],
       excludePrivateBrowsing: true,
+      excludeLoginScreens: true,
     })
 
     expect(flushCount).toBe(1)
@@ -256,6 +257,7 @@ describe('capture blacklist coordinator', () => {
       apps: [],
       urlPatterns: [],
       excludePrivateBrowsing: false,
+      excludeLoginScreens: true,
     })
 
     const sameWindowAfterDisable = appChangeEvent('chrome', {
@@ -289,6 +291,96 @@ describe('capture blacklist coordinator', () => {
 
     expect(suppressionTransitions).toEqual([])
     expect(forwarded).toEqual([terminalEvent])
+  })
+
+  it('suppresses screenshots and flushes events on a login screen', () => {
+    const forwarded: InteractionContext[] = []
+    const suppressionTransitions: boolean[] = []
+    let flushCount = 0
+
+    const coordinator = createCaptureBlacklistCoordinator({
+      initialExcludedApps: [],
+      forwardInteraction: (event) => forwarded.push(event),
+      flushEvents: () => {
+        flushCount++
+      },
+      setScreenshotsSuppressed: (suppressed) => {
+        suppressionTransitions.push(suppressed)
+      },
+    })
+
+    coordinator.handleInteraction(
+      appChangeEvent('Google Chrome', {
+        title: 'Okta',
+        url: 'https://login.okta.com/app/dashboard',
+      }),
+    )
+    coordinator.handleInteraction({ type: 'keyboard', timestamp: Date.now(), keyCount: 4 })
+
+    expect(flushCount).toBe(1)
+    expect(suppressionTransitions).toEqual([true])
+    expect(forwarded).toHaveLength(0)
+  })
+
+  it('resumes after navigating from a login screen to a post-auth url in the same window', () => {
+    const forwarded: InteractionContext[] = []
+    const suppressionTransitions: boolean[] = []
+
+    const coordinator = createCaptureBlacklistCoordinator({
+      initialExcludedApps: [],
+      forwardInteraction: (event) => forwarded.push(event),
+      flushEvents: () => undefined,
+      setScreenshotsSuppressed: (suppressed) => {
+        suppressionTransitions.push(suppressed)
+      },
+    })
+
+    coordinator.handleInteraction(
+      appChangeEvent('Google Chrome', {
+        hwnd: '0x6B0A0A',
+        title: 'Sign in to GitHub',
+        url: 'https://github.com/session/new',
+      }),
+    )
+    const postAuthWindow = appChangeEvent('Google Chrome', {
+      hwnd: '0x6B0A0A',
+      title: 'Pull requests - GitHub',
+      url: 'https://github.com/pulls',
+    })
+    coordinator.handleInteraction(postAuthWindow)
+
+    expect(suppressionTransitions).toEqual([true, false])
+    expect(forwarded).toEqual([postAuthWindow])
+  })
+
+  it('lifts an active login-screen block when the exclusion is disabled', () => {
+    const forwarded: InteractionContext[] = []
+    const suppressionTransitions: boolean[] = []
+
+    const coordinator = createCaptureBlacklistCoordinator({
+      initialExcludedApps: [],
+      forwardInteraction: (event) => forwarded.push(event),
+      flushEvents: () => undefined,
+      setScreenshotsSuppressed: (suppressed) => {
+        suppressionTransitions.push(suppressed)
+      },
+    })
+
+    coordinator.handleInteraction(
+      appChangeEvent('Google Chrome', {
+        title: 'Okta',
+        url: 'https://login.okta.com/',
+      }),
+    )
+
+    coordinator.updateExclusions({
+      apps: [],
+      urlPatterns: [],
+      excludePrivateBrowsing: true,
+      excludeLoginScreens: false,
+    })
+
+    expect(suppressionTransitions).toEqual([true, false])
   })
 
   it('enforces org-managed app exclusions immediately when synced', () => {
@@ -329,6 +421,7 @@ describe('capture blacklist coordinator', () => {
       apps: ['signal'],
       urlPatterns: [],
       excludePrivateBrowsing: true,
+      excludeLoginScreens: true,
     })
 
     coordinator.handleInteraction(appChangeEvent('Slack'))

--- a/src/main/capture/capture-blacklist-coordinator.ts
+++ b/src/main/capture/capture-blacklist-coordinator.ts
@@ -7,6 +7,7 @@ import {
   normalizeWildcardPatterns,
 } from './capture-exclusions'
 import { getAnonymousModeBrowserMatch } from './capture-anonymous-mode'
+import { getLoginScreenMatch } from './capture-login-gate'
 import { normalizeUrlPattern } from '@/shared/url-utils'
 
 export interface CaptureBlacklistCoordinator {
@@ -15,6 +16,7 @@ export interface CaptureBlacklistCoordinator {
     apps: string[]
     urlPatterns: string[]
     excludePrivateBrowsing: boolean
+    excludeLoginScreens: boolean
   }): void
   /** The org's centrally-synced blacklist (enterprise). Unioned with the user's
    * own exclusions for app/URL matching; private browsing stays user-only. */
@@ -25,6 +27,7 @@ export function createCaptureBlacklistCoordinator(params: {
   initialExcludedApps?: string[]
   initialExcludedUrlPatterns?: string[]
   initialExcludePrivateBrowsing?: boolean
+  initialExcludeLoginScreens?: boolean
   onPrivacyBlockingChanged?: (blocked: boolean) => void
   forwardInteraction: (event: InteractionContext) => void
   flushEvents: () => void
@@ -45,6 +48,7 @@ export function createCaptureBlacklistCoordinator(params: {
   let managedExcludedApps: string[] = []
   let managedExcludedUrlPatterns: string[] = []
   let excludePrivateBrowsing = params.initialExcludePrivateBrowsing ?? true
+  let excludeLoginScreens = params.initialExcludeLoginScreens ?? true
 
   let excludedApps = new Set<string>()
   let excludedUrlPatterns: string[] = []
@@ -56,6 +60,7 @@ export function createCaptureBlacklistCoordinator(params: {
   let blockedByExcludedApp = false
   let blockedByExcludedUrl = false
   let blockedByAnonymousBrowser = false
+  let blockedByLoginScreen = false
   const privateBrowserWindowHandles = new Set<string>()
   let lastActiveWindow: InteractionContext['activeWindow'] | undefined
 
@@ -90,18 +95,28 @@ export function createCaptureBlacklistCoordinator(params: {
     excludedAppMatch: string | null,
     excludedUrlMatch: string | null,
     anonymousModeMatch: string | null,
+    loginScreenMatch: string | null,
     reason: string,
   ): void => {
     const nextBlockedByExcludedApp = excludedAppMatch !== null
     const nextBlockedByExcludedUrl = excludedUrlMatch !== null
     const nextBlockedByAnonymousBrowser = anonymousModeMatch !== null
-    const wasBlocked = blockedByExcludedApp || blockedByExcludedUrl || blockedByAnonymousBrowser
+    const nextBlockedByLoginScreen = loginScreenMatch !== null
+    const wasBlocked =
+      blockedByExcludedApp ||
+      blockedByExcludedUrl ||
+      blockedByAnonymousBrowser ||
+      blockedByLoginScreen
     const blocked =
-      nextBlockedByExcludedApp || nextBlockedByExcludedUrl || nextBlockedByAnonymousBrowser
+      nextBlockedByExcludedApp ||
+      nextBlockedByExcludedUrl ||
+      nextBlockedByAnonymousBrowser ||
+      nextBlockedByLoginScreen
 
     blockedByExcludedApp = nextBlockedByExcludedApp
     blockedByExcludedUrl = nextBlockedByExcludedUrl
     blockedByAnonymousBrowser = nextBlockedByAnonymousBrowser
+    blockedByLoginScreen = nextBlockedByLoginScreen
 
     if (wasBlocked !== blocked) {
       params.onPrivacyBlockingChanged?.(blocked)
@@ -116,6 +131,7 @@ export function createCaptureBlacklistCoordinator(params: {
       if (excludedAppMatch !== null) details.push(`excluded_app=${excludedAppMatch}`)
       if (excludedUrlMatch !== null) details.push(`excluded_url=${excludedUrlMatch}`)
       if (anonymousModeMatch !== null) details.push(`anonymous_mode=${anonymousModeMatch}`)
+      if (loginScreenMatch !== null) details.push(`login_screen=${loginScreenMatch}`)
       log.info(`[Blacklist] Entering blocked mode (${reason}: ${details.join(', ')})`)
       return
     }
@@ -133,13 +149,20 @@ export function createCaptureBlacklistCoordinator(params: {
       ? getAnonymousModeBrowserMatch(activeWindow)
       : null
     const anonymousModeMatch = resolveAnonymousModeMatch(activeWindow, detectedAnonymousModeMatch)
+    const loginScreenMatch = excludeLoginScreens ? getLoginScreenMatch(activeWindow) : null
     log.debug(
       `[Blacklist] reconcile reason=${reason} url=${activeWindow?.url ?? '(none)'} ` +
         `urlMatch=${excludedUrlMatch ?? '(none)'} appMatch=${excludedAppMatch ?? '(none)'} ` +
-        `anon=${anonymousModeMatch ?? '(none)'} urlPatterns=${excludedUrlPatterns.length}`,
+        `anon=${anonymousModeMatch ?? '(none)'} login=${loginScreenMatch ?? '(none)'} ` +
+        `urlPatterns=${excludedUrlPatterns.length}`,
     )
-    setBlocked(excludedAppMatch, excludedUrlMatch, anonymousModeMatch, reason)
-    return excludedAppMatch === null && excludedUrlMatch === null && anonymousModeMatch === null
+    setBlocked(excludedAppMatch, excludedUrlMatch, anonymousModeMatch, loginScreenMatch, reason)
+    return (
+      excludedAppMatch === null &&
+      excludedUrlMatch === null &&
+      anonymousModeMatch === null &&
+      loginScreenMatch === null
+    )
   }
 
   return {
@@ -154,7 +177,12 @@ export function createCaptureBlacklistCoordinator(params: {
         return
       }
 
-      if (blockedByExcludedApp || blockedByExcludedUrl || blockedByAnonymousBrowser) {
+      if (
+        blockedByExcludedApp ||
+        blockedByExcludedUrl ||
+        blockedByAnonymousBrowser ||
+        blockedByLoginScreen
+      ) {
         return
       }
       params.forwardInteraction(event)
@@ -163,6 +191,7 @@ export function createCaptureBlacklistCoordinator(params: {
       userExcludedApps = normalizeExcludedApps(exclusions.apps)
       userExcludedUrlPatterns = normalizeUrlPatterns(exclusions.urlPatterns)
       excludePrivateBrowsing = exclusions.excludePrivateBrowsing
+      excludeLoginScreens = exclusions.excludeLoginScreens
       if (!excludePrivateBrowsing) {
         privateBrowserWindowHandles.clear()
       }

--- a/src/main/capture/capture-login-gate.test.ts
+++ b/src/main/capture/capture-login-gate.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { getLoginScreenMatch } from './capture-login-gate'
+
+describe('capture login gate detection', () => {
+  it('matches a login host prefix in a browser url', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Google Chrome',
+      title: 'Okta',
+      url: 'https://login.okta.com/',
+    })
+
+    expect(match).toBe('host=login.')
+  })
+
+  it('matches a schemeless accounts host', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Google Chrome',
+      title: 'Google Accounts',
+      url: 'accounts.google.com',
+    })
+
+    expect(match).toBe('host=accounts.')
+  })
+
+  it('matches an oauth path segment', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Firefox',
+      title: 'Authorize application',
+      url: 'https://example.com/oauth/authorize',
+    })
+
+    expect(match).toBe('path=oauth')
+  })
+
+  it('matches a sign-in title phrase in a browser', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Safari',
+      title: 'Sign in to GitHub',
+    })
+
+    expect(match).toBe('title=sign in')
+  })
+
+  it('matches a password manager by bundle id outside a browser', () => {
+    const match = getLoginScreenMatch({
+      processName: '1Password',
+      bundleId: 'com.1password.1password',
+      title: 'Vault',
+    })
+
+    expect(match).toBe('com.1password.1password')
+  })
+
+  it('ignores login-like file names in non-browser apps', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Code',
+      title: 'login.tsx — Visual Studio Code',
+    })
+
+    expect(match).toBeNull()
+  })
+
+  it('ignores a password manager marketing site in a browser', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Google Chrome',
+      title: '1Password Pricing',
+      url: 'https://1password.com/pricing',
+    })
+
+    expect(match).toBeNull()
+  })
+
+  it('ignores login mentioned inside a longer path segment', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Google Chrome',
+      title: 'Login best practices',
+      url: 'https://example.com/blog/login-best-practices',
+    })
+
+    expect(match).toBeNull()
+  })
+
+  it('ignores a host that merely contains a prefix substring', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Google Chrome',
+      title: 'Menu',
+      url: 'https://expresso.com/menu',
+    })
+
+    expect(match).toBeNull()
+  })
+
+  it('ignores a browser title about password requirements', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Google Chrome',
+      title: 'password requirements',
+    })
+
+    expect(match).toBeNull()
+  })
+
+  it('ignores a bare vendor docs url', () => {
+    const match = getLoginScreenMatch({
+      processName: 'Google Chrome',
+      title: 'Okta docs',
+      url: 'https://okta.com/docs',
+    })
+
+    expect(match).toBeNull()
+  })
+})

--- a/src/main/capture/capture-login-gate.ts
+++ b/src/main/capture/capture-login-gate.ts
@@ -1,0 +1,146 @@
+import { isLikelyBrowser, normalize, normalizeProcessName } from './capture-anonymous-mode'
+
+export interface LoginGateWindowContext {
+  processName?: string
+  bundleId?: string
+  title?: string
+  url?: string
+}
+
+const PASSWORD_MANAGER_BUNDLE_IDS = [
+  'com.1password.1password',
+  'com.agilebits.onepassword7',
+  'com.bitwarden.desktop',
+  'org.keepassxc.keepassxc',
+  'com.lastpass.lastpass',
+  'com.dashlane.dashlanephonefinal',
+  'in.sinew.enpass-desktop',
+]
+
+const PASSWORD_MANAGER_PROCESS_NAMES = [
+  '1password',
+  'bitwarden',
+  'keepassxc',
+  'lastpass',
+  'dashlane',
+  'enpass',
+]
+
+const LOGIN_HOST_PREFIXES = [
+  'login.',
+  'signin.',
+  'sso.',
+  'auth.',
+  'accounts.',
+  'id.',
+  'idp.',
+  'mfa.',
+]
+
+const LOGIN_PATH_SEGMENTS = [
+  'login',
+  'signin',
+  'sign-in',
+  'oauth',
+  'authorize',
+  'saml',
+  'sso',
+  '2fa',
+  'mfa',
+  'otp',
+  'reset-password',
+  'forgot-password',
+]
+
+const LOGIN_TITLE_PHRASES = [
+  'sign in',
+  'log in to',
+  'sign in to',
+  'two-factor',
+  'verification code',
+  'enter your password',
+  'authentication required',
+  'single sign-on',
+]
+
+function findPasswordManagerMarker(window: LoginGateWindowContext): string | null {
+  const bundleId = normalize(window.bundleId)
+  const processName = normalizeProcessName(window.processName)
+
+  for (const marker of PASSWORD_MANAGER_BUNDLE_IDS) {
+    if (bundleId === marker) {
+      return marker
+    }
+  }
+
+  for (const marker of PASSWORD_MANAGER_PROCESS_NAMES) {
+    if (processName.includes(marker)) {
+      return marker
+    }
+  }
+
+  return null
+}
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value)
+  } catch {
+    try {
+      return new URL(`https://${value}`)
+    } catch {
+      return null
+    }
+  }
+}
+
+function findLoginUrlMarker(url: string | undefined): string | null {
+  const normalized = normalize(url)
+  if (!normalized) return null
+
+  const parsed = parseUrl(normalized)
+  if (!parsed) return null
+
+  const host = parsed.hostname
+  const bareHost = host.startsWith('www.') ? host.slice(4) : host
+  for (const prefix of LOGIN_HOST_PREFIXES) {
+    if (host.startsWith(prefix) || bareHost.startsWith(prefix)) {
+      return `host=${prefix}`
+    }
+  }
+
+  const segments = parsed.pathname.split('/').filter(Boolean)
+  for (const segment of segments) {
+    if (LOGIN_PATH_SEGMENTS.includes(segment)) {
+      return `path=${segment}`
+    }
+  }
+
+  return null
+}
+
+function findLoginTitleMarker(title: string | undefined): string | null {
+  const normalized = normalize(title)
+
+  for (const phrase of LOGIN_TITLE_PHRASES) {
+    if (normalized.includes(phrase)) {
+      return `title=${phrase}`
+    }
+  }
+
+  return null
+}
+
+export function getLoginScreenMatch(window: LoginGateWindowContext | undefined): string | null {
+  if (!window) return null
+
+  const passwordManagerMarker = findPasswordManagerMarker(window)
+  if (passwordManagerMarker !== null) return passwordManagerMarker
+
+  if (!isLikelyBrowser(window)) return null
+
+  const urlMarker = findLoginUrlMarker(window.url)
+  if (urlMarker !== null) return urlMarker
+
+  return findLoginTitleMarker(window.title)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import { listInstalledApps } from './apps/installed-apps'
 import { VendorCredentialsManager } from './settings/vendor-credentials-manager'
 import { TaskMiner } from './services/task-miner'
 import type { MiningStatus } from '../shared/types'
+import { scrubPII } from '../shared/sanitize'
 import { UserContextBuilder } from './services/user-context-builder'
 import { RawDatabaseExportSync } from './services/raw-database-export-sync'
 import { DatabaseUploadSync } from './services/database-upload-sync'
@@ -297,6 +298,7 @@ app.on('ready', async () => {
     excludedApps: initialCaptureSettings.excludedApps,
     excludedUrlPatterns: initialCaptureSettings.excludedUrlPatterns,
     excludePrivateBrowsing: initialCaptureSettings.excludePrivateBrowsing,
+    excludeLoginScreens: initialCaptureSettings.excludeLoginScreens,
     deviceIdentity,
     vendorCredentials: vendorCredentialsManager,
     getActiveVendor: () => captureSettingsManager.get().activeVendor,
@@ -545,6 +547,8 @@ app.on('ready', async () => {
     evalRecorder: runtime.evalRecorder,
     evalFixtureStore: runtime.evalFixtureStore,
     taskFixtureStore: runtime.taskFixtureStore,
+    scrubTexts: (texts, allow) =>
+      runtime?.mlWorker.scrubBatch(texts, allow) ?? Promise.resolve(texts.map(scrubPII)),
   })
 
   runtime.accessProvider.startPeriodicRefresh()

--- a/src/main/mcp/formatting.ts
+++ b/src/main/mcp/formatting.ts
@@ -1,4 +1,5 @@
 import { ActivitySummary } from '../storage'
+import { scrubPromptPII } from '@/shared/sanitize'
 
 /**
  * Formats a single activity as a compact summary line with duration and screenshot count.
@@ -12,7 +13,7 @@ export function formatActivityLine(activity: {
 }): string {
   const timeStr = new Date(activity.startTimestamp).toLocaleString()
   const appInfo = activity.appName ? ` [${activity.appName}]` : ''
-  const summary = activity.summary || '(no summary)'
+  const summary = activity.summary ? scrubPromptPII(activity.summary) : '(no summary)'
   return `- ${activity.id} | ${timeStr}${appInfo} | ${summary}`
 }
 
@@ -46,8 +47,10 @@ export function activityToTimelineEntry(activity: ActivitySummary): TimelineEntr
 export function formatTimelineEntry(entry: TimelineEntry): string {
   const timeStr = new Date(entry.timestamp).toLocaleString()
   const appInfo = entry.appName ? ` [${entry.appName}]` : ''
-  const windowInfo = entry.windowTitle ? ` [window: ${JSON.stringify(entry.windowTitle)}]` : ''
-  const summary = entry.summary || '(no summary)'
+  const windowInfo = entry.windowTitle
+    ? ` [window: ${JSON.stringify(scrubPromptPII(entry.windowTitle))}]`
+    : ''
+  const summary = entry.summary ? scrubPromptPII(entry.summary) : '(no summary)'
   return `- ${entry.id} | ${timeStr}${appInfo}${windowInfo} | ${summary}`
 }
 

--- a/src/main/mcp/tools.test.ts
+++ b/src/main/mcp/tools.test.ts
@@ -293,6 +293,44 @@ describe('pattern tools (task clusters)', () => {
       expect(text).toContain('Activity IDs: act-a, act-b')
     })
 
+    it('scrubs secrets and phones from sighting fields but keeps emails and IDs verbatim', async () => {
+      addClusterWithMembers(createCluster({ id: 'c1', label: 'Send report' }), [
+        createSighting({
+          id: 's1',
+          subject: 'jane.doe@acme.co',
+          description: 'Used password: hunter42 and called +1 (555) 123-4567',
+          activityIds: ['act-a1', 'act-b2'],
+        }),
+        createSighting({ id: 's2' }),
+      ])
+
+      const text = (await handlers.get('get_pattern_details')!({ patternId: 'c1' })).content[0].text
+      expect(text).not.toContain('hunter42')
+      expect(text).not.toContain('555) 123-4567')
+      expect(text).toContain('[redacted password]')
+      expect(text).toContain('[phone number]')
+      expect(text).toContain('jane.doe@acme.co')
+      expect(text).toContain('Activity IDs: act-a1, act-b2')
+    })
+
+    it('scrubs secrets from activity summaries and OCR in get_activity_details', async () => {
+      storage.activities.add(
+        createStoredActivity({
+          id: 'act-ocr',
+          summary: 'Logged in with password: hunter42',
+          ocrText: 'Username: jane.doe@acme.co\nAPI_KEY=9f8e7d6c5b4a\nCall 555-123-4567',
+        }),
+      )
+
+      const text = (await handlers.get('get_activity_details')!({ ids: ['act-ocr'] })).content[0]
+        .text
+      expect(text).not.toContain('hunter42')
+      expect(text).not.toContain('9f8e7d6c5b4a')
+      expect(text).not.toContain('555-123-4567')
+      expect(text).toContain('jane.doe@acme.co')
+      expect(text).toContain('ID: act-ocr')
+    })
+
     it('never prints raw member step text (steps are not scrubbed for egress)', async () => {
       addClusterWithMembers(createCluster({ id: 'c1', label: 'Daily standup notes' }), [
         createSighting({

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -26,6 +26,7 @@ import {
 import { CLUSTER_VIEW_CONFIG } from '@/shared/constants'
 import type { ClusterInfo } from '../../shared/types'
 import log from '@main/utils/logger'
+import { scrubPromptPII } from '@/shared/sanitize'
 
 export interface MCPServices {
   storage: StorageService
@@ -617,9 +618,11 @@ function formatClusterLine(c: ClusterInfo): string {
   }
   stats.push(`avg ${Math.round(c.avgActiveMin)} min/run`)
   if (c.lastSeenAt) stats.push(`last seen ${new Date(c.lastSeenAt).toLocaleString()}`)
-  const lines = [`- ${c.id} | ${c.title} [${c.apps.join(', ')}] (${stats.join(', ')})`]
-  if (c.description) lines.push(`  ${c.description}`)
-  if (c.mechanism) lines.push(`  Replace with: ${c.mechanism}`)
+  const lines = [
+    `- ${c.id} | ${scrubPromptPII(c.title)} [${c.apps.join(', ')}] (${stats.join(', ')})`,
+  ]
+  if (c.description) lines.push(`  ${scrubPromptPII(c.description)}`)
+  if (c.mechanism) lines.push(`  Replace with: ${scrubPromptPII(c.mechanism)}`)
   return lines.join('\n')
 }
 
@@ -631,8 +634,8 @@ function formatClusterSightingLine(s: Sighting): string {
   const lines = [
     `- ${s.id} | ${start} -> ${end} | ~${activeMin} min active | [${s.apps.join(', ')}]`,
   ]
-  lines.push(`  ${title}`)
-  if (s.description) lines.push(`  ${s.description}`)
+  lines.push(`  ${scrubPromptPII(title)}`)
+  if (s.description) lines.push(`  ${scrubPromptPII(s.description)}`)
   lines.push(`  Activity IDs: ${s.activityIds.join(', ')}`)
   return lines.join('\n')
 }
@@ -830,7 +833,7 @@ async function handleGetUserContext(services: MCPServices | null) {
       content: [
         {
           type: 'text' as const,
-          text: `User profile (last updated: ${updatedAtStr}):\n\nShort summary:\n${ctx.shortSummary}\n\nDetailed summary:\n${ctx.detailedSummary}`,
+          text: `User profile (last updated: ${updatedAtStr}):\n\nShort summary:\n${scrubPromptPII(ctx.shortSummary)}\n\nDetailed summary:\n${scrubPromptPII(ctx.detailedSummary)}`,
         },
       ],
     }
@@ -881,8 +884,9 @@ async function handleGetActivityDetails(services: MCPServices | null, { ids }: {
         const timeStr = new Date(a.startTimestamp).toLocaleString()
         const endTimeStr = new Date(a.endTimestamp).toLocaleString()
         const appInfo = a.appName ? ` [${a.appName}]` : ''
-        const summaryLine = a.summary ? `\nSummary: ${a.summary}` : ''
-        return `ID: ${a.id}\n[${timeStr} → ${endTimeStr}]${appInfo}${summaryLine}\nOCR: ${a.ocrText}`
+        const summaryLine = a.summary ? `\nSummary: ${scrubPromptPII(a.summary)}` : ''
+        const ocrText = a.ocrText ? scrubPromptPII(a.ocrText) : a.ocrText
+        return `ID: ${a.id}\n[${timeStr} → ${endTimeStr}]${appInfo}${summaryLine}\nOCR: ${ocrText}`
       })
       .join('\n\n---\n\n')
 

--- a/src/main/processor/embedding-bundle.test.ts
+++ b/src/main/processor/embedding-bundle.test.ts
@@ -4,10 +4,18 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { pipeline, env } from '@huggingface/transformers'
 
 const MODEL_ID = 'Xenova/all-MiniLM-L6-v2'
+const NER_MODEL_ID = 'nationaldesignstudio/rampart'
 const BUNDLE_DIR = path.resolve(__dirname, '..', '..', '..', 'build', 'models')
 const MODEL_DIR = path.join(BUNDLE_DIR, MODEL_ID)
+const NER_MODEL_DIR = path.join(BUNDLE_DIR, NER_MODEL_ID)
 
 const REQUIRED_FILES = ['config.json', 'tokenizer.json', 'tokenizer_config.json', 'onnx/model.onnx']
+const NER_REQUIRED_FILES = [
+  'config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  'onnx/model_q4.onnx',
+]
 
 describe('bundled embedding model', () => {
   it('download script produced all required files', () => {
@@ -39,5 +47,34 @@ describe('bundled embedding model', () => {
     expect(vector.length).toBe(384)
     expect(typeof vector[0]).toBe('number')
     expect(isNaN(vector[0])).toBe(false)
+  })
+})
+
+describe('bundled pii ner model', () => {
+  it('download script produced all required files', () => {
+    for (const file of NER_REQUIRED_FILES) {
+      const filePath = path.join(NER_MODEL_DIR, file)
+      expect(fs.existsSync(filePath), `missing: ${file}`).toBe(true)
+      const stat = fs.statSync(filePath)
+      expect(stat.size, `${file} is empty`).toBeGreaterThan(0)
+    }
+  })
+
+  it('model loads fully offline from bundled path', { timeout: 30000 }, async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (() => {
+      throw new Error('Network call detected — bundled model should load without fetch')
+    }) as typeof fetch
+    afterEach(() => {
+      globalThis.fetch = originalFetch
+    })
+
+    env.localModelPath = BUNDLE_DIR
+    env.allowRemoteModels = false
+
+    const pipe = await pipeline('token-classification', NER_MODEL_ID, { dtype: 'q4' })
+    const result = (await pipe('Reviewed the invoice with Sarah Johnson yesterday.')) as unknown[]
+
+    expect(Array.isArray(result)).toBe(true)
   })
 })

--- a/src/main/processor/pii-scrub.test.ts
+++ b/src/main/processor/pii-scrub.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { PiiScrubber, type NerToken } from './pii-scrub'
+
+const tok = (entity: string, index: number, word: string, score = 0.9): NerToken => ({
+  entity,
+  score,
+  index,
+  word,
+  start: null,
+  end: null,
+})
+
+const fakePipe =
+  (tokensBySlice: (slice: string) => NerToken[]) =>
+  async (slice: string): Promise<NerToken[]> =>
+    tokensBySlice(slice)
+
+describe('PiiScrubber', () => {
+  it('reconstructs spans from null-offset tokens and replaces them', async () => {
+    const scrubber = new PiiScrubber(
+      fakePipe(() => [
+        tok('B-GIVENNAME', 1, 'pav'),
+        tok('I-GIVENNAME', 2, '##lina'),
+        tok('B-SURNAME', 3, 'koutecka'),
+      ]),
+    )
+    const [out] = await scrubber.scrubBatch(['Reviewed chat with Pavlina Koutecka today'])
+    expect(out).toBe('Reviewed chat with [redacted name] [redacted name] today')
+  })
+
+  it('shifts spans found in later windows back to global offsets', async () => {
+    const filler = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod. '
+    const text = filler.repeat(30) + 'Contact Jonathan for access.'
+    const scrubber = new PiiScrubber(
+      fakePipe((slice) => (slice.includes('Jonathan') ? [tok('B-GIVENNAME', 1, 'jonathan')] : [])),
+    )
+    const [out] = await scrubber.scrubBatch([text])
+    expect(out).toBe(filler.repeat(30) + 'Contact [redacted name] for access.')
+  })
+
+  it('merges overlapping spans into one placeholder', async () => {
+    const scrubber = new PiiScrubber(
+      fakePipe(() => [
+        { ...tok('B-NAME', 1, 'anna'), start: 5, end: 9 },
+        { ...tok('B-USERNAME', 5, 'anna-marie', 0.95), start: 5, end: 15 },
+      ]),
+    )
+    const [out] = await scrubber.scrubBatch(['ping anna-marie now'])
+    expect(out).toBe('ping [redacted username] now')
+  })
+
+  it('drops skip-listed entity types', async () => {
+    const scrubber = new PiiScrubber(fakePipe(() => [tok('B-URL', 1, 'example.com')]))
+    const [out] = await scrubber.scrubBatch(['visit example.com today'])
+    expect(out).toBe('visit example.com today')
+  })
+
+  it('skips spans matching the allowlist', async () => {
+    const scrubber = new PiiScrubber(fakePipe(() => [tok('B-NAME', 1, 'claude')]))
+    const [out] = await scrubber.scrubBatch(['opened Claude to review'], ['Claude Code'])
+    expect(out).toBe('opened Claude to review')
+  })
+
+  it('ignores tokens below the score threshold', async () => {
+    const scrubber = new PiiScrubber(fakePipe(() => [tok('B-NAME', 1, 'claude', 0.2)]))
+    const [out] = await scrubber.scrubBatch(['opened Claude to review'])
+    expect(out).toBe('opened Claude to review')
+  })
+
+  it('maps labels to typed placeholders and falls back for unknown labels', async () => {
+    const scrubber = new PiiScrubber(
+      fakePipe((slice) =>
+        slice.includes('jane@')
+          ? [tok('B-EMAIL', 1, 'jane@acme.co')]
+          : [tok('B-MYSTERY', 1, 'blob')],
+      ),
+    )
+    const [email, unknown] = await scrubber.scrubBatch(['mail jane@acme.co', 'the blob thing'])
+    expect(email).toBe('mail [email address]')
+    expect(unknown).toBe('the [redacted] thing')
+  })
+
+  it('applies the regex backstop after NER', async () => {
+    const scrubber = new PiiScrubber(fakePipe(() => []))
+    const [out] = await scrubber.scrubBatch(['mail jane.doe@acme.co about order 100294'])
+    expect(out).toBe('mail [email address] about order [id number]')
+  })
+
+  it('passes through empty and blank texts without model calls', async () => {
+    let calls = 0
+    const scrubber = new PiiScrubber(async () => {
+      calls++
+      return []
+    })
+    const out = await scrubber.scrubBatch(['', '   '])
+    expect(out).toEqual(['', '   '])
+    expect(calls).toBe(0)
+  })
+})

--- a/src/main/processor/pii-scrub.ts
+++ b/src/main/processor/pii-scrub.ts
@@ -1,0 +1,239 @@
+import log from '@main/utils/logger'
+import { configureModelEnv } from '@main/processor/embedding'
+import { scrubPII } from '@/shared/sanitize'
+
+const MODEL_NAME = 'nationaldesignstudio/rampart'
+const MODEL_DTYPE = 'q4'
+const SCORE_THRESHOLD = 0.5
+const WINDOW_CHARS = 1800
+const WINDOW_OVERLAP = 200
+
+const LABEL_PLACEHOLDERS: Record<string, string> = {
+  GIVENNAME: '[redacted name]',
+  SURNAME: '[redacted name]',
+  MIDDLENAME: '[redacted name]',
+  FIRSTNAME: '[redacted name]',
+  LASTNAME: '[redacted name]',
+  NAME: '[redacted name]',
+  PER: '[redacted name]',
+  PERSON: '[redacted name]',
+  EMAIL: '[email address]',
+  TELEPHONENUM: '[phone number]',
+  PHONENUMBER: '[phone number]',
+  PHONE: '[phone number]',
+  STREET: '[redacted address]',
+  STREETNAME: '[redacted address]',
+  STREETADDRESS: '[redacted address]',
+  SECONDARYADDRESS: '[redacted address]',
+  BUILDINGNUM: '[redacted address]',
+  CITY: '[redacted address]',
+  STATE: '[redacted address]',
+  ZIPCODE: '[redacted address]',
+  POSTCODE: '[redacted address]',
+  SOCIALNUM: '[redacted personal id]',
+  SOCIALSECURITYNUMBER: '[redacted personal id]',
+  SSN: '[redacted personal id]',
+  IDCARDNUM: '[redacted personal id]',
+  DRIVERLICENSENUM: '[redacted personal id]',
+  DRIVERSLICENSE: '[redacted personal id]',
+  PASSPORT: '[redacted personal id]',
+  PASSPORTNUM: '[redacted personal id]',
+  PASSPORTNUMBER: '[redacted personal id]',
+  TAXNUM: '[redacted personal id]',
+  TAXID: '[redacted personal id]',
+  GOVERNMENTID: '[redacted personal id]',
+  NATIONALID: '[redacted personal id]',
+  CREDITCARDNUMBER: '[redacted payment card]',
+  CREDITCARD: '[redacted payment card]',
+  ACCOUNTNUM: '[redacted bank account]',
+  IBAN: '[redacted bank account]',
+  ROUTINGNUM: '[redacted bank account]',
+  ROUTINGNUMBER: '[redacted bank account]',
+  DATEOFBIRTH: '[redacted date of birth]',
+  DOB: '[redacted date of birth]',
+  USERNAME: '[redacted username]',
+  PASSWORD: '[redacted password]',
+  SECRET: '[redacted secret]',
+  APIKEY: '[redacted secret]',
+  TOKEN: '[redacted secret]',
+}
+
+const SKIP_TYPES = new Set(['URL', 'BUILDINGNUMBER'])
+
+export interface NerToken {
+  entity: string
+  score: number
+  index: number
+  word: string
+  start: number | null
+  end: number | null
+}
+
+export type NerPipeline = (text: string) => Promise<NerToken[]>
+
+interface Span {
+  start: number
+  end: number
+  type: string
+  score: number
+}
+
+function normalizeLabel(type: string): string {
+  return type.toUpperCase().replace(/[^A-Z]/g, '')
+}
+
+function locateToken(
+  lowerText: string,
+  cursor: number,
+  word: string,
+): { start: number; end: number } | null {
+  const piece = word.replace(/^##/, '').replace(/▁/g, ' ').trim().toLowerCase()
+  if (!piece) return null
+  const at = lowerText.indexOf(piece, cursor)
+  if (at === -1) return null
+  return { start: at, end: at + piece.length }
+}
+
+function* windows(text: string): Generator<{ offset: number; slice: string }> {
+  if (text.length <= WINDOW_CHARS) {
+    yield { offset: 0, slice: text }
+    return
+  }
+  let offset = 0
+  while (offset < text.length) {
+    yield { offset, slice: text.slice(offset, offset + WINDOW_CHARS) }
+    if (offset + WINDOW_CHARS >= text.length) break
+    offset += WINDOW_CHARS - WINDOW_OVERLAP
+  }
+}
+
+function buildSpans(text: string, toks: NerToken[], threshold: number): Span[] {
+  const lower = text.toLowerCase()
+  const spans: Span[] = []
+  let cur: (Span & { lastIndex: number }) | null = null
+  let cursor = 0
+
+  for (const tok of toks) {
+    if (tok.score < threshold) continue
+    const type = tok.entity.replace(/^[BI]-/, '')
+    let start = typeof tok.start === 'number' ? tok.start : null
+    let end = typeof tok.end === 'number' ? tok.end : null
+    if (start === null || end === null) {
+      const located = locateToken(lower, cursor, tok.word)
+      if (!located) continue
+      start = located.start
+      end = located.end
+    }
+    cursor = Math.max(cursor, end)
+
+    if (cur && cur.type === type && tok.index === cur.lastIndex + 1) {
+      cur.end = Math.max(cur.end, end)
+      cur.score = Math.max(cur.score, tok.score)
+      cur.lastIndex = tok.index
+    } else {
+      if (cur) spans.push({ start: cur.start, end: cur.end, type: cur.type, score: cur.score })
+      cur = { start, end, type, score: tok.score, lastIndex: tok.index }
+    }
+  }
+  if (cur) spans.push({ start: cur.start, end: cur.end, type: cur.type, score: cur.score })
+  return spans
+}
+
+function mergeSpans(spans: Span[]): Span[] {
+  const sorted = [...spans].sort((a, b) => a.start - b.start || b.end - a.end)
+  const merged: Span[] = []
+  for (const span of sorted) {
+    const last = merged[merged.length - 1]
+    if (last && span.start < last.end) {
+      last.end = Math.max(last.end, span.end)
+      if (span.score > last.score) last.type = span.type
+    } else {
+      merged.push({ ...span })
+    }
+  }
+  return merged
+}
+
+function replaceSpans(text: string, spans: (Span & { placeholder: string })[]): string {
+  let out = text
+  for (const span of [...spans].sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, span.start) + span.placeholder + out.slice(span.end)
+  }
+  return out
+}
+
+function isAllowed(spanText: string, allow: string[]): boolean {
+  const norm = spanText.trim().toLowerCase()
+  if (!norm) return false
+  return allow.some((entry) => {
+    const e = entry.trim().toLowerCase()
+    return e === norm || e.split(/\s+/).includes(norm)
+  })
+}
+
+export class PiiScrubber {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private pipe: any = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private loading: Promise<any> | null = null
+
+  constructor(pipe?: NerPipeline) {
+    this.pipe = pipe ?? null
+  }
+
+  private async ensurePipe(): Promise<NerPipeline> {
+    if (this.pipe) return this.pipe
+    if (!this.loading) {
+      this.loading = (async () => {
+        configureModelEnv()
+        const t0 = Date.now()
+        const { pipeline } = await import('@huggingface/transformers')
+        const pipe = await pipeline('token-classification', MODEL_NAME, { dtype: MODEL_DTYPE })
+        log.debug(`[PiiScrubber] loaded ${MODEL_NAME} in ${Date.now() - t0}ms`)
+        return pipe
+      })()
+      this.loading.catch(() => {
+        this.loading = null
+      })
+    }
+    this.pipe = await this.loading
+    return this.pipe
+  }
+
+  async scrubBatch(texts: string[], allow: string[] = []): Promise<string[]> {
+    if (texts.length === 0) return []
+    const pipe = await this.ensurePipe()
+    const t0 = Date.now()
+    let spanCount = 0
+    let charCount = 0
+    const out: string[] = []
+    for (const text of texts) {
+      charCount += text.length
+      if (!text.trim()) {
+        out.push(text)
+        continue
+      }
+      const spans: Span[] = []
+      for (const { offset, slice } of windows(text)) {
+        const raw = await pipe(slice)
+        for (const span of buildSpans(slice, raw, SCORE_THRESHOLD)) {
+          spans.push({ ...span, start: span.start + offset, end: span.end + offset })
+        }
+      }
+      const kept = spans.filter(
+        (s) =>
+          !SKIP_TYPES.has(normalizeLabel(s.type)) && !isAllowed(text.slice(s.start, s.end), allow),
+      )
+      spanCount += kept.length
+      const resolved = mergeSpans(kept).map((s) => ({
+        ...s,
+        placeholder: LABEL_PLACEHOLDERS[normalizeLabel(s.type)] ?? '[redacted]',
+      }))
+      out.push(scrubPII(replaceSpans(text, resolved)))
+    }
+    log.debug(
+      `[PiiScrubber] scrubBatch n=${texts.length} chars=${charCount} spans=${spanCount} ms=${Date.now() - t0}`,
+    )
+    return out
+  }
+}

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -55,6 +55,7 @@ export interface MainRuntime {
     apps: string[]
     urlPatterns: string[]
     excludePrivateBrowsing: boolean
+    excludeLoginScreens: boolean
   }): void
   setManagedExclusions(managed: { apps: string[]; urlPatterns: string[] }): void
   purgeAll(): Promise<void>
@@ -69,6 +70,7 @@ export async function createMainRuntime(params: {
   excludedApps?: string[]
   excludedUrlPatterns?: string[]
   excludePrivateBrowsing?: boolean
+  excludeLoginScreens?: boolean
   deviceIdentity?: DeviceIdentity
   edition: AppEdition
   vendorCredentials: VendorCredentialsManager
@@ -156,6 +158,8 @@ export async function createMainRuntime(params: {
     throw error
   }
 
+  let excludeLoginScreens = params.excludeLoginScreens ?? true
+
   const transformer = new DefaultActivityTransformer(
     new FfmpegVideoStitcher(),
     activityOcrService,
@@ -164,6 +168,7 @@ export async function createMainRuntime(params: {
     {
       outputDir,
       getPipelinePreference: () => semanticService.getPipelinePreference(),
+      getExcludeLoginScreens: () => excludeLoginScreens,
     },
   )
   const sink = new SqliteActivitySink(storage.activities)
@@ -200,6 +205,7 @@ export async function createMainRuntime(params: {
     initialExcludedApps: params.excludedApps,
     initialExcludedUrlPatterns: params.excludedUrlPatterns,
     initialExcludePrivateBrowsing: params.excludePrivateBrowsing,
+    initialExcludeLoginScreens: params.excludeLoginScreens,
     onPrivacyBlockingChanged: params.onPrivacyBlockingChanged,
     forwardInteraction: (event) => {
       // Dump only events that passed the blacklist — excluded window
@@ -250,6 +256,7 @@ export async function createMainRuntime(params: {
     taskFixtureStore,
     evalFixturesRoot,
     updateExclusions(exclusions): void {
+      excludeLoginScreens = exclusions.excludeLoginScreens
       blacklistCoordinator.updateExclusions(exclusions)
     },
     setManagedExclusions(managed): void {

--- a/src/main/semantic/prompt.ts
+++ b/src/main/semantic/prompt.ts
@@ -1,5 +1,6 @@
 import type { InteractionContext } from '../../shared/types'
 import type { Activity } from '@main/activity/activity-types'
+import { scrubPromptPII } from '@/shared/sanitize'
 import type { SemanticMode } from './types'
 
 export function buildSemanticPrompt(
@@ -26,6 +27,8 @@ export function buildSemanticPrompt(
   prompt +=
     '- Be specific: name files, functions, errors, URLs, and UI elements visible in the provided media.\n'
   prompt +=
+    '- NEVER transcribe credentials, API keys, or payment/account numbers. Replace them with a typed placeholder ([redacted password], [redacted secret], [redacted payment card]) — never silently omit what happened.\n'
+  prompt +=
     '- Match verb intensity to evidence: browsing/reviewing (no visible edits) -> "browsed," "reviewed," "checked." Light editing (small visible changes) -> "tweaked," "adjusted." Active work (sustained edits, new code, debugging) -> "implemented," "debugged," "refactored." Evidence of editing = visible changed lines, new code, or diff markers.\n'
   prompt +=
     '- Do NOT exaggerate. Switching files/tabs = browsing, not editing. Opening a file/page = reviewing, not working on it.\n'
@@ -44,7 +47,7 @@ export function buildSemanticPrompt(
   prompt += '## Context\n'
   prompt += `- App: ${activity.context.appName}\n`
   if (activity.context.windowTitle) {
-    prompt += `- Window: ${activity.context.windowTitle}\n`
+    prompt += `- Window: ${scrubPromptPII(activity.context.windowTitle)}\n`
   }
   if (activity.context.tld) {
     prompt += `- TLD: ${activity.context.tld}\n`
@@ -53,7 +56,7 @@ export function buildSemanticPrompt(
   prompt += `- Start: ${new Date(activity.startTimestamp).toISOString()}\n`
   prompt += `- End: ${new Date(activity.endTimestamp).toISOString()}\n`
   if (userContext) {
-    prompt += `- User: ${userContext}\n`
+    prompt += `- User: ${scrubPromptPII(userContext)}\n`
   }
   prompt += `- ${sourceNote}\n\n`
 
@@ -86,7 +89,7 @@ function buildInteractionTimeline(activity: Activity): string {
   const items: string[] = []
   for (const interaction of interactions.slice(0, maxItems)) {
     const offsetSeconds = ((interaction.timestamp - activity.startTimestamp) / 1000).toFixed(1)
-    items.push(`- t+${offsetSeconds}s: ${describeInteraction(interaction)}`)
+    items.push(`- t+${offsetSeconds}s: ${scrubPromptPII(describeInteraction(interaction))}`)
   }
 
   if (interactions.length > maxItems) {

--- a/src/main/services/ml-worker-client.ts
+++ b/src/main/services/ml-worker-client.ts
@@ -3,6 +3,7 @@ import type { UtilityProcess } from 'electron'
 import * as os from 'os'
 import * as path from 'path'
 import log from '@main/utils/logger'
+import { scrubPII } from '@/shared/sanitize'
 import { getBundledModelPath, getModelCacheDir } from '@main/utils/paths'
 import { isWorkerLogEvent, logWorkerEvent, type WorkerLogEvent } from '@main/utils/worker-log'
 import type { ActivityEmbeddingService } from '@main/activity/activity-transformer-types'
@@ -26,6 +27,9 @@ function workerScriptPath(): string {
 const INIT_TIMEOUT_MS = 15 * 60 * 1000
 const EMBED_TIMEOUT_MS = 60 * 1000
 const CLUSTER_TIMEOUT_MS = 2 * 60 * 1000
+// First scrub may download the NER model in dev, and a timeout kills the
+// shared worker that also serves embeddings — err far on the generous side.
+const SCRUB_TIMEOUT_MS = 5 * 60 * 1000
 const RESPAWN_WINDOW_MS = 60 * 1000
 const MAX_SPAWNS_PER_WINDOW = 3
 
@@ -84,6 +88,22 @@ export class MlWorkerClient implements ActivityEmbeddingService {
     )
     if (result.type !== 'groups') throw new Error(`ml-worker: unexpected ${result.type} response`)
     return result.groups
+  }
+
+  /** NER + regex PII scrub in the worker; falls back to the local regex scrub
+   * on any worker error so egress is never left unscrubbed. */
+  async scrubBatch(texts: string[], allow?: string[]): Promise<string[]> {
+    if (texts.length === 0) return []
+    try {
+      await this.ensureReady()
+      const result = await this.request({ type: 'scrubBatch', texts, allow }, SCRUB_TIMEOUT_MS)
+      if (result.type !== 'scrubbed')
+        throw new Error(`ml-worker: unexpected ${result.type} response`)
+      return result.texts
+    } catch (error) {
+      log.warn('[MlWorker] scrubBatch failed; falling back to regex scrub', error)
+      return texts.map(scrubPII)
+    }
   }
 
   dispose(): void {

--- a/src/main/services/ml-worker-protocol.ts
+++ b/src/main/services/ml-worker-protocol.ts
@@ -8,6 +8,7 @@ export type MlWorkerRequestBody =
   | { type: 'init'; bundledModelPath: string | null; cacheDir: string; maxThreads: number | null }
   | { type: 'embedBatch'; texts: string[] }
   | { type: 'clusterVectors'; vectors: ArrayBuffer; dims: number; threshold: number }
+  | { type: 'scrubBatch'; texts: string[]; allow?: string[] }
 
 export type MlWorkerRequest = MlWorkerRequestBody & { id: number }
 
@@ -15,6 +16,7 @@ export type MlWorkerResult =
   | { type: 'ready' }
   | { type: 'vectors'; vectors: ArrayBuffer; dims: number }
   | { type: 'groups'; groups: number[][] }
+  | { type: 'scrubbed'; texts: string[] }
 
 export type MlWorkerResponse =
   | { id: number; ok: true; result: MlWorkerResult }

--- a/src/main/services/ml-worker.test.ts
+++ b/src/main/services/ml-worker.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { handleMlWorkerRequest } from './ml-worker'
 import { packVectors, unpackVectors } from './ml-worker-protocol'
+import { PiiScrubber } from '@main/processor/pii-scrub'
 import type { EmbeddingService } from '@main/processor/embedding'
 
 const fakeService = {
@@ -51,6 +52,20 @@ describe('handleMlWorkerRequest', () => {
     expect(response.ok).toBe(true)
     if (!response.ok || response.result.type !== 'groups') throw new Error('wrong response')
     expect(response.result.groups).toEqual([[0, 1], [2]])
+  })
+
+  it('scrubBatch returns scrubbed texts', async () => {
+    const scrubber = new PiiScrubber(async () => [
+      { entity: 'B-GIVENNAME', score: 0.9, index: 1, word: 'jane', start: null, end: null },
+    ])
+    const response = await handleMlWorkerRequest(
+      { id: 4, type: 'scrubBatch', texts: ['ping Jane about it'] },
+      fakeService,
+      scrubber,
+    )
+    expect(response.ok).toBe(true)
+    if (!response.ok || response.result.type !== 'scrubbed') throw new Error('wrong response')
+    expect(response.result.texts).toEqual(['ping [redacted name] about it'])
   })
 
   it('maps a thrown error to ok:false', async () => {

--- a/src/main/services/ml-worker.ts
+++ b/src/main/services/ml-worker.ts
@@ -1,4 +1,5 @@
 import { EmbeddingService, configureModelEnv } from '@main/processor/embedding'
+import { PiiScrubber } from '@main/processor/pii-scrub'
 import { averageLinkageGroupIndices } from '@main/services/task-miner/clustering/attach'
 import { forwardLogsToParent, type WorkerLogEvent } from '@main/utils/worker-log'
 import {
@@ -15,11 +16,13 @@ import {
  */
 
 const embedder = new EmbeddingService()
+const piiScrubber = new PiiScrubber()
 
 /** Exported for unit tests; the parentPort wiring below is the runtime path. */
 export async function handleMlWorkerRequest(
   request: MlWorkerRequest,
   service: EmbeddingService = embedder,
+  scrubber: PiiScrubber = piiScrubber,
 ): Promise<MlWorkerResponse> {
   try {
     switch (request.type) {
@@ -40,6 +43,10 @@ export async function handleMlWorkerRequest(
         const vectors = unpackVectors(request.vectors, request.dims)
         const groups = averageLinkageGroupIndices(vectors, request.threshold)
         return { id: request.id, ok: true, result: { type: 'groups', groups } }
+      }
+      case 'scrubBatch': {
+        const texts = await scrubber.scrubBatch(request.texts, request.allow ?? [])
+        return { id: request.id, ok: true, result: { type: 'scrubbed', texts } }
       }
     }
   } catch (error) {

--- a/src/main/services/task-miner/clustering/index.ts
+++ b/src/main/services/task-miner/clustering/index.ts
@@ -53,6 +53,8 @@ export interface ClusteringDeps {
   ) => Promise<number[][]>
   /** Absent → deterministic steps only (offline / tests). */
   provider?: InferenceProvider
+  /** NER egress scrub for model-written review output; absent → regex-only downstream. */
+  scrub?: (texts: string[], allow?: string[]) => Promise<string[]>
   model: string
   now?: number
   onProgress?: ProgressCallback
@@ -171,7 +173,7 @@ export async function runClustering(deps: ClusteringDeps): Promise<ClusteringRun
     try {
       const review = deps.structureReview
         ? await deps.structureReview(input)
-        : await runStructureReview(provider, model, input, progress)
+        : await runStructureReview(provider, model, input, progress, deps.scrub)
       summary.tokenUsage.input += review.tokenUsage.input
       summary.tokenUsage.output += review.tokenUsage.output
       if (!review.output) {
@@ -246,7 +248,7 @@ async function contentRound(
     try {
       const round = deps.contentReview
         ? await deps.contentReview(input)
-        : await runContentReview(provider, model, input, progress)
+        : await runContentReview(provider, model, input, progress, deps.scrub)
       summary.tokenUsage.input += round.tokenUsage.input
       summary.tokenUsage.output += round.tokenUsage.output
       if (!round.output) {

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -71,3 +71,87 @@ describe('runContentReview', () => {
     expect(mockedGenerateText).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('PII scrubbing', () => {
+  const memberInput = {
+    clusters: [
+      {
+        id: 'c1',
+        splittable: false,
+        label: '',
+        stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
+        members: [
+          {
+            sighting_id: 's1',
+            title: 'Email jane.doe@acme.co the report',
+            subject: 'password: hunter42',
+            description: 'Sent the weekly report',
+            steps: ['mail.google.com: mail jane.doe@acme.co'],
+            apps: ['mail.google.com'],
+            active_min: 5,
+            date: '2026-07-30',
+          },
+        ],
+      },
+    ],
+    mergeCandidates: [] as [string, string][],
+  }
+
+  it('scrubs secrets from the prompt but keeps emails for context', async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: '{"clusters":[]}',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never)
+
+    await runContentReview(provider, 'model', memberInput)
+
+    const call = mockedGenerateText.mock.calls[0][0] as { prompt: string }
+    expect(call.prompt).not.toContain('hunter42')
+    expect(call.prompt).toContain('[redacted password]')
+    expect(call.prompt).toContain('jane.doe@acme.co')
+  })
+
+  it('scrubs model-written output through the injected scrubber before returning', async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: JSON.stringify({
+        clusters: [
+          {
+            id: 'c1',
+            label: 'Email Jane Novak the report',
+            description: 'Weekly report emailing',
+            steps: ['mail.google.com: mail Jane Novak'],
+            variables: ['recipient'],
+          },
+        ],
+      }),
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never)
+    const scrub = vi.fn(async (texts: string[]) =>
+      texts.map((t) => t.replace(/Jane Novak/g, '[redacted name]')),
+    )
+
+    const result = await runContentReview(provider, 'model', memberInput, undefined, scrub)
+
+    expect(scrub).toHaveBeenCalledWith(expect.arrayContaining(['Email Jane Novak the report']), [
+      'mail.google.com',
+    ])
+    expect(result.output?.clusters?.[0]).toEqual({
+      id: 'c1',
+      label: 'Email [redacted name] the report',
+      description: 'Weekly report emailing',
+      steps: ['mail.google.com: mail [redacted name]'],
+      variables: ['recipient'],
+    })
+  })
+
+  it('returns output untouched when no scrubber is provided', async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: '{"clusters":[{"id":"c1","label":"Email Jane Novak"}]}',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never)
+
+    const result = await runContentReview(provider, 'model', memberInput)
+
+    expect(result.output?.clusters?.[0].label).toBe('Email Jane Novak')
+  })
+})

--- a/src/main/services/task-miner/clustering/llm-review.ts
+++ b/src/main/services/task-miner/clustering/llm-review.ts
@@ -2,6 +2,7 @@ import { generateText } from 'ai'
 import type { InferenceProvider } from '@main/llm'
 import { extractJsonObject, formatApiError } from '../helpers'
 import { PATTERN_DETECTION_CONFIG } from '@/shared/constants'
+import { scrubPromptPII } from '@/shared/sanitize'
 import type { ReviewInput, ReviewOutput } from './types'
 import { CLUSTERING_CONFIG } from './types'
 import {
@@ -16,6 +17,70 @@ export interface ReviewCallResult {
   tokenUsage: { input: number; output: number }
 }
 
+export type ReviewScrubber = (texts: string[], allow?: string[]) => Promise<string[]>
+
+function scrubReviewInputForPrompt(input: ReviewInput): ReviewInput {
+  return {
+    mergeCandidates: input.mergeCandidates,
+    clusters: input.clusters.map((cluster) => ({
+      ...cluster,
+      label: scrubPromptPII(cluster.label),
+      members: cluster.members.map((member) => ({
+        ...member,
+        title: scrubPromptPII(member.title),
+        subject: scrubPromptPII(member.subject),
+        description: scrubPromptPII(member.description),
+        ...(member.steps && { steps: member.steps.map(scrubPromptPII) }),
+      })),
+    })),
+  }
+}
+
+/** Runs here because applyStructure/applyContent transactions cannot await;
+ * fields are unvalidated model output, so only strings are touched. */
+async function scrubReviewOutput(
+  output: ReviewOutput,
+  input: ReviewInput,
+  scrub: ReviewScrubber,
+): Promise<ReviewOutput> {
+  if (!Array.isArray(output.clusters)) return output
+  const texts: string[] = []
+  const collect = (value: unknown): number => {
+    if (typeof value !== 'string' || value === '') return -1
+    texts.push(value)
+    return texts.length - 1
+  }
+  const slots = output.clusters.map((verdict) => ({
+    label: collect(verdict.label),
+    description: collect(verdict.description),
+    mechanism: collect(verdict.mechanism),
+    steps: Array.isArray(verdict.steps) ? verdict.steps.map(collect) : [],
+    variables: Array.isArray(verdict.variables) ? verdict.variables.map(collect) : [],
+  }))
+  if (texts.length === 0) return output
+
+  const allow = [...new Set(input.clusters.flatMap((c) => c.members.flatMap((m) => m.apps)))]
+  const scrubbed = await scrub(texts, allow)
+  const pick = <T>(index: number, original: T): T | string =>
+    index >= 0 ? scrubbed[index] : original
+
+  return {
+    ...output,
+    clusters: output.clusters.map((verdict, i) => ({
+      ...verdict,
+      ...(slots[i].label >= 0 && { label: scrubbed[slots[i].label] }),
+      ...(slots[i].description >= 0 && { description: scrubbed[slots[i].description] }),
+      ...(slots[i].mechanism >= 0 && { mechanism: scrubbed[slots[i].mechanism] }),
+      ...(Array.isArray(verdict.steps) && {
+        steps: verdict.steps.map((step, j) => pick(slots[i].steps[j], step)),
+      }),
+      ...(Array.isArray(verdict.variables) && {
+        variables: verdict.variables.map((v, j) => pick(slots[i].variables[j], v)),
+      }),
+    })),
+  }
+}
+
 /**
  * Attempts cover thrown errors too — a transient timeout on a long call must
  * not forfeit the whole pass. The last attempt rethrows so the caller's error
@@ -28,8 +93,9 @@ async function callReview(
   input: ReviewInput,
   describe: (attempt: number) => string,
   progress?: ProgressCallback,
+  scrub?: ReviewScrubber,
 ): Promise<ReviewCallResult> {
-  const prompt = serializeReviewInput(input)
+  const prompt = serializeReviewInput(scrubReviewInputForPrompt(input))
   const tokenUsage = { input: 0, output: 0 }
 
   for (let attempt = 1; attempt <= CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS; attempt++) {
@@ -45,7 +111,10 @@ async function callReview(
       tokenUsage.output += result.usage.outputTokens ?? 0
 
       const parsed = extractJsonObject<ReviewOutput>(result.text)
-      if (parsed) return { output: parsed, tokenUsage }
+      if (parsed) {
+        const output = scrub ? await scrubReviewOutput(parsed, input, scrub) : parsed
+        return { output, tokenUsage }
+      }
       progress?.(
         `[Clustering] Could not parse review response` +
           (attempt < CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS ? ' — retrying' : ''),
@@ -65,6 +134,7 @@ export async function runStructureReview(
   model: string,
   input: ReviewInput,
   progress?: ProgressCallback,
+  scrub?: ReviewScrubber,
 ): Promise<ReviewCallResult> {
   return callReview(
     provider,
@@ -76,6 +146,7 @@ export async function runStructureReview(
       `${input.mergeCandidates.length} merge candidates with ${model}` +
       (attempt > 1 ? ` (attempt ${attempt}/${CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS})` : ''),
     progress,
+    scrub,
   )
 }
 
@@ -85,6 +156,7 @@ export async function runContentReview(
   model: string,
   input: ReviewInput,
   progress?: ProgressCallback,
+  scrub?: ReviewScrubber,
 ): Promise<ReviewCallResult> {
   return callReview(
     provider,
@@ -95,5 +167,6 @@ export async function runContentReview(
       `[Clustering] Content review: ${input.clusters.length} clusters with ${model}` +
       (attempt > 1 ? ` (attempt ${attempt}/${CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS})` : ''),
     progress,
+    scrub,
   )
 }

--- a/src/main/services/task-miner/clustering/prompts.ts
+++ b/src/main/services/task-miner/clustering/prompts.ts
@@ -72,7 +72,7 @@ Rules:
 - Never invent cluster ids not present in the input.
 - Do not mention counts, frequencies, or durations in labels/descriptions — those are computed separately.
 - When unsure of the kind, choose the non-eliminable reading — a wrongly promised automation costs more than a missed one.
-- steps and variables carry NO personal data: no real names, companies, emails, phone numbers, ids, or PII/PHI. When in doubt, replace the specific with a generic variable.
+- labels, descriptions, steps, and variables carry NO personal data: no real names, companies, emails, phone numbers, credentials, account numbers, or PII/PHI. They are copied into outside tools; when in doubt, replace the specific with a generic variable.
 
 Output a single JSON object, no other text:
 

--- a/src/main/services/task-miner/index.ts
+++ b/src/main/services/task-miner/index.ts
@@ -430,6 +430,7 @@ export class TaskMiner {
         storage: this.storage,
         embedder: this.embedder,
         clusterVectors: this.embedder.clusterVectors?.bind(this.embedder),
+        scrub: this.embedder.scrubBatch?.bind(this.embedder),
         provider:
           this.enabled && model && this.provider?.isConfigured() ? this.provider : undefined,
         model,
@@ -588,6 +589,7 @@ export class TaskMiner {
         storage: this.storage,
         embedder: this.embedder,
         clusterVectors: this.embedder.clusterVectors?.bind(this.embedder),
+        scrub: this.embedder.scrubBatch?.bind(this.embedder),
         provider,
         model: this.clusterModel ?? cfg.model,
         onProgress,

--- a/src/main/services/task-miner/prompts.test.ts
+++ b/src/main/services/task-miner/prompts.test.ts
@@ -33,6 +33,12 @@ describe('buildScanSystemPrompt', () => {
     expect(prompt).toContain('describe only actions the cited activities evidence')
   })
 
+  it('forbids copying credentials or account numbers into any field', () => {
+    const prompt = buildScanSystemPrompt('Monday')
+    expect(prompt).toContain('Never copy credentials, passwords, API keys')
+    expect(prompt).toContain('[redacted account number]')
+  })
+
   it('instructs canonical, object-free titles', () => {
     const prompt = buildScanSystemPrompt('Monday')
     expect(prompt).toContain(
@@ -50,6 +56,12 @@ describe('buildGroundingSystemPrompt', () => {
     steps: ['admin.acme.com: create the tenant'],
     activity_ids: ['a1', 'a2'],
   }
+
+  it('forbids copying credentials from the OCR into any field', () => {
+    const prompt = buildGroundingSystemPrompt(candidate, ['admin.acme.com'])
+    expect(prompt).toContain('Never copy credentials, passwords, API keys')
+    expect(prompt).toContain('[redacted secret]')
+  })
 
   it('carries subject through the keep-JSON so scanOnly=false persists it', () => {
     expect(buildGroundingSystemPrompt(candidate, ['admin.acme.com'])).toContain('"subject"')

--- a/src/main/services/task-miner/prompts.ts
+++ b/src/main/services/task-miner/prompts.ts
@@ -50,6 +50,7 @@ A run of a repeatable multi-step procedure that CHANGES something — creates, p
 - Every description ENDS with exactly one sentence naming the mechanism: "Replace with: <the concrete script, integration, alert, or platform feature>." If you cannot write that sentence concretely, the finding does not exist.
 - \`steps\` describe only actions the cited activities evidence, one action per line, each starting with that activity's \`app\` — never a browser name.
 - Titles name the procedure, subjects name the object: title "Process invoice", subject "Customer ABC" — never title "Process invoice for Customer ABC". The title is worded so every run of the procedure gets it identically; the specific object goes in \`subject\`. Two runs of the same procedure on different objects share one title and differ only in subject. \`subject\` is optional — leave it empty when the run acted on no single nameable object.
+- Never copy credentials, passwords, API keys, or payment/account/government-id numbers into \`title\`, \`subject\`, \`description\`, or \`steps\`; if the object is only identifiable by one, use a typed placeholder like [redacted account number].
 ${knownProceduresSection}
 ## Output
 
@@ -109,6 +110,8 @@ If this is a real, grounded run:
 }
 \`\`\`
 If you cannot write the "Replace with:" sentence concretely, reject.
+
+Never copy credentials, passwords, API keys, or payment/account/government-id numbers from the OCR into any field; use a typed placeholder like [redacted secret] where one is needed.
 
 ### Reject
 Reject if the evidence shows checking/watching, re-checks of that day's work in progress, dev-loop mechanics, a one-off action, creative or judgment work; if the cited activities don't support the claim; or if fewer than 2 substantive activities remain after cleanup. Keep only what you could defend to the client from the evidence on screen:

--- a/src/main/services/task-miner/run-detection.test.ts
+++ b/src/main/services/task-miner/run-detection.test.ts
@@ -67,6 +67,32 @@ describe('runDetection day commit', () => {
     deleteDbFiles(TEST_DB_PATH)
   })
 
+  it('scrubs secrets and phones from the scan prompt but keeps emails and names', async () => {
+    storage.activities.add({
+      id: 'act-pii',
+      appName: 'TestApp',
+      windowTitle: 'Call Jane Novak at +1 (555) 123-4567',
+      tld: null,
+      startTimestamp: dayStart(1) + 5000,
+      endTimestamp: dayStart(1) + 5500,
+      summary: 'Mailed jane.doe@acme.co the password: hunter42',
+      summaryModel: '',
+      ocrText: '',
+      vector: v(0.1),
+    })
+    mockedGenerateText.mockResolvedValue(scanResponse('[]'))
+
+    await runDetection(provider, storage, embedder, { lookbackDays: 1 })
+
+    const call = mockedGenerateText.mock.calls[0][0] as { prompt: string }
+    expect(call.prompt).not.toContain('555) 123-4567')
+    expect(call.prompt).not.toContain('hunter42')
+    expect(call.prompt).toContain('[phone number]')
+    expect(call.prompt).toContain('[redacted password]')
+    expect(call.prompt).toContain('Jane Novak')
+    expect(call.prompt).toContain('jane.doe@acme.co')
+  })
+
   it('throws after all scan attempts return unusable output, leaving the day uncommitted', async () => {
     mockedGenerateText.mockResolvedValue(scanResponse('not json at all'))
     const onCommit = vi.fn()

--- a/src/main/services/task-miner/run-detection.ts
+++ b/src/main/services/task-miner/run-detection.ts
@@ -22,6 +22,7 @@ import {
 } from './helpers'
 import { getDayBoundaries } from '@main/utils/day'
 import { deriveSightingApps } from '@/shared/app-utils'
+import { scrubPromptPII } from '@/shared/sanitize'
 import { buildVerificationTools } from './tools'
 import { normalizeScanCandidates, normalizeSteps } from './candidate-normalizer'
 import { buildScanSystemPrompt, buildGroundingSystemPrompt } from './prompts'
@@ -112,12 +113,12 @@ export async function runDetection(
   // 2. User context (optional flavor for the scan)
   const userCtx = storage.userContext.get()
   const userContextStr = userCtx
-    ? `${userCtx.shortSummary}\n\n${userCtx.detailedSummary}`
+    ? scrubPromptPII(`${userCtx.shortSummary}\n\n${userCtx.detailedSummary}`)
     : undefined
 
   // Canonical titles of established procedures, fed back so recurring work
   // reuses its name cross-day. Empty on fresh/eval DBs — section omitted.
-  const knownProcedures = getKnownProcedureTitles(storage)
+  const knownProcedures = getKnownProcedureTitles(storage).map(scrubPromptPII)
 
   // =========================================================================
   // Phase 1: Scan — discover discrete task instances
@@ -127,7 +128,13 @@ export async function runDetection(
   // models mangle long opaque ids when citing them (dropping whole findings),
   // and short handles cut prompt tokens. Mapped back right after parsing.
   const realIdOf = new Map<string, string>()
-  const serialized = serializeActivities(activities).map((row, i) => {
+  const serialized = serializeActivities(
+    activities.map((a) => ({
+      ...a,
+      windowTitle: scrubPromptPII(a.windowTitle),
+      summary: scrubPromptPII(a.summary),
+    })),
+  ).map((row, i) => {
     const shortId = `a${i + 1}`
     realIdOf.set(shortId, activities[i].id)
     return { ...row, id: shortId }
@@ -261,26 +268,33 @@ export async function runDetection(
       let parsed: Record<string, unknown> = {}
       if (!cfg.scanOnly) {
         const candidateActivities = storage.activities.getByIds(candidate.activity_ids)
+        const promptCandidate = {
+          ...candidate,
+          title: scrubPromptPII(candidate.title),
+          subject: scrubPromptPII(candidate.subject),
+          description: scrubPromptPII(candidate.description),
+          steps: candidate.steps.map(scrubPromptPII),
+        }
         const groundPrompt = buildGroundingSystemPrompt(
-          candidate,
+          promptCandidate,
           deriveSightingApps(candidateActivities),
         )
 
         const enrichedActivities = candidateActivities.map((a) => ({
           id: a.id,
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPromptPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
           end_time: new Date(a.endTimestamp).toISOString(),
-          summary: a.summary,
+          summary: scrubPromptPII(a.summary),
         }))
 
         const candidateInput = `Investigate this candidate task:\n\n\`\`\`json\n${JSON.stringify(
           {
-            title: candidate.title,
-            subject: candidate.subject,
-            description: candidate.description,
-            steps: candidate.steps,
+            title: promptCandidate.title,
+            subject: promptCandidate.subject,
+            description: promptCandidate.description,
+            steps: promptCandidate.steps,
             activities: enrichedActivities,
           },
           null,

--- a/src/main/services/task-miner/tools.ts
+++ b/src/main/services/task-miner/tools.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai'
 import { z } from 'zod'
 import type { StorageService } from '../../storage'
 import type { ActivityEmbeddingService } from '@main/activity/activity-transformer-types'
+import { scrubPromptPII } from '@/shared/sanitize'
 
 export function buildVerificationTools(
   storage: StorageService,
@@ -29,10 +30,10 @@ export function buildVerificationTools(
         return activities.map((a) => ({
           id: a.id,
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPromptPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
-          summary: a.summary,
-          ocr_text: a.ocrText || '(no OCR text captured)',
+          summary: scrubPromptPII(a.summary),
+          ocr_text: a.ocrText ? scrubPromptPII(a.ocrText) : '(no OCR text captured)',
         }))
       },
     }),
@@ -54,10 +55,10 @@ export function buildVerificationTools(
         return results.map((a) => ({
           id: a.id,
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPromptPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
           duration_min: Math.round((a.endTimestamp - a.startTimestamp) / 60000),
-          summary: a.summary,
+          summary: scrubPromptPII(a.summary),
         }))
       },
     }),
@@ -90,11 +91,11 @@ export function buildVerificationTools(
         return activities.map((a) => ({
           id: a.id,
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPromptPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
           end_time: new Date(a.endTimestamp).toISOString(),
           duration_min: Math.round((a.endTimestamp - a.startTimestamp) / 60000),
-          summary: a.summary,
+          summary: scrubPromptPII(a.summary),
         }))
       },
     }),

--- a/src/main/services/task-miner/types.ts
+++ b/src/main/services/task-miner/types.ts
@@ -53,6 +53,7 @@ export interface MinerEmbedder {
   embed(text: string): Promise<number[]>
   embedBatch(texts: string[]): Promise<number[][]>
   clusterVectors?(vectors: readonly (readonly number[])[], threshold: number): Promise<number[][]>
+  scrubBatch?(texts: string[], allow?: string[]): Promise<string[]>
 }
 
 /** A discrete task instance proposed by the broad scan. */

--- a/src/main/services/user-context-builder.ts
+++ b/src/main/services/user-context-builder.ts
@@ -15,6 +15,7 @@ import type { StorageService, ActivityDetail } from '../storage'
 import type { InferenceProvider } from '../llm'
 import type { UserContext } from '../storage/user-context-repository'
 import { USER_CONTEXT_CONFIG } from '../../shared/constants'
+import { scrubPromptPII } from '@/shared/sanitize'
 import log from '@main/utils/logger'
 
 // ---------------------------------------------------------------------------
@@ -92,7 +93,7 @@ function aggregateActivities(activities: ActivityDetail[]): AggregatedProfile {
       top_windows: [...stats.windows.entries()]
         .sort((a, b) => b[1] - a[1])
         .slice(0, 5)
-        .map(([title]) => title),
+        .map(([title]) => scrubPromptPII(title)),
     }))
 
   // Sample up to 80 unique summaries evenly across the set
@@ -101,7 +102,7 @@ function aggregateActivities(activities: ActivityDetail[]): AggregatedProfile {
   const step = Math.max(1, Math.floor(allSummaries.length / maxSamples))
   const sample_summaries: string[] = []
   for (let i = 0; i < allSummaries.length && sample_summaries.length < maxSamples; i += step) {
-    sample_summaries.push(allSummaries[i])
+    sample_summaries.push(scrubPromptPII(allSummaries[i]))
   }
 
   const totalMs = activities.reduce((sum, a) => sum + (a.endTimestamp - a.startTimestamp), 0)

--- a/src/main/settings/capture-settings-manager.test.ts
+++ b/src/main/settings/capture-settings-manager.test.ts
@@ -53,6 +53,7 @@ describe('CaptureSettingsManager', () => {
       expect(defaults.captureHotkeyAccelerator).toBe(DEFAULT_CAPTURE_HOTKEY_ACCELERATOR)
       expect(defaults.databaseExportDirectory).toBe('')
       expect(defaults.excludePrivateBrowsing).toBe(true)
+      expect(defaults.excludeLoginScreens).toBe(true)
       expect(defaults.excludedApps).toEqual([])
       expect(defaults.excludedUrlPatterns).toEqual([])
       expect(defaults.uploadDetailLevel).toBe('off')
@@ -169,6 +170,20 @@ describe('CaptureSettingsManager', () => {
 
       const reloaded = new CaptureSettingsManager(configPath)
       expect(reloaded.get().excludePrivateBrowsing).toBe(false)
+    })
+
+    it('persists login screen exclusion flag', () => {
+      const manager = new CaptureSettingsManager(configPath)
+      manager.save({ excludeLoginScreens: false })
+
+      const reloaded = new CaptureSettingsManager(configPath)
+      expect(reloaded.get().excludeLoginScreens).toBe(false)
+    })
+
+    it('loads excludeLoginScreens as true when the stored file lacks the key', () => {
+      fs.writeFileSync(configPath, JSON.stringify({ excludePrivateBrowsing: false }))
+      const manager = new CaptureSettingsManager(configPath)
+      expect(manager.get().excludeLoginScreens).toBe(true)
     })
 
     it('persists uploadDetailLevel across reloads', () => {

--- a/src/main/settings/capture-settings-manager.ts
+++ b/src/main/settings/capture-settings-manager.ts
@@ -153,6 +153,7 @@ const DEFAULTS: CaptureSettings = {
   captureHotkeyAccelerator: DEFAULT_CAPTURE_HOTKEY_ACCELERATOR,
   databaseExportDirectory: '',
   excludePrivateBrowsing: true,
+  excludeLoginScreens: true,
   excludedApps: [],
   excludedUrlPatterns: [],
   urlMatchSchemaVersion: URL_MATCH_SCHEMA_VERSION,

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -121,6 +121,7 @@ interface MainWindowDependencies {
     apps: string[]
     urlPatterns: string[]
     excludePrivateBrowsing: boolean
+    excludeLoginScreens: boolean
   }) => void
   // Org-provided (centrally-synced) exclusions, surfaced read-only in the UI.
   getManagedExclusions: () => { apps: string[]; urlPatterns: string[] }
@@ -148,6 +149,7 @@ interface MainWindowDependencies {
   evalRecorder: EvalRecorder
   evalFixtureStore: EvalFixtureStore
   taskFixtureStore: TaskFixtureStore
+  scrubTexts: (texts: string[], allow?: string[]) => Promise<string[]>
 }
 
 let mainWindow: BrowserWindow | null = null
@@ -362,6 +364,7 @@ function logCaptureSettingsChanges(previous: CaptureSettings, updated: CaptureSe
     'semanticPipelineMode',
     'captureHotkeyAccelerator',
     'excludePrivateBrowsing',
+    'excludeLoginScreens',
     'activeVendor',
     'semanticVideoModel',
     'semanticSnapshotModel',
@@ -702,6 +705,11 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
     return deps.accessProvider.getAccessState().customerSubscriptionStatus ?? 'idle'
   })
 
+  handle('main-window:scrubTexts', (_event, texts: string[], allow?: string[]) => {
+    if (!deps) return texts
+    return deps.scrubTexts(texts, allow)
+  })
+
   // Patterns (task clusters)
   handle('main-window:getClusters', (): ClustersView => {
     if (!deps) return { clusters: [], hiddenCount: 0 }
@@ -953,6 +961,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
           apps: updated.excludedApps,
           urlPatterns: updated.excludedUrlPatterns,
           excludePrivateBrowsing: updated.excludePrivateBrowsing,
+          excludeLoginScreens: updated.excludeLoginScreens,
         })
         deps.semanticService.updatePipelinePreference(updated.semanticPipelineMode)
         deps.semanticService.updateRequestTimeoutMs(updated.activityRequestTimeoutMs)
@@ -1014,6 +1023,7 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
         apps: updated.excludedApps,
         urlPatterns: updated.excludedUrlPatterns,
         excludePrivateBrowsing: updated.excludePrivateBrowsing,
+        excludeLoginScreens: updated.excludeLoginScreens,
       })
       deps.semanticService.updatePipelinePreference(updated.semanticPipelineMode)
       deps.semanticService.updateRequestTimeoutMs(updated.activityRequestTimeoutMs)

--- a/src/main/utils/test-utils.ts
+++ b/src/main/utils/test-utils.ts
@@ -26,6 +26,7 @@ export function makeCaptureSettings(overrides: Partial<CaptureSettings> = {}): C
     captureHotkeyAccelerator: 'CommandOrControl+Shift+M',
     databaseExportDirectory: '',
     excludePrivateBrowsing: true,
+    excludeLoginScreens: true,
     excludedApps: [],
     excludedUrlPatterns: [],
     activeVendor: 'openrouter',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -70,6 +70,8 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
   resetCaptureSettings: () => ipcRenderer.invoke('main-window:resetCaptureSettings'),
   // Patterns (task clusters) — new TaskMiner view
   getClusters: () => ipcRenderer.invoke('main-window:getClusters'),
+  scrubTexts: (texts: string[], allow?: string[]) =>
+    ipcRenderer.invoke('main-window:scrubTexts', texts, allow),
   getClusterDetail: (id: string) => ipcRenderer.invoke('main-window:getClusterDetail', id),
   // Task-mining progress (ledger sweep)
   getMiningStatus: () => ipcRenderer.invoke('main-window:getMiningStatus'),

--- a/src/renderer/pages/main-window/components/ClusterDetailPane.tsx
+++ b/src/renderer/pages/main-window/components/ClusterDetailPane.tsx
@@ -7,7 +7,11 @@ import type { ClusterDetailInfo, ClusterInfo, MainWindowAPI } from '@types'
 import { formatMinutes, formatMonthlyHours, formatSightingTime } from './activities/format'
 import { WeeklyTrend } from './WeeklyTrend'
 import { ClaudeWordmark } from './ClaudeWordmark'
-import { buildClusterAgentPrompt, buildClusterAnalyzePrompt } from './claude-prompts'
+import {
+  buildClusterAgentPrompt,
+  buildClusterAnalyzePrompt,
+  scrubClusterForShare,
+} from './claude-prompts'
 
 interface ClusterDetailPaneProps {
   api: MainWindowAPI
@@ -75,21 +79,23 @@ export function ClusterDetailPane({ api, cluster }: ClusterDetailPaneProps): Rea
   const trendTimestamps = useMemo(() => (detail?.sightings ?? []).map((s) => s.startedAt), [detail])
 
   const handleCopyPrompt = (): void => {
-    navigator.clipboard
-      .writeText(buildClusterAnalyzePrompt(cluster, sightings))
+    scrubClusterForShare(cluster, sightings, api.scrubTexts)
+      .then((clean) =>
+        navigator.clipboard.writeText(buildClusterAnalyzePrompt(clean.cluster, clean.sightings)),
+      )
       .then(() => toast.success('Copied! Paste it into Claude Cowork'))
       .catch((err) => {
-        console.warn('[clusters] clipboard.writeText failed', err)
+        console.warn('[clusters] copy prompt failed', err)
         toast.error('Could not copy prompt to clipboard')
       })
   }
 
   const handleCopyAgentPrompt = (): void => {
-    navigator.clipboard
-      .writeText(buildClusterAgentPrompt(cluster))
+    scrubClusterForShare(cluster, [], api.scrubTexts)
+      .then((clean) => navigator.clipboard.writeText(buildClusterAgentPrompt(clean.cluster)))
       .then(() => toast.success('Agent prompt copied to clipboard'))
       .catch((err) => {
-        console.warn('[clusters] clipboard.writeText failed', err)
+        console.warn('[clusters] copy prompt failed', err)
         toast.error('Could not copy prompt to clipboard')
       })
   }

--- a/src/renderer/pages/main-window/components/advanced-settings/CapturePrivacySection.tsx
+++ b/src/renderer/pages/main-window/components/advanced-settings/CapturePrivacySection.tsx
@@ -14,6 +14,7 @@ interface CapturePrivacySectionProps {
   onToggleRecordingHotkey: () => void
   onAutoStartEnabledChange: (enabled: boolean) => void
   onExcludePrivateBrowsingChange: (enabled: boolean) => void
+  onExcludeLoginScreensChange: (enabled: boolean) => void
   onExcludedRulesCommit: (rules: { excludedApps: string[]; excludedUrlPatterns: string[] }) => void
   onObserved: () => void
 }
@@ -25,6 +26,7 @@ export function CapturePrivacySection({
   onToggleRecordingHotkey,
   onAutoStartEnabledChange,
   onExcludePrivateBrowsingChange,
+  onExcludeLoginScreensChange,
   onExcludedRulesCommit,
   onObserved,
 }: CapturePrivacySectionProps): React.JSX.Element {
@@ -63,6 +65,18 @@ export function CapturePrivacySection({
               checked={form.excludePrivateBrowsing}
               onCheckedChange={onExcludePrivateBrowsingChange}
               aria-label="Exclude private browsing"
+            />
+          }
+        />
+
+        <SettingsRow
+          label="Exclude sign-in screens"
+          description="Login and password pages are never captured."
+          control={
+            <Switch
+              checked={form.excludeLoginScreens}
+              onCheckedChange={onExcludeLoginScreensChange}
+              aria-label="Exclude sign-in screens"
             />
           }
         />

--- a/src/renderer/pages/main-window/components/advanced-settings/types.ts
+++ b/src/renderer/pages/main-window/components/advanced-settings/types.ts
@@ -6,6 +6,7 @@ export type NumericCaptureSetting = Exclude<
   | 'semanticPipelineMode'
   | 'captureHotkeyAccelerator'
   | 'excludePrivateBrowsing'
+  | 'excludeLoginScreens'
   | 'excludedApps'
   | 'excludedUrlPatterns'
   | 'urlMatchSchemaVersion'

--- a/src/renderer/pages/main-window/components/claude-prompts.test.ts
+++ b/src/renderer/pages/main-window/components/claude-prompts.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ClusterInfo, ClusterSightingInfo } from '@types'
+import {
+  buildClusterAgentPrompt,
+  buildClusterAnalyzePrompt,
+  scrubClusterForShare,
+} from './claude-prompts'
+
+const cluster: ClusterInfo = {
+  id: 'c1',
+  title: 'Email Jane Novak the report',
+  description: 'Weekly report for jane.doe@acme.co',
+  apps: ['mail.google.com'],
+  timesSeen: 3,
+  timesPerWeek: 1.5,
+  observedDays: 14,
+  avgActiveMin: 12,
+  mechanism: '',
+  steps: ['mail.google.com: mail Jane Novak'],
+  variables: ['recipient'],
+  lastSeenAt: 0,
+  recurrence: [],
+}
+
+const sightings: ClusterSightingInfo[] = [
+  {
+    id: 's1',
+    title: 'Email Jane Novak the report',
+    subject: 'Q3 report',
+    apps: ['mail.google.com'],
+    startedAt: 1753600000000,
+    activeMin: 10,
+    activityIds: ['550e8400-e29b-41d4-a716-446655440000', '3f2a9c81-77de-4b02-9e41-c05a12ef88a3'],
+  },
+]
+
+const fakeScrub = vi.fn(async (texts: string[]) =>
+  texts.map((t) => t.replace(/Jane Novak/g, '[redacted name]')),
+)
+
+describe('scrubClusterForShare', () => {
+  it('routes every interpolated field through the scrubber with the app allowlist', async () => {
+    const clean = await scrubClusterForShare(cluster, sightings, fakeScrub)
+
+    expect(fakeScrub).toHaveBeenCalledWith(expect.arrayContaining([cluster.title]), [
+      'mail.google.com',
+    ])
+    expect(clean.cluster.title).toBe('Email [redacted name] the report')
+    expect(clean.cluster.steps).toEqual(['mail.google.com: mail [redacted name]'])
+    expect(clean.sightings[0].title).toBe('Email [redacted name] the report')
+    expect(clean.sightings[0].subject).toBe('Q3 report')
+    expect(clean.sightings[0].activityIds).toEqual(sightings[0].activityIds)
+  })
+})
+
+describe('buildClusterAnalyzePrompt', () => {
+  it('keeps activity-id UUIDs intact in the assembled prompt', async () => {
+    const clean = await scrubClusterForShare(cluster, sightings, fakeScrub)
+    const prompt = buildClusterAnalyzePrompt(clean.cluster, clean.sightings)
+
+    expect(prompt).toContain('550e8400-e29b-41d4-a716-446655440000')
+    expect(prompt).toContain('3f2a9c81-77de-4b02-9e41-c05a12ef88a3')
+    expect(prompt).not.toContain('Jane Novak')
+  })
+})
+
+describe('buildClusterAgentPrompt', () => {
+  it('keeps the regex backstop over the final string', () => {
+    const prompt = buildClusterAgentPrompt(cluster)
+    expect(prompt).not.toContain('jane.doe@acme.co')
+    expect(prompt).toContain('[email address]')
+  })
+})

--- a/src/renderer/pages/main-window/components/claude-prompts.ts
+++ b/src/renderer/pages/main-window/components/claude-prompts.ts
@@ -3,9 +3,36 @@ import { scrubPII } from '@/shared/sanitize'
 import { formatFrequency, formatSightingTime } from './activities/format'
 
 /** Clipboard prompts for the "Analyze with Claude" / "Build AI agent" buttons.
- * The analyze prompt is NOT scrubbed: activity ids are UUIDs, and
- * scrubPII's id/phone patterns would corrupt all-digit segments (DEU-207
- * tracks the egress-scrub redesign). */
+ * Callers pre-scrub the interpolated fields via scrubClusterForShare (NER in
+ * the main process); the assembled strings are never scrubbed whole, so
+ * activity-id UUIDs survive intact. */
+
+export async function scrubClusterForShare(
+  cluster: ClusterInfo,
+  sightings: ClusterSightingInfo[],
+  scrubTexts: (texts: string[], allow?: string[]) => Promise<string[]>,
+): Promise<{ cluster: ClusterInfo; sightings: ClusterSightingInfo[] }> {
+  const texts = [
+    cluster.title,
+    cluster.description,
+    ...cluster.steps,
+    ...cluster.variables,
+    ...sightings.flatMap((s) => [s.title, s.subject]),
+  ]
+  const scrubbed = await scrubTexts(texts, cluster.apps)
+  let i = 0
+  const next = (): string => scrubbed[i++]
+  return {
+    cluster: {
+      ...cluster,
+      title: next(),
+      description: next(),
+      steps: cluster.steps.map(() => next()),
+      variables: cluster.variables.map(() => next()),
+    },
+    sightings: sightings.map((s) => ({ ...s, title: next(), subject: next() })),
+  }
+}
 
 export function buildClusterAnalyzePrompt(
   cluster: ClusterInfo,
@@ -89,9 +116,8 @@ export function buildClusterAnalyzePrompt(
   return lines.filter((l) => l !== null).join('\n')
 }
 
-/** Tool-agnostic prompt; scrubPII runs over the final string. For labeled
- * clusters that backstops the recipe's LLM de-identification; for fallback
- * member steps it is the only scrub, and it does not catch names. */
+/** Tool-agnostic prompt; the final-string scrubPII stays as the regex
+ * backstop behind the caller's scrubClusterForShare NER pass. */
 export function buildClusterAgentPrompt(cluster: ClusterInfo): string {
   const lines: string[] = [
     `Build an AI agent that automates this task.`,

--- a/src/renderer/pages/main-window/pages/SettingsPage.tsx
+++ b/src/renderer/pages/main-window/pages/SettingsPage.tsx
@@ -154,6 +154,17 @@ export function SettingsPage({
     [save],
   )
 
+  const commitExcludeLoginScreens = useCallback(
+    (enabled: boolean): void => {
+      setForm((prev) => (prev ? { ...prev, excludeLoginScreens: enabled } : prev))
+      save(
+        { excludeLoginScreens: enabled },
+        enabled ? 'Sign-in screen exclusion enabled' : 'Sign-in screen exclusion disabled',
+      )
+    },
+    [save],
+  )
+
   const setCaptureHotkeyAccelerator = useCallback((value: string): void => {
     setForm((prev) => (prev ? { ...prev, captureHotkeyAccelerator: value } : prev))
   }, [])
@@ -294,6 +305,7 @@ export function SettingsPage({
               onToggleRecordingHotkey={() => setRecordingHotkey((current) => !current)}
               onAutoStartEnabledChange={setAutoStartEnabled}
               onExcludePrivateBrowsingChange={commitExcludePrivateBrowsing}
+              onExcludeLoginScreensChange={commitExcludeLoginScreens}
               onExcludedRulesCommit={commitExcludedRules}
               onObserved={() => void load()}
             />

--- a/src/shared/sanitize.test.ts
+++ b/src/shared/sanitize.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { scrubPII } from './sanitize'
+import { scrubPII, scrubPromptPII } from './sanitize'
+
+const OPENAI_KEY = 'sk-' + 'proj-Ab12Cd34Ef56Gh78Ij90'
+const GH_TOKEN = 'ghp_' + 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4'
+const GH_PAT = 'github_pat_' + '11ABCDEFG0abcdefghijklmnop'
+const AWS_KEY_ID = 'AKIA' + 'IOSFODNN7EXAMPLE'
+const JWT = 'eyJ' + 'hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9P'
 
 describe('scrubPII', () => {
   it('replaces email addresses with a typed slot', () => {
@@ -37,5 +43,78 @@ describe('scrubPII', () => {
   it('leaves clean recipe text untouched', () => {
     const text = 'Open the customer thread in Gmail (mail.google.com) and read the latest reply.'
     expect(scrubPII(text)).toBe(text)
+  })
+
+  it('replaces secret-shaped tokens', () => {
+    expect(scrubPII(`export OPENAI_API_KEY=${OPENAI_KEY}`)).toBe(
+      'export OPENAI_API_KEY=[redacted secret]',
+    )
+    expect(scrubPII(`git push with ${GH_TOKEN}`)).toBe('git push with [redacted secret]')
+    expect(scrubPII(`token ${GH_PAT} created`)).toBe('token [redacted secret] created')
+    expect(scrubPII(`aws configure ${AWS_KEY_ID}`)).toBe('aws configure [redacted secret]')
+    expect(scrubPII(`Authorization: Bearer ${JWT}`)).toBe('Authorization: Bearer [redacted secret]')
+  })
+
+  it('replaces labeled secret values', () => {
+    expect(scrubPII('AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG')).toBe(
+      'AWS_SECRET_ACCESS_KEY=[redacted secret]',
+    )
+    expect(scrubPII('api_key: 9f8e7d6c5b4a')).toBe('api_key: [redacted secret]')
+    expect(scrubPII('set max_tokens: 4096 in the request')).toBe(
+      'set max_tokens: 4096 in the request',
+    )
+  })
+
+  it('replaces labeled passwords', () => {
+    expect(scrubPII('password: Tr0ub4dor&3')).toBe('password: [redacted password]')
+    expect(scrubPII('pwd=hunter42')).toBe('pwd=[redacted password]')
+    expect(scrubPII('enter your password: ')).toBe('enter your password: ')
+  })
+
+  it('replaces password-shaped tokens on the line after a password label', () => {
+    expect(scrubPII('Temporary password\nSumm3r!2026\nChange on first login')).toBe(
+      'Temporary password\n[redacted password]\nChange on first login',
+    )
+    expect(scrubPII('Change password\nSettings')).toBe('Change password\nSettings')
+  })
+
+  it('replaces labeled employee ids', () => {
+    expect(scrubPII('Employee ID: EMP-04481\nDepartment: Ops')).toBe(
+      'Employee ID: [redacted employee id]\nDepartment: Ops',
+    )
+    expect(scrubPII('Emp No. E-118245 on shift')).toBe('Emp No. [redacted employee id] on shift')
+    expect(scrubPII('the employee handbook')).toBe('the employee handbook')
+  })
+
+  it('replaces labeled dates of birth but not plain dates', () => {
+    expect(scrubPII('DOB: 04/12/1985')).toBe('DOB: [redacted date of birth]')
+    expect(scrubPII('Date of birth: 1985-04-12')).toBe('Date of birth: [redacted date of birth]')
+    expect(scrubPII('born March 3, 1990 in Ohio')).toBe('born [redacted date of birth] in Ohio')
+    expect(scrubPII('meeting on 04/12/2026 moved')).toBe('meeting on 04/12/2026 moved')
+  })
+
+  it('preserves technical identifiers', () => {
+    expect(scrubPII('ssh deploy@192.168.1.100 failed')).toBe('ssh deploy@192.168.1.100 failed')
+    expect(scrubPII('activity 550e8400-e29b-41d4-a716-446655440000 missing')).toBe(
+      'activity 550e8400-e29b-41d4-a716-446655440000 missing',
+    )
+    expect(scrubPII('git checkout a1b2c3d4e5f6 to bisect')).toBe(
+      'git checkout a1b2c3d4e5f6 to bisect',
+    )
+    expect(scrubPII('saved 2026-07-03T14-26-21-980Z.md to disk')).toBe(
+      'saved 2026-07-03T14-26-21-980Z.md to disk',
+    )
+    expect(scrubPII('JIRA OPS-11842: rotate the certs')).toBe('JIRA OPS-11842: rotate the certs')
+    expect(scrubPII('trace id 7f3c9a2b1d8e4f60 logged')).toBe('trace id 7f3c9a2b1d8e4f60 logged')
+  })
+})
+
+describe('scrubPromptPII', () => {
+  it('keeps emails but scrubs secrets, passwords, and digit runs', () => {
+    expect(scrubPromptPII('mail jane.doe@acme.co about it')).toBe('mail jane.doe@acme.co about it')
+    expect(scrubPromptPII(`key ${OPENAI_KEY} leaked`)).toBe('key [redacted secret] leaked')
+    expect(scrubPromptPII('password: Tr0ub4dor&3')).toBe('password: [redacted password]')
+    expect(scrubPromptPII('call +1 (555) 123-4567 now')).toBe('call [phone number] now')
+    expect(scrubPromptPII('order 100294 shipped')).toBe('order [id number] shipped')
   })
 })

--- a/src/shared/sanitize.ts
+++ b/src/shared/sanitize.ts
@@ -1,9 +1,10 @@
 /**
  * Deterministic PII scrub — the regex backstop behind the LLM's de-identification
- * (the model handles names; this catches emails, phone numbers, and long id runs).
- * Typed slot names instead of [redacted] so the recipe still says what goes there.
- * Conservative by design: must never mangle prose like "4 steps" or dates, and
- * every quantifier is bounded so matching stays linear.
+ * (the model handles names; this catches emails, phone numbers, long id runs,
+ * and secret-shaped values). Typed slot names instead of [redacted] so the
+ * recipe still says what goes there. Conservative by design: must never mangle
+ * prose like "4 steps" or dates, and every quantifier is bounded so matching
+ * stays linear.
  */
 
 const EMAIL =
@@ -14,17 +15,57 @@ const LONG_DIGITS = /\b\d{5,}\b/g
 // 2026-07-19, 2026/7/9, 19.07.2026, 19. 7. 2026, and year ranges like 2024-2025.
 const DATE_LIKE =
   /^\d{4}([-/.])\d{1,2}(?:\1\d{1,2})?$|^\d{1,2}([./-])\s?\d{1,2}\2\s?\d{4}$|^\d{4}-\d{4}$/
+const DOTTED_QUAD = /^\d{1,3}(?:\.\d{1,3}){3}$/
+
+const SECRET_TOKEN =
+  /\b(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[A-Z0-9]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{8,})\b/g
+const LABELED_SECRET =
+  /\b([A-Za-z0-9_.-]*(?:secret|token|api[_-]?key|apikey|access[_-]?key|private[_-]?key)\b\s*[:=]\s*)(?!\[)(\S{6,})/gi
+const LABELED_PASSWORD = /\b((?:password|passwd|passphrase|pwd)\s*[:=]\s*)(?!\[)(\S{4,})/gi
+const PASSWORD_LINE =
+  /\b((?:password|passwd|passphrase)\s*\n\s*)(?!\[)((?=\S*[\d#!@$%^&*+=])\S{6,})/gi
+const LABELED_DOB =
+  /\b((?:date of birth|birth ?date|dob|born(?: on)?)\s*[:=]?\s*(?:(?:to|is)\s+)?)((?:\d{1,2}[/. -]){2}\d{2,4}|\d{4}-\d{2}-\d{2}|(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.? \d{1,2},? \d{4})/gi
+const LABELED_EMPLOYEE_ID =
+  /\b((?:employee|badge|worker|emp)\s*(?:id|no|number)?\.?\s*[:#]?\s*)((?=[A-Za-z0-9-]*\d{4})[A-Za-z0-9-]{4,})/gi
 
 const countDigits = (s: string): number => s.match(/\d/g)?.length ?? 0
 
-export function scrubPII(text: string): string {
-  return text
-    .replace(EMAIL, '[email address]')
-    .replace(PHONE_LIKE, (m) => {
+// A digit run touching letters through [\w-] is an identifier (UUID segment,
+// timestamp filename, tracking/ticket id), not a phone or bare id.
+const isIdentifierBound = (s: string, start: number, end: number): boolean => {
+  for (let i = start - 1; i >= 0 && /[\w-]/.test(s[i]); i--) {
+    if (/[A-Za-z_]/.test(s[i])) return true
+  }
+  for (let j = end; j < s.length && /[\w-]/.test(s[j]); j++) {
+    if (/[A-Za-z_]/.test(s[j])) return true
+  }
+  return false
+}
+
+const scrubCore = (text: string): string =>
+  text
+    .replace(SECRET_TOKEN, '[redacted secret]')
+    .replace(LABELED_SECRET, '$1[redacted secret]')
+    .replace(LABELED_PASSWORD, '$1[redacted password]')
+    .replace(PASSWORD_LINE, '$1[redacted password]')
+    .replace(LABELED_DOB, '$1[redacted date of birth]')
+    .replace(LABELED_EMPLOYEE_ID, '$1[redacted employee id]')
+    .replace(PHONE_LIKE, (m, offset: number, s: string) => {
       // Digit-and-space-only runs need 9+ digits so spaced amounts like
       // "1 000 000" survive; real spaced phones (CZ "777 123 456") still hit 9.
       const minDigits = /^[\d\s]+$/.test(m) ? 9 : 7
-      return countDigits(m) >= minDigits && !DATE_LIKE.test(m) ? '[phone number]' : m
+      if (countDigits(m) < minDigits || DATE_LIKE.test(m) || DOTTED_QUAD.test(m)) return m
+      return isIdentifierBound(s, offset, offset + m.length) ? m : '[phone number]'
     })
-    .replace(LONG_DIGITS, '[id number]')
+    .replace(LONG_DIGITS, (m, offset: number, s: string) =>
+      isIdentifierBound(s, offset, offset + m.length) ? m : '[id number]',
+    )
+
+export function scrubPII(text: string): string {
+  return scrubCore(text.replace(EMAIL, '[email address]'))
+}
+
+export function scrubPromptPII(text: string): string {
+  return scrubCore(text)
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -239,6 +239,7 @@ export interface CaptureSettings {
   captureHotkeyAccelerator: string
   databaseExportDirectory: string
   excludePrivateBrowsing: boolean
+  excludeLoginScreens: boolean
   excludedApps: string[]
   excludedUrlPatterns: string[]
   urlMatchSchemaVersion?: number
@@ -430,6 +431,8 @@ export interface MainWindowAPI {
   // Patterns (task clusters) — new TaskMiner view
   getClusters: () => Promise<ClustersView>
   getClusterDetail: (id: string) => Promise<ClusterDetailInfo | null>
+  /** NER + regex PII scrub in the main process, for share/copy surfaces. */
+  scrubTexts: (texts: string[], allow?: string[]) => Promise<string[]>
   // Task-mining progress (ledger sweep)
   getMiningStatus: () => Promise<MiningStatus>
   onMiningProgressChanged: (callback: (status: MiningStatus) => void) => () => void


### PR DESCRIPTION
DEU-205 steps 2–4 (step 1, the scrubber bake-off, merged in #259). Closes out everything on the ticket except the DB-upload scrub, which stays open.

## Design: two tiers, chosen by what the text is for

**Prompt tier — every cloud-LLM input and MCP output** gets the sync regex `scrubPromptPII`: secrets/API keys/JWTs, labeled passwords and DOBs, employee ids, payment/SSN/bank digit runs, phones. Emails and names deliberately survive — they carry the signal the model reasons with (e.g. whether a conversation is internal or external), and the output prompt rules stop the model from transcribing harm classes. On a real dev-DB day this tier alters 4/400 texts.

Seams: task-miner scan + grounding + verification tools (incl. OCR), cluster structure/content review input, semantic summarizer context/timeline, user-context builder aggregation, and all MCP tool outputs. Applied per-field at interpolation — ids, timestamps, and app names never enter the scrub.

**Share tier — where text becomes a shareable artifact** gets Rampart NER (`nationaldesignstudio/rampart`, q4, 14 MB, ~3.5 ms/text) + full `scrubPII` (emails included):
- cluster review **output** (labels/descriptions/mechanisms/recipes), scrubbed pre-transaction in `llm-review.ts` — the stored copy is what every share surface reads; `sanitizeRecipe` stays as the in-transaction regex backstop
- the two renderer copy prompts, via a `main-window:scrubTexts` IPC to the ml-worker; fields are pre-scrubbed so activity-id UUIDs survive, and the renderer fails closed (no copy) while the main-process client fails open to regex

`PiiScrubber` (`src/main/processor/pii-scrub.ts`) is the eval harness's span logic productionized: windowing, null-offset token reconstruction, per-type drop policy, and a caller-supplied allowlist (app names) that protects product names like Claude/Cursor from rampart's known name-FP class. It rides the existing ml-worker as a fourth message (`scrubBatch`), lazy-loaded so startup cost is unchanged; the scrub timeout is deliberately generous because a timeout kills the worker that also serves embeddings. `MinerEmbedder` gains optional `scrubBatch?` — CLI/enode mining degrades to regex-only.

**Regex layer** (`sanitize.ts`): new secret/password/DOB/employee-id classes, plus an identifier-adjacency guard that ends the UUID-segment/timestamp-filename/tracking-number false positives.

**Login screens are never captured or OCR'd**: `capture-login-gate.ts` (password-manager apps in any context; browser-gated host-prefix, exact-path-segment, and multi-word-title markers — `/blog/login-best-practices` and `expresso.com` survive), wired as a fourth non-sticky blocking flag so post-auth navigation lifts it, plus an OCR-skip predicate because the OCR'd frame can predate the block. New `excludeLoginScreens` setting, default on, with a settings switch.

## Evals (same harness as the #259 decision)

| scrubber | total | FP | ms/text |
|---|---|---|---|
| current (regex, was 51/99 @ 10 FP) | 68/99 | 6 | 0.0 |
| prompt tier | 58/99 | 6 | 0.0 |
| **shipped (NER + regex, decision bar 84/99 @ 23 FP)** | **98/99** | 18 | 3.5 |

The one leak is an unlabeled username mid-OCR (known NER gap). `eval-cluster-review`: 86% kind accuracy, 0 false-eliminable — byte-identical with the input scrub bypassed, so label quality costs nothing. Full report in the private evals repo.

## Notes

- Structure-review prompt intentionally gets no PII rule — its output is ids/booleans only.
- Sightings stay stored raw (existing contract); only prompt-bound copies and share artifacts are scrubbed.
- Rampart is bundled as a second model (`download-model.js` → `MODELS` array, +14 MB); electron-builder config unchanged; offline-load asserted in `embedding-bundle.test.ts`.
- Deferred on the ticket: DB-upload scrub (the `scrubBatch` seam is ready for it), native secure-input/UIA password detection, pixel redaction (vendor ZDR governs).

Manual checks still worth doing on a packaged build: visit accounts.google.com → tray shows privacy-blocked and capture resumes after navigating away; copy both cluster prompts and inspect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)