### PR TITLE
Prompt-tier PII scrub at all LLM/MCP seams (DEU-205)

### DIFF
--- a/src/main/mcp/formatting.ts
+++ b/src/main/mcp/formatting.ts
@@ -1,4 +1,5 @@
 import { ActivitySummary } from '../storage'
+import { scrubPromptPII } from '@/shared/sanitize'
 
 /**
  * Formats a single activity as a compact summary line with duration and screenshot count.
@@ -12,7 +13,7 @@ export function formatActivityLine(activity: {
 }): string {
   const timeStr = new Date(activity.startTimestamp).toLocaleString()
   const appInfo = activity.appName ? ` [${activity.appName}]` : ''
-  const summary = activity.summary || '(no summary)'
+  const summary = activity.summary ? scrubPromptPII(activity.summary) : '(no summary)'
   return `- ${activity.id} | ${timeStr}${appInfo} | ${summary}`
 }
 
@@ -46,8 +47,10 @@ export function activityToTimelineEntry(activity: ActivitySummary): TimelineEntr
 export function formatTimelineEntry(entry: TimelineEntry): string {
   const timeStr = new Date(entry.timestamp).toLocaleString()
   const appInfo = entry.appName ? ` [${entry.appName}]` : ''
-  const windowInfo = entry.windowTitle ? ` [window: ${JSON.stringify(entry.windowTitle)}]` : ''
-  const summary = entry.summary || '(no summary)'
+  const windowInfo = entry.windowTitle
+    ? ` [window: ${JSON.stringify(scrubPromptPII(entry.windowTitle))}]`
+    : ''
+  const summary = entry.summary ? scrubPromptPII(entry.summary) : '(no summary)'
   return `- ${entry.id} | ${timeStr}${appInfo}${windowInfo} | ${summary}`
 }
 

--- a/src/main/mcp/tools.test.ts
+++ b/src/main/mcp/tools.test.ts
@@ -293,6 +293,44 @@ describe('pattern tools (task clusters)', () => {
       expect(text).toContain('Activity IDs: act-a, act-b')
     })
 
+    it('scrubs secrets and phones from sighting fields but keeps emails and IDs verbatim', async () => {
+      addClusterWithMembers(createCluster({ id: 'c1', label: 'Send report' }), [
+        createSighting({
+          id: 's1',
+          subject: 'jane.doe@acme.co',
+          description: 'Used password: hunter42 and called +1 (555) 123-4567',
+          activityIds: ['act-a1', 'act-b2'],
+        }),
+        createSighting({ id: 's2' }),
+      ])
+
+      const text = (await handlers.get('get_pattern_details')!({ patternId: 'c1' })).content[0].text
+      expect(text).not.toContain('hunter42')
+      expect(text).not.toContain('555) 123-4567')
+      expect(text).toContain('[redacted password]')
+      expect(text).toContain('[phone number]')
+      expect(text).toContain('jane.doe@acme.co')
+      expect(text).toContain('Activity IDs: act-a1, act-b2')
+    })
+
+    it('scrubs secrets from activity summaries and OCR in get_activity_details', async () => {
+      storage.activities.add(
+        createStoredActivity({
+          id: 'act-ocr',
+          summary: 'Logged in with password: hunter42',
+          ocrText: 'Username: jane.doe@acme.co\nAPI_KEY=9f8e7d6c5b4a\nCall 555-123-4567',
+        }),
+      )
+
+      const text = (await handlers.get('get_activity_details')!({ ids: ['act-ocr'] })).content[0]
+        .text
+      expect(text).not.toContain('hunter42')
+      expect(text).not.toContain('9f8e7d6c5b4a')
+      expect(text).not.toContain('555-123-4567')
+      expect(text).toContain('jane.doe@acme.co')
+      expect(text).toContain('ID: act-ocr')
+    })
+
     it('never prints raw member step text (steps are not scrubbed for egress)', async () => {
       addClusterWithMembers(createCluster({ id: 'c1', label: 'Daily standup notes' }), [
         createSighting({

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -26,6 +26,7 @@ import {
 import { CLUSTER_VIEW_CONFIG } from '@/shared/constants'
 import type { ClusterInfo } from '../../shared/types'
 import log from '@main/utils/logger'
+import { scrubPromptPII } from '@/shared/sanitize'
 
 export interface MCPServices {
   storage: StorageService
@@ -617,9 +618,11 @@ function formatClusterLine(c: ClusterInfo): string {
   }
   stats.push(`avg ${Math.round(c.avgActiveMin)} min/run`)
   if (c.lastSeenAt) stats.push(`last seen ${new Date(c.lastSeenAt).toLocaleString()}`)
-  const lines = [`- ${c.id} | ${c.title} [${c.apps.join(', ')}] (${stats.join(', ')})`]
-  if (c.description) lines.push(`  ${c.description}`)
-  if (c.mechanism) lines.push(`  Replace with: ${c.mechanism}`)
+  const lines = [
+    `- ${c.id} | ${scrubPromptPII(c.title)} [${c.apps.join(', ')}] (${stats.join(', ')})`,
+  ]
+  if (c.description) lines.push(`  ${scrubPromptPII(c.description)}`)
+  if (c.mechanism) lines.push(`  Replace with: ${scrubPromptPII(c.mechanism)}`)
   return lines.join('\n')
 }
 
@@ -631,8 +634,8 @@ function formatClusterSightingLine(s: Sighting): string {
   const lines = [
     `- ${s.id} | ${start} -> ${end} | ~${activeMin} min active | [${s.apps.join(', ')}]`,
   ]
-  lines.push(`  ${title}`)
-  if (s.description) lines.push(`  ${s.description}`)
+  lines.push(`  ${scrubPromptPII(title)}`)
+  if (s.description) lines.push(`  ${scrubPromptPII(s.description)}`)
   lines.push(`  Activity IDs: ${s.activityIds.join(', ')}`)
   return lines.join('\n')
 }
@@ -830,7 +833,7 @@ async function handleGetUserContext(services: MCPServices | null) {
       content: [
         {
           type: 'text' as const,
-          text: `User profile (last updated: ${updatedAtStr}):\n\nShort summary:\n${ctx.shortSummary}\n\nDetailed summary:\n${ctx.detailedSummary}`,
+          text: `User profile (last updated: ${updatedAtStr}):\n\nShort summary:\n${scrubPromptPII(ctx.shortSummary)}\n\nDetailed summary:\n${scrubPromptPII(ctx.detailedSummary)}`,
         },
       ],
     }
@@ -881,8 +884,9 @@ async function handleGetActivityDetails(services: MCPServices | null, { ids }: {
         const timeStr = new Date(a.startTimestamp).toLocaleString()
         const endTimeStr = new Date(a.endTimestamp).toLocaleString()
         const appInfo = a.appName ? ` [${a.appName}]` : ''
-        const summaryLine = a.summary ? `\nSummary: ${a.summary}` : ''
-        return `ID: ${a.id}\n[${timeStr} → ${endTimeStr}]${appInfo}${summaryLine}\nOCR: ${a.ocrText}`
+        const summaryLine = a.summary ? `\nSummary: ${scrubPromptPII(a.summary)}` : ''
+        const ocrText = a.ocrText ? scrubPromptPII(a.ocrText) : a.ocrText
+        return `ID: ${a.id}\n[${timeStr} → ${endTimeStr}]${appInfo}${summaryLine}\nOCR: ${ocrText}`
       })
       .join('\n\n---\n\n')
 

--- a/src/main/semantic/prompt.ts
+++ b/src/main/semantic/prompt.ts
@@ -1,5 +1,6 @@
 import type { InteractionContext } from '../../shared/types'
 import type { Activity } from '@main/activity/activity-types'
+import { scrubPromptPII } from '@/shared/sanitize'
 import type { SemanticMode } from './types'
 
 export function buildSemanticPrompt(
@@ -26,6 +27,8 @@ export function buildSemanticPrompt(
   prompt +=
     '- Be specific: name files, functions, errors, URLs, and UI elements visible in the provided media.\n'
   prompt +=
+    '- NEVER transcribe credentials, API keys, or payment/account numbers. Replace them with a typed placeholder ([redacted password], [redacted secret], [redacted payment card]) — never silently omit what happened.\n'
+  prompt +=
     '- Match verb intensity to evidence: browsing/reviewing (no visible edits) -> "browsed," "reviewed," "checked." Light editing (small visible changes) -> "tweaked," "adjusted." Active work (sustained edits, new code, debugging) -> "implemented," "debugged," "refactored." Evidence of editing = visible changed lines, new code, or diff markers.\n'
   prompt +=
     '- Do NOT exaggerate. Switching files/tabs = browsing, not editing. Opening a file/page = reviewing, not working on it.\n'
@@ -44,7 +47,7 @@ export function buildSemanticPrompt(
   prompt += '## Context\n'
   prompt += `- App: ${activity.context.appName}\n`
   if (activity.context.windowTitle) {
-    prompt += `- Window: ${activity.context.windowTitle}\n`
+    prompt += `- Window: ${scrubPromptPII(activity.context.windowTitle)}\n`
   }
   if (activity.context.tld) {
     prompt += `- TLD: ${activity.context.tld}\n`
@@ -53,7 +56,7 @@ export function buildSemanticPrompt(
   prompt += `- Start: ${new Date(activity.startTimestamp).toISOString()}\n`
   prompt += `- End: ${new Date(activity.endTimestamp).toISOString()}\n`
   if (userContext) {
-    prompt += `- User: ${userContext}\n`
+    prompt += `- User: ${scrubPromptPII(userContext)}\n`
   }
   prompt += `- ${sourceNote}\n\n`
 
@@ -86,7 +89,7 @@ function buildInteractionTimeline(activity: Activity): string {
   const items: string[] = []
   for (const interaction of interactions.slice(0, maxItems)) {
     const offsetSeconds = ((interaction.timestamp - activity.startTimestamp) / 1000).toFixed(1)
-    items.push(`- t+${offsetSeconds}s: ${describeInteraction(interaction)}`)
+    items.push(`- t+${offsetSeconds}s: ${scrubPromptPII(describeInteraction(interaction))}`)
   }
 
   if (interactions.length > maxItems) {

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -71,3 +71,43 @@ describe('runContentReview', () => {
     expect(mockedGenerateText).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('PII scrubbing', () => {
+  const memberInput = {
+    clusters: [
+      {
+        id: 'c1',
+        splittable: false,
+        label: '',
+        stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
+        members: [
+          {
+            sighting_id: 's1',
+            title: 'Email jane.doe@acme.co the report',
+            subject: 'password: hunter42',
+            description: 'Sent the weekly report',
+            steps: ['mail.google.com: mail jane.doe@acme.co'],
+            apps: ['mail.google.com'],
+            active_min: 5,
+            date: '2026-07-30',
+          },
+        ],
+      },
+    ],
+    mergeCandidates: [] as [string, string][],
+  }
+
+  it('scrubs secrets from the prompt but keeps emails for context', async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: '{"clusters":[]}',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never)
+
+    await runContentReview(provider, 'model', memberInput)
+
+    const call = mockedGenerateText.mock.calls[0][0] as { prompt: string }
+    expect(call.prompt).not.toContain('hunter42')
+    expect(call.prompt).toContain('[redacted password]')
+    expect(call.prompt).toContain('jane.doe@acme.co')
+  })
+})

--- a/src/main/services/task-miner/clustering/llm-review.ts
+++ b/src/main/services/task-miner/clustering/llm-review.ts
@@ -2,6 +2,7 @@ import { generateText } from 'ai'
 import type { InferenceProvider } from '@main/llm'
 import { extractJsonObject, formatApiError } from '../helpers'
 import { PATTERN_DETECTION_CONFIG } from '@/shared/constants'
+import { scrubPromptPII } from '@/shared/sanitize'
 import type { ReviewInput, ReviewOutput } from './types'
 import { CLUSTERING_CONFIG } from './types'
 import {
@@ -14,6 +15,23 @@ import type { ProgressCallback } from '../types'
 export interface ReviewCallResult {
   output: ReviewOutput | null
   tokenUsage: { input: number; output: number }
+}
+
+function scrubReviewInputForPrompt(input: ReviewInput): ReviewInput {
+  return {
+    mergeCandidates: input.mergeCandidates,
+    clusters: input.clusters.map((cluster) => ({
+      ...cluster,
+      label: scrubPromptPII(cluster.label),
+      members: cluster.members.map((member) => ({
+        ...member,
+        title: scrubPromptPII(member.title),
+        subject: scrubPromptPII(member.subject),
+        description: scrubPromptPII(member.description),
+        ...(member.steps && { steps: member.steps.map(scrubPromptPII) }),
+      })),
+    })),
+  }
 }
 
 /**
@@ -29,7 +47,7 @@ async function callReview(
   describe: (attempt: number) => string,
   progress?: ProgressCallback,
 ): Promise<ReviewCallResult> {
-  const prompt = serializeReviewInput(input)
+  const prompt = serializeReviewInput(scrubReviewInputForPrompt(input))
   const tokenUsage = { input: 0, output: 0 }
 
   for (let attempt = 1; attempt <= CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS; attempt++) {

--- a/src/main/services/task-miner/clustering/prompts.ts
+++ b/src/main/services/task-miner/clustering/prompts.ts
@@ -69,7 +69,7 @@ Rules:
 - Never invent cluster ids not present in the input.
 - Do not mention counts, frequencies, or durations in labels/descriptions — those are computed separately.
 - When unsure of the kind, choose the non-eliminable reading — a wrongly promised automation costs more than a missed one.
-- steps and variables carry NO personal data: no real names, companies, emails, phone numbers, ids, or PII/PHI. When in doubt, replace the specific with a generic variable.
+- labels, descriptions, steps, and variables carry NO personal data: no real names, companies, emails, phone numbers, credentials, account numbers, or PII/PHI. They are copied into outside tools; when in doubt, replace the specific with a generic variable.
 
 Output a single JSON object, no other text:
 

--- a/src/main/services/task-miner/prompts.test.ts
+++ b/src/main/services/task-miner/prompts.test.ts
@@ -33,6 +33,12 @@ describe('buildScanSystemPrompt', () => {
     expect(prompt).toContain('describe only actions the cited activities evidence')
   })
 
+  it('forbids copying credentials or account numbers into any field', () => {
+    const prompt = buildScanSystemPrompt('Monday')
+    expect(prompt).toContain('Never copy credentials, passwords, API keys')
+    expect(prompt).toContain('[redacted account number]')
+  })
+
   it('instructs canonical, object-free titles', () => {
     const prompt = buildScanSystemPrompt('Monday')
     expect(prompt).toContain(
@@ -50,6 +56,12 @@ describe('buildGroundingSystemPrompt', () => {
     steps: ['admin.acme.com: create the tenant'],
     activity_ids: ['a1', 'a2'],
   }
+
+  it('forbids copying credentials from the OCR into any field', () => {
+    const prompt = buildGroundingSystemPrompt(candidate, ['admin.acme.com'])
+    expect(prompt).toContain('Never copy credentials, passwords, API keys')
+    expect(prompt).toContain('[redacted secret]')
+  })
 
   it('carries subject through the keep-JSON so scanOnly=false persists it', () => {
     expect(buildGroundingSystemPrompt(candidate, ['admin.acme.com'])).toContain('"subject"')

--- a/src/main/services/task-miner/prompts.ts
+++ b/src/main/services/task-miner/prompts.ts
@@ -50,6 +50,7 @@ A run of a repeatable multi-step procedure that CHANGES something — creates, p
 - Every description ENDS with exactly one sentence naming the mechanism: "Replace with: <the concrete script, integration, alert, or platform feature>." If you cannot write that sentence concretely, the finding does not exist.
 - \`steps\` describe only actions the cited activities evidence, one action per line, each starting with that activity's \`app\` — never a browser name.
 - Titles name the procedure, subjects name the object: title "Process invoice", subject "Customer ABC" — never title "Process invoice for Customer ABC". The title is worded so every run of the procedure gets it identically; the specific object goes in \`subject\`. Two runs of the same procedure on different objects share one title and differ only in subject. \`subject\` is optional — leave it empty when the run acted on no single nameable object.
+- Never copy credentials, passwords, API keys, or payment/account/government-id numbers into \`title\`, \`subject\`, \`description\`, or \`steps\`; if the object is only identifiable by one, use a typed placeholder like [redacted account number].
 ${knownProceduresSection}
 ## Output
 
@@ -109,6 +110,8 @@ If this is a real, grounded run:
 }
 \`\`\`
 If you cannot write the "Replace with:" sentence concretely, reject.
+
+Never copy credentials, passwords, API keys, or payment/account/government-id numbers from the OCR into any field; use a typed placeholder like [redacted secret] where one is needed.
 
 ### Reject
 Reject if the evidence shows checking/watching, re-checks of that day's work in progress, dev-loop mechanics, a one-off action, creative or judgment work; if the cited activities don't support the claim; or if fewer than 2 substantive activities remain after cleanup. Keep only what you could defend to the client from the evidence on screen:

--- a/src/main/services/task-miner/run-detection.test.ts
+++ b/src/main/services/task-miner/run-detection.test.ts
@@ -67,6 +67,32 @@ describe('runDetection day commit', () => {
     deleteDbFiles(TEST_DB_PATH)
   })
 
+  it('scrubs secrets and phones from the scan prompt but keeps emails and names', async () => {
+    storage.activities.add({
+      id: 'act-pii',
+      appName: 'TestApp',
+      windowTitle: 'Call Jane Novak at +1 (555) 123-4567',
+      tld: null,
+      startTimestamp: dayStart(1) + 5000,
+      endTimestamp: dayStart(1) + 5500,
+      summary: 'Mailed jane.doe@acme.co the password: hunter42',
+      summaryModel: '',
+      ocrText: '',
+      vector: v(0.1),
+    })
+    mockedGenerateText.mockResolvedValue(scanResponse('[]'))
+
+    await runDetection(provider, storage, embedder, { lookbackDays: 1 })
+
+    const call = mockedGenerateText.mock.calls[0][0] as { prompt: string }
+    expect(call.prompt).not.toContain('555) 123-4567')
+    expect(call.prompt).not.toContain('hunter42')
+    expect(call.prompt).toContain('[phone number]')
+    expect(call.prompt).toContain('[redacted password]')
+    expect(call.prompt).toContain('Jane Novak')
+    expect(call.prompt).toContain('jane.doe@acme.co')
+  })
+
   it('throws after all scan attempts return unusable output, leaving the day uncommitted', async () => {
     mockedGenerateText.mockResolvedValue(scanResponse('not json at all'))
     const onCommit = vi.fn()

--- a/src/main/services/task-miner/run-detection.ts
+++ b/src/main/services/task-miner/run-detection.ts
@@ -22,6 +22,7 @@ import {
 } from './helpers'
 import { getDayBoundaries } from '@main/utils/day'
 import { deriveSightingApps } from '@/shared/app-utils'
+import { scrubPromptPII } from '@/shared/sanitize'
 import { buildVerificationTools } from './tools'
 import { normalizeScanCandidates, normalizeSteps } from './candidate-normalizer'
 import { buildScanSystemPrompt, buildGroundingSystemPrompt } from './prompts'
@@ -112,12 +113,12 @@ export async function runDetection(
   // 2. User context (optional flavor for the scan)
   const userCtx = storage.userContext.get()
   const userContextStr = userCtx
-    ? `${userCtx.shortSummary}\n\n${userCtx.detailedSummary}`
+    ? scrubPromptPII(`${userCtx.shortSummary}\n\n${userCtx.detailedSummary}`)
     : undefined
 
   // Canonical titles of established procedures, fed back so recurring work
   // reuses its name cross-day. Empty on fresh/eval DBs — section omitted.
-  const knownProcedures = getKnownProcedureTitles(storage)
+  const knownProcedures = getKnownProcedureTitles(storage).map(scrubPromptPII)
 
   // =========================================================================
   // Phase 1: Scan — discover discrete task instances
@@ -127,7 +128,13 @@ export async function runDetection(
   // models mangle long opaque ids when citing them (dropping whole findings),
   // and short handles cut prompt tokens. Mapped back right after parsing.
   const realIdOf = new Map<string, string>()
-  const serialized = serializeActivities(activities).map((row, i) => {
+  const serialized = serializeActivities(
+    activities.map((a) => ({
+      ...a,
+      windowTitle: scrubPromptPII(a.windowTitle),
+      summary: scrubPromptPII(a.summary),
+    })),
+  ).map((row, i) => {
     const shortId = `a${i + 1}`
     realIdOf.set(shortId, activities[i].id)
     return { ...row, id: shortId }
@@ -261,26 +268,33 @@ export async function runDetection(
       let parsed: Record<string, unknown> = {}
       if (!cfg.scanOnly) {
         const candidateActivities = storage.activities.getByIds(candidate.activity_ids)
+        const promptCandidate = {
+          ...candidate,
+          title: scrubPromptPII(candidate.title),
+          subject: scrubPromptPII(candidate.subject),
+          description: scrubPromptPII(candidate.description),
+          steps: candidate.steps.map(scrubPromptPII),
+        }
         const groundPrompt = buildGroundingSystemPrompt(
-          candidate,
+          promptCandidate,
           deriveSightingApps(candidateActivities),
         )
 
         const enrichedActivities = candidateActivities.map((a) => ({
           id: a.id,
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPromptPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
           end_time: new Date(a.endTimestamp).toISOString(),
-          summary: a.summary,
+          summary: scrubPromptPII(a.summary),
         }))
 
         const candidateInput = `Investigate this candidate task:\n\n\`\`\`json\n${JSON.stringify(
           {
-            title: candidate.title,
-            subject: candidate.subject,
-            description: candidate.description,
-            steps: candidate.steps,
+            title: promptCandidate.title,
+            subject: promptCandidate.subject,
+            description: promptCandidate.description,
+            steps: promptCandidate.steps,
             activities: enrichedActivities,
           },
           null,

--- a/src/main/services/task-miner/tools.ts
+++ b/src/main/services/task-miner/tools.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai'
 import { z } from 'zod'
 import type { StorageService } from '../../storage'
 import type { ActivityEmbeddingService } from '@main/activity/activity-transformer-types'
+import { scrubPromptPII } from '@/shared/sanitize'
 
 export function buildVerificationTools(
   storage: StorageService,
@@ -29,10 +30,10 @@ export function buildVerificationTools(
         return activities.map((a) => ({
           id: a.id,
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPromptPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
-          summary: a.summary,
-          ocr_text: a.ocrText || '(no OCR text captured)',
+          summary: scrubPromptPII(a.summary),
+          ocr_text: a.ocrText ? scrubPromptPII(a.ocrText) : '(no OCR text captured)',
         }))
       },
     }),
@@ -54,10 +55,10 @@ export function buildVerificationTools(
         return results.map((a) => ({
           id: a.id,
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPromptPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
           duration_min: Math.round((a.endTimestamp - a.startTimestamp) / 60000),
-          summary: a.summary,
+          summary: scrubPromptPII(a.summary),
         }))
       },
     }),
@@ -90,11 +91,11 @@ export function buildVerificationTools(
         return activities.map((a) => ({
           id: a.id,
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPromptPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
           end_time: new Date(a.endTimestamp).toISOString(),
           duration_min: Math.round((a.endTimestamp - a.startTimestamp) / 60000),
-          summary: a.summary,
+          summary: scrubPromptPII(a.summary),
         }))
       },
     }),

--- a/src/main/services/user-context-builder.ts
+++ b/src/main/services/user-context-builder.ts
@@ -15,6 +15,7 @@ import type { StorageService, ActivityDetail } from '../storage'
 import type { InferenceProvider } from '../llm'
 import type { UserContext } from '../storage/user-context-repository'
 import { USER_CONTEXT_CONFIG } from '../../shared/constants'
+import { scrubPromptPII } from '@/shared/sanitize'
 import log from '@main/utils/logger'
 
 // ---------------------------------------------------------------------------
@@ -92,7 +93,7 @@ function aggregateActivities(activities: ActivityDetail[]): AggregatedProfile {
       top_windows: [...stats.windows.entries()]
         .sort((a, b) => b[1] - a[1])
         .slice(0, 5)
-        .map(([title]) => title),
+        .map(([title]) => scrubPromptPII(title)),
     }))
 
   // Sample up to 80 unique summaries evenly across the set
@@ -101,7 +102,7 @@ function aggregateActivities(activities: ActivityDetail[]): AggregatedProfile {
   const step = Math.max(1, Math.floor(allSummaries.length / maxSamples))
   const sample_summaries: string[] = []
   for (let i = 0; i < allSummaries.length && sample_summaries.length < maxSamples; i += step) {
-    sample_summaries.push(allSummaries[i])
+    sample_summaries.push(scrubPromptPII(allSummaries[i]))
   }
 
   const totalMs = activities.reduce((sum, a) => sum + (a.endTimestamp - a.startTimestamp), 0)

--- a/src/shared/sanitize.test.ts
+++ b/src/shared/sanitize.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { scrubPII } from './sanitize'
+import { scrubPII, scrubPromptPII } from './sanitize'
+
+const OPENAI_KEY = 'sk-' + 'proj-Ab12Cd34Ef56Gh78Ij90'
+const GH_TOKEN = 'ghp_' + 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4'
+const GH_PAT = 'github_pat_' + '11ABCDEFG0abcdefghijklmnop'
+const AWS_KEY_ID = 'AKIA' + 'IOSFODNN7EXAMPLE'
+const JWT = 'eyJ' + 'hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9P'
 
 describe('scrubPII', () => {
   it('replaces email addresses with a typed slot', () => {
@@ -37,5 +43,78 @@ describe('scrubPII', () => {
   it('leaves clean recipe text untouched', () => {
     const text = 'Open the customer thread in Gmail (mail.google.com) and read the latest reply.'
     expect(scrubPII(text)).toBe(text)
+  })
+
+  it('replaces secret-shaped tokens', () => {
+    expect(scrubPII(`export OPENAI_API_KEY=${OPENAI_KEY}`)).toBe(
+      'export OPENAI_API_KEY=[redacted secret]',
+    )
+    expect(scrubPII(`git push with ${GH_TOKEN}`)).toBe('git push with [redacted secret]')
+    expect(scrubPII(`token ${GH_PAT} created`)).toBe('token [redacted secret] created')
+    expect(scrubPII(`aws configure ${AWS_KEY_ID}`)).toBe('aws configure [redacted secret]')
+    expect(scrubPII(`Authorization: Bearer ${JWT}`)).toBe('Authorization: Bearer [redacted secret]')
+  })
+
+  it('replaces labeled secret values', () => {
+    expect(scrubPII('AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG')).toBe(
+      'AWS_SECRET_ACCESS_KEY=[redacted secret]',
+    )
+    expect(scrubPII('api_key: 9f8e7d6c5b4a')).toBe('api_key: [redacted secret]')
+    expect(scrubPII('set max_tokens: 4096 in the request')).toBe(
+      'set max_tokens: 4096 in the request',
+    )
+  })
+
+  it('replaces labeled passwords', () => {
+    expect(scrubPII('password: Tr0ub4dor&3')).toBe('password: [redacted password]')
+    expect(scrubPII('pwd=hunter42')).toBe('pwd=[redacted password]')
+    expect(scrubPII('enter your password: ')).toBe('enter your password: ')
+  })
+
+  it('replaces password-shaped tokens on the line after a password label', () => {
+    expect(scrubPII('Temporary password\nSumm3r!2026\nChange on first login')).toBe(
+      'Temporary password\n[redacted password]\nChange on first login',
+    )
+    expect(scrubPII('Change password\nSettings')).toBe('Change password\nSettings')
+  })
+
+  it('replaces labeled employee ids', () => {
+    expect(scrubPII('Employee ID: EMP-04481\nDepartment: Ops')).toBe(
+      'Employee ID: [redacted employee id]\nDepartment: Ops',
+    )
+    expect(scrubPII('Emp No. E-118245 on shift')).toBe('Emp No. [redacted employee id] on shift')
+    expect(scrubPII('the employee handbook')).toBe('the employee handbook')
+  })
+
+  it('replaces labeled dates of birth but not plain dates', () => {
+    expect(scrubPII('DOB: 04/12/1985')).toBe('DOB: [redacted date of birth]')
+    expect(scrubPII('Date of birth: 1985-04-12')).toBe('Date of birth: [redacted date of birth]')
+    expect(scrubPII('born March 3, 1990 in Ohio')).toBe('born [redacted date of birth] in Ohio')
+    expect(scrubPII('meeting on 04/12/2026 moved')).toBe('meeting on 04/12/2026 moved')
+  })
+
+  it('preserves technical identifiers', () => {
+    expect(scrubPII('ssh deploy@192.168.1.100 failed')).toBe('ssh deploy@192.168.1.100 failed')
+    expect(scrubPII('activity 550e8400-e29b-41d4-a716-446655440000 missing')).toBe(
+      'activity 550e8400-e29b-41d4-a716-446655440000 missing',
+    )
+    expect(scrubPII('git checkout a1b2c3d4e5f6 to bisect')).toBe(
+      'git checkout a1b2c3d4e5f6 to bisect',
+    )
+    expect(scrubPII('saved 2026-07-03T14-26-21-980Z.md to disk')).toBe(
+      'saved 2026-07-03T14-26-21-980Z.md to disk',
+    )
+    expect(scrubPII('JIRA OPS-11842: rotate the certs')).toBe('JIRA OPS-11842: rotate the certs')
+    expect(scrubPII('trace id 7f3c9a2b1d8e4f60 logged')).toBe('trace id 7f3c9a2b1d8e4f60 logged')
+  })
+})
+
+describe('scrubPromptPII', () => {
+  it('keeps emails but scrubs secrets, passwords, and digit runs', () => {
+    expect(scrubPromptPII('mail jane.doe@acme.co about it')).toBe('mail jane.doe@acme.co about it')
+    expect(scrubPromptPII(`key ${OPENAI_KEY} leaked`)).toBe('key [redacted secret] leaked')
+    expect(scrubPromptPII('password: Tr0ub4dor&3')).toBe('password: [redacted password]')
+    expect(scrubPromptPII('call +1 (555) 123-4567 now')).toBe('call [phone number] now')
+    expect(scrubPromptPII('order 100294 shipped')).toBe('order [id number] shipped')
   })
 })

--- a/src/shared/sanitize.ts
+++ b/src/shared/sanitize.ts
@@ -1,9 +1,10 @@
 /**
  * Deterministic PII scrub — the regex backstop behind the LLM's de-identification
- * (the model handles names; this catches emails, phone numbers, and long id runs).
- * Typed slot names instead of [redacted] so the recipe still says what goes there.
- * Conservative by design: must never mangle prose like "4 steps" or dates, and
- * every quantifier is bounded so matching stays linear.
+ * (the model handles names; this catches emails, phone numbers, long id runs,
+ * and secret-shaped values). Typed slot names instead of [redacted] so the
+ * recipe still says what goes there. Conservative by design: must never mangle
+ * prose like "4 steps" or dates, and every quantifier is bounded so matching
+ * stays linear.
  */
 
 const EMAIL =
@@ -14,17 +15,57 @@ const LONG_DIGITS = /\b\d{5,}\b/g
 // 2026-07-19, 2026/7/9, 19.07.2026, 19. 7. 2026, and year ranges like 2024-2025.
 const DATE_LIKE =
   /^\d{4}([-/.])\d{1,2}(?:\1\d{1,2})?$|^\d{1,2}([./-])\s?\d{1,2}\2\s?\d{4}$|^\d{4}-\d{4}$/
+const DOTTED_QUAD = /^\d{1,3}(?:\.\d{1,3}){3}$/
+
+const SECRET_TOKEN =
+  /\b(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[A-Z0-9]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{8,})\b/g
+const LABELED_SECRET =
+  /\b([A-Za-z0-9_.-]*(?:secret|token|api[_-]?key|apikey|access[_-]?key|private[_-]?key)\b\s*[:=]\s*)(?!\[)(\S{6,})/gi
+const LABELED_PASSWORD = /\b((?:password|passwd|passphrase|pwd)\s*[:=]\s*)(?!\[)(\S{4,})/gi
+const PASSWORD_LINE =
+  /\b((?:password|passwd|passphrase)\s*\n\s*)(?!\[)((?=\S*[\d#!@$%^&*+=])\S{6,})/gi
+const LABELED_DOB =
+  /\b((?:date of birth|birth ?date|dob|born(?: on)?)\s*[:=]?\s*(?:(?:to|is)\s+)?)((?:\d{1,2}[/. -]){2}\d{2,4}|\d{4}-\d{2}-\d{2}|(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.? \d{1,2},? \d{4})/gi
+const LABELED_EMPLOYEE_ID =
+  /\b((?:employee|badge|worker|emp)\s*(?:id|no|number)?\.?\s*[:#]?\s*)((?=[A-Za-z0-9-]*\d{4})[A-Za-z0-9-]{4,})/gi
 
 const countDigits = (s: string): number => s.match(/\d/g)?.length ?? 0
 
-export function scrubPII(text: string): string {
-  return text
-    .replace(EMAIL, '[email address]')
-    .replace(PHONE_LIKE, (m) => {
+// A digit run touching letters through [\w-] is an identifier (UUID segment,
+// timestamp filename, tracking/ticket id), not a phone or bare id.
+const isIdentifierBound = (s: string, start: number, end: number): boolean => {
+  for (let i = start - 1; i >= 0 && /[\w-]/.test(s[i]); i--) {
+    if (/[A-Za-z_]/.test(s[i])) return true
+  }
+  for (let j = end; j < s.length && /[\w-]/.test(s[j]); j++) {
+    if (/[A-Za-z_]/.test(s[j])) return true
+  }
+  return false
+}
+
+const scrubCore = (text: string): string =>
+  text
+    .replace(SECRET_TOKEN, '[redacted secret]')
+    .replace(LABELED_SECRET, '$1[redacted secret]')
+    .replace(LABELED_PASSWORD, '$1[redacted password]')
+    .replace(PASSWORD_LINE, '$1[redacted password]')
+    .replace(LABELED_DOB, '$1[redacted date of birth]')
+    .replace(LABELED_EMPLOYEE_ID, '$1[redacted employee id]')
+    .replace(PHONE_LIKE, (m, offset: number, s: string) => {
       // Digit-and-space-only runs need 9+ digits so spaced amounts like
       // "1 000 000" survive; real spaced phones (CZ "777 123 456") still hit 9.
       const minDigits = /^[\d\s]+$/.test(m) ? 9 : 7
-      return countDigits(m) >= minDigits && !DATE_LIKE.test(m) ? '[phone number]' : m
+      if (countDigits(m) < minDigits || DATE_LIKE.test(m) || DOTTED_QUAD.test(m)) return m
+      return isIdentifierBound(s, offset, offset + m.length) ? m : '[phone number]'
     })
-    .replace(LONG_DIGITS, '[id number]')
+    .replace(LONG_DIGITS, (m, offset: number, s: string) =>
+      isIdentifierBound(s, offset, offset + m.length) ? m : '[id number]',
+    )
+
+export function scrubPII(text: string): string {
+  return scrubCore(text.replace(EMAIL, '[email address]'))
+}
+
+export function scrubPromptPII(text: string): string {
+  return scrubCore(text)
 }


### PR DESCRIPTION
Split from #270 (2/3). Every cloud-LLM input and MCP output gets the sync regex `scrubPromptPII`: secrets/API keys/JWTs, labeled passwords and DOBs, employee ids, payment/SSN/bank digit runs, phones. Emails and names deliberately survive — they carry the signal the model reasons with — and output prompt rules stop the model from transcribing harm classes. On a real dev-DB day this alters 4/400 texts.

Seams: task-miner scan + grounding + verification tools (incl. OCR), cluster review input, semantic summarizer, user-context builder, and all MCP tool outputs. Applied per-field at interpolation — ids, timestamps, and app names never enter the scrub.

Regex layer (`sanitize.ts`): new secret/password/DOB/employee-id classes, plus an identifier-adjacency guard that ends the UUID-segment/timestamp-filename/tracking-number false positives.

Includes the one-line rebase resolution of `clustering/prompts.ts` over #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)