### PR TITLE
Share-tier NER PII scrub for share surfaces (DEU-205)

### DIFF
--- a/scripts/download-model.js
+++ b/scripts/download-model.js
@@ -2,23 +2,28 @@
 const fs = require('fs')
 const path = require('path')
 
-const MODEL_ID = 'Xenova/all-MiniLM-L6-v2'
-const BASE_URL = `https://huggingface.co/${MODEL_ID}/resolve/main`
+const MODELS = [
+  {
+    id: 'Xenova/all-MiniLM-L6-v2',
+    files: ['config.json', 'tokenizer.json', 'tokenizer_config.json', 'onnx/model.onnx'],
+  },
+  {
+    id: 'nationaldesignstudio/rampart',
+    files: ['config.json', 'tokenizer.json', 'tokenizer_config.json', 'onnx/model_q4.onnx'],
+  },
+]
 
 const repoRoot = path.resolve(__dirname, '..')
-const outputDir = path.join(repoRoot, 'build', 'models', MODEL_ID)
 
-const FILES = ['config.json', 'tokenizer.json', 'tokenizer_config.json', 'onnx/model.onnx']
-
-async function downloadFile(file) {
+async function downloadFile(model, outputDir, file) {
   const dest = path.join(outputDir, file)
   if (fs.existsSync(dest)) {
-    console.log(`[build:model] Already exists, skipping: ${file}`)
+    console.log(`[build:model] Already exists, skipping: ${model.id}/${file}`)
     return
   }
 
-  const url = `${BASE_URL}/${file}`
-  console.log(`[build:model] Downloading ${file}...`)
+  const url = `https://huggingface.co/${model.id}/resolve/main/${file}`
+  console.log(`[build:model] Downloading ${model.id}/${file}...`)
 
   const res = await fetch(url)
   if (!res.ok) {
@@ -30,15 +35,18 @@ async function downloadFile(file) {
   const buffer = Buffer.from(await res.arrayBuffer())
   fs.writeFileSync(dest, buffer)
   const sizeMB = (buffer.length / 1024 / 1024).toFixed(1)
-  console.log(`[build:model] Saved ${file} (${sizeMB} MB)`)
+  console.log(`[build:model] Saved ${model.id}/${file} (${sizeMB} MB)`)
 }
 
 async function main() {
-  console.log(`[build:model] Downloading ${MODEL_ID} to ${outputDir}`)
-  fs.mkdirSync(outputDir, { recursive: true })
+  for (const model of MODELS) {
+    const outputDir = path.join(repoRoot, 'build', 'models', model.id)
+    console.log(`[build:model] Downloading ${model.id} to ${outputDir}`)
+    fs.mkdirSync(outputDir, { recursive: true })
 
-  for (const file of FILES) {
-    await downloadFile(file)
+    for (const file of model.files) {
+      await downloadFile(model, outputDir, file)
+    }
   }
 
   console.log('[build:model] Done.')

--- a/scripts/eval-pii-scrub.ts
+++ b/scripts/eval-pii-scrub.ts
@@ -16,8 +16,9 @@
 
 import * as fs from 'fs'
 import * as path from 'path'
-import Database from 'better-sqlite3'
-import { scrubPII } from '../src/shared/sanitize'
+import DatabaseConstructor from 'better-sqlite3'
+import { scrubPII, scrubPromptPII } from '../src/shared/sanitize'
+import { PiiScrubber } from '../src/main/processor/pii-scrub'
 import { getDefaultDbPath, getModelCacheDir } from '../src/main/utils/paths'
 import {
   PII_PLANTS,
@@ -63,6 +64,8 @@ const NER_MODELS: Record<string, { id: string; dtype: string }> = {
 
 const ALL_SCRUBBERS = [
   'current',
+  'prompt',
+  'shipped',
   'remove-pii',
   'redact-pii',
   'rampart',
@@ -382,6 +385,28 @@ function buildScrubber(spec: string, threshold: number, cache: Map<string, Scrub
       async () => scrubPII,
       () => '0MB (built-in)',
     )
+  } else if (spec === 'prompt') {
+    scrubber = makeSimpleScrubber(
+      'prompt',
+      async () => scrubPromptPII,
+      () => '0MB (built-in)',
+    )
+  } else if (spec === 'shipped') {
+    const shipped = new PiiScrubber()
+    scrubber = {
+      name: 'shipped',
+      loadMs: 0,
+      async init() {
+        const t0 = performance.now()
+        await shipped.scrubBatch(['warmup'])
+        this.loadMs = Math.round(performance.now() - t0)
+      },
+      async scrub(text: string) {
+        const [out] = await shipped.scrubBatch([text])
+        return out
+      },
+      footprint: () => '14MB model + 0MB (built-in)',
+    }
   } else if (spec === 'remove-pii') {
     scrubber = makeSimpleScrubber(
       'remove-pii',
@@ -508,7 +533,7 @@ function diffSample(before: string, after: string): { before: string; after: str
 function loadDayTexts(dbPath: string, day: string, includeOcr: boolean, cap: number): string[] {
   const start = new Date(`${day}T00:00:00`).getTime()
   const end = start + 24 * 60 * 60 * 1000
-  const db = new Database(dbPath, { readonly: true, fileMustExist: true })
+  const db = new DatabaseConstructor(dbPath, { readonly: true, fileMustExist: true })
   try {
     const rows = db
       .prepare(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import { listInstalledApps } from './apps/installed-apps'
 import { VendorCredentialsManager } from './settings/vendor-credentials-manager'
 import { TaskMiner } from './services/task-miner'
 import type { MiningStatus } from '../shared/types'
+import { scrubPII } from '../shared/sanitize'
 import { UserContextBuilder } from './services/user-context-builder'
 import { RawDatabaseExportSync } from './services/raw-database-export-sync'
 import { DatabaseUploadSync } from './services/database-upload-sync'
@@ -545,6 +546,8 @@ app.on('ready', async () => {
     evalRecorder: runtime.evalRecorder,
     evalFixtureStore: runtime.evalFixtureStore,
     taskFixtureStore: runtime.taskFixtureStore,
+    scrubTexts: (texts, allow) =>
+      runtime?.mlWorker.scrubBatch(texts, allow) ?? Promise.resolve(texts.map(scrubPII)),
   })
 
   runtime.accessProvider.startPeriodicRefresh()

--- a/src/main/processor/embedding-bundle.test.ts
+++ b/src/main/processor/embedding-bundle.test.ts
@@ -4,10 +4,18 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { pipeline, env } from '@huggingface/transformers'
 
 const MODEL_ID = 'Xenova/all-MiniLM-L6-v2'
+const NER_MODEL_ID = 'nationaldesignstudio/rampart'
 const BUNDLE_DIR = path.resolve(__dirname, '..', '..', '..', 'build', 'models')
 const MODEL_DIR = path.join(BUNDLE_DIR, MODEL_ID)
+const NER_MODEL_DIR = path.join(BUNDLE_DIR, NER_MODEL_ID)
 
 const REQUIRED_FILES = ['config.json', 'tokenizer.json', 'tokenizer_config.json', 'onnx/model.onnx']
+const NER_REQUIRED_FILES = [
+  'config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  'onnx/model_q4.onnx',
+]
 
 describe('bundled embedding model', () => {
   it('download script produced all required files', () => {
@@ -39,5 +47,34 @@ describe('bundled embedding model', () => {
     expect(vector.length).toBe(384)
     expect(typeof vector[0]).toBe('number')
     expect(isNaN(vector[0])).toBe(false)
+  })
+})
+
+describe('bundled pii ner model', () => {
+  it('download script produced all required files', () => {
+    for (const file of NER_REQUIRED_FILES) {
+      const filePath = path.join(NER_MODEL_DIR, file)
+      expect(fs.existsSync(filePath), `missing: ${file}`).toBe(true)
+      const stat = fs.statSync(filePath)
+      expect(stat.size, `${file} is empty`).toBeGreaterThan(0)
+    }
+  })
+
+  it('model loads fully offline from bundled path', { timeout: 30000 }, async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (() => {
+      throw new Error('Network call detected — bundled model should load without fetch')
+    }) as typeof fetch
+    afterEach(() => {
+      globalThis.fetch = originalFetch
+    })
+
+    env.localModelPath = BUNDLE_DIR
+    env.allowRemoteModels = false
+
+    const pipe = await pipeline('token-classification', NER_MODEL_ID, { dtype: 'q4' })
+    const result = (await pipe('Reviewed the invoice with Sarah Johnson yesterday.')) as unknown[]
+
+    expect(Array.isArray(result)).toBe(true)
   })
 })

--- a/src/main/processor/pii-scrub.test.ts
+++ b/src/main/processor/pii-scrub.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { PiiScrubber, type NerToken } from './pii-scrub'
+
+const tok = (entity: string, index: number, word: string, score = 0.9): NerToken => ({
+  entity,
+  score,
+  index,
+  word,
+  start: null,
+  end: null,
+})
+
+const fakePipe =
+  (tokensBySlice: (slice: string) => NerToken[]) =>
+  async (slice: string): Promise<NerToken[]> =>
+    tokensBySlice(slice)
+
+describe('PiiScrubber', () => {
+  it('reconstructs spans from null-offset tokens and replaces them', async () => {
+    const scrubber = new PiiScrubber(
+      fakePipe(() => [
+        tok('B-GIVENNAME', 1, 'pav'),
+        tok('I-GIVENNAME', 2, '##lina'),
+        tok('B-SURNAME', 3, 'koutecka'),
+      ]),
+    )
+    const [out] = await scrubber.scrubBatch(['Reviewed chat with Pavlina Koutecka today'])
+    expect(out).toBe('Reviewed chat with [redacted name] [redacted name] today')
+  })
+
+  it('shifts spans found in later windows back to global offsets', async () => {
+    const filler = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod. '
+    const text = filler.repeat(30) + 'Contact Jonathan for access.'
+    const scrubber = new PiiScrubber(
+      fakePipe((slice) => (slice.includes('Jonathan') ? [tok('B-GIVENNAME', 1, 'jonathan')] : [])),
+    )
+    const [out] = await scrubber.scrubBatch([text])
+    expect(out).toBe(filler.repeat(30) + 'Contact [redacted name] for access.')
+  })
+
+  it('merges overlapping spans into one placeholder', async () => {
+    const scrubber = new PiiScrubber(
+      fakePipe(() => [
+        { ...tok('B-NAME', 1, 'anna'), start: 5, end: 9 },
+        { ...tok('B-USERNAME', 5, 'anna-marie', 0.95), start: 5, end: 15 },
+      ]),
+    )
+    const [out] = await scrubber.scrubBatch(['ping anna-marie now'])
+    expect(out).toBe('ping [redacted username] now')
+  })
+
+  it('drops skip-listed entity types', async () => {
+    const scrubber = new PiiScrubber(fakePipe(() => [tok('B-URL', 1, 'example.com')]))
+    const [out] = await scrubber.scrubBatch(['visit example.com today'])
+    expect(out).toBe('visit example.com today')
+  })
+
+  it('skips spans matching the allowlist', async () => {
+    const scrubber = new PiiScrubber(fakePipe(() => [tok('B-NAME', 1, 'claude')]))
+    const [out] = await scrubber.scrubBatch(['opened Claude to review'], ['Claude Code'])
+    expect(out).toBe('opened Claude to review')
+  })
+
+  it('ignores tokens below the score threshold', async () => {
+    const scrubber = new PiiScrubber(fakePipe(() => [tok('B-NAME', 1, 'claude', 0.2)]))
+    const [out] = await scrubber.scrubBatch(['opened Claude to review'])
+    expect(out).toBe('opened Claude to review')
+  })
+
+  it('maps labels to typed placeholders and falls back for unknown labels', async () => {
+    const scrubber = new PiiScrubber(
+      fakePipe((slice) =>
+        slice.includes('jane@')
+          ? [tok('B-EMAIL', 1, 'jane@acme.co')]
+          : [tok('B-MYSTERY', 1, 'blob')],
+      ),
+    )
+    const [email, unknown] = await scrubber.scrubBatch(['mail jane@acme.co', 'the blob thing'])
+    expect(email).toBe('mail [email address]')
+    expect(unknown).toBe('the [redacted] thing')
+  })
+
+  it('applies the regex backstop after NER', async () => {
+    const scrubber = new PiiScrubber(fakePipe(() => []))
+    const [out] = await scrubber.scrubBatch(['mail jane.doe@acme.co about order 100294'])
+    expect(out).toBe('mail [email address] about order [id number]')
+  })
+
+  it('passes through empty and blank texts without model calls', async () => {
+    let calls = 0
+    const scrubber = new PiiScrubber(async () => {
+      calls++
+      return []
+    })
+    const out = await scrubber.scrubBatch(['', '   '])
+    expect(out).toEqual(['', '   '])
+    expect(calls).toBe(0)
+  })
+})

--- a/src/main/processor/pii-scrub.ts
+++ b/src/main/processor/pii-scrub.ts
@@ -1,0 +1,239 @@
+import log from '@main/utils/logger'
+import { configureModelEnv } from '@main/processor/embedding'
+import { scrubPII } from '@/shared/sanitize'
+
+const MODEL_NAME = 'nationaldesignstudio/rampart'
+const MODEL_DTYPE = 'q4'
+const SCORE_THRESHOLD = 0.5
+const WINDOW_CHARS = 1800
+const WINDOW_OVERLAP = 200
+
+const LABEL_PLACEHOLDERS: Record<string, string> = {
+  GIVENNAME: '[redacted name]',
+  SURNAME: '[redacted name]',
+  MIDDLENAME: '[redacted name]',
+  FIRSTNAME: '[redacted name]',
+  LASTNAME: '[redacted name]',
+  NAME: '[redacted name]',
+  PER: '[redacted name]',
+  PERSON: '[redacted name]',
+  EMAIL: '[email address]',
+  TELEPHONENUM: '[phone number]',
+  PHONENUMBER: '[phone number]',
+  PHONE: '[phone number]',
+  STREET: '[redacted address]',
+  STREETNAME: '[redacted address]',
+  STREETADDRESS: '[redacted address]',
+  SECONDARYADDRESS: '[redacted address]',
+  BUILDINGNUM: '[redacted address]',
+  CITY: '[redacted address]',
+  STATE: '[redacted address]',
+  ZIPCODE: '[redacted address]',
+  POSTCODE: '[redacted address]',
+  SOCIALNUM: '[redacted personal id]',
+  SOCIALSECURITYNUMBER: '[redacted personal id]',
+  SSN: '[redacted personal id]',
+  IDCARDNUM: '[redacted personal id]',
+  DRIVERLICENSENUM: '[redacted personal id]',
+  DRIVERSLICENSE: '[redacted personal id]',
+  PASSPORT: '[redacted personal id]',
+  PASSPORTNUM: '[redacted personal id]',
+  PASSPORTNUMBER: '[redacted personal id]',
+  TAXNUM: '[redacted personal id]',
+  TAXID: '[redacted personal id]',
+  GOVERNMENTID: '[redacted personal id]',
+  NATIONALID: '[redacted personal id]',
+  CREDITCARDNUMBER: '[redacted payment card]',
+  CREDITCARD: '[redacted payment card]',
+  ACCOUNTNUM: '[redacted bank account]',
+  IBAN: '[redacted bank account]',
+  ROUTINGNUM: '[redacted bank account]',
+  ROUTINGNUMBER: '[redacted bank account]',
+  DATEOFBIRTH: '[redacted date of birth]',
+  DOB: '[redacted date of birth]',
+  USERNAME: '[redacted username]',
+  PASSWORD: '[redacted password]',
+  SECRET: '[redacted secret]',
+  APIKEY: '[redacted secret]',
+  TOKEN: '[redacted secret]',
+}
+
+const SKIP_TYPES = new Set(['URL', 'BUILDINGNUMBER'])
+
+export interface NerToken {
+  entity: string
+  score: number
+  index: number
+  word: string
+  start: number | null
+  end: number | null
+}
+
+export type NerPipeline = (text: string) => Promise<NerToken[]>
+
+interface Span {
+  start: number
+  end: number
+  type: string
+  score: number
+}
+
+function normalizeLabel(type: string): string {
+  return type.toUpperCase().replace(/[^A-Z]/g, '')
+}
+
+function locateToken(
+  lowerText: string,
+  cursor: number,
+  word: string,
+): { start: number; end: number } | null {
+  const piece = word.replace(/^##/, '').replace(/▁/g, ' ').trim().toLowerCase()
+  if (!piece) return null
+  const at = lowerText.indexOf(piece, cursor)
+  if (at === -1) return null
+  return { start: at, end: at + piece.length }
+}
+
+function* windows(text: string): Generator<{ offset: number; slice: string }> {
+  if (text.length <= WINDOW_CHARS) {
+    yield { offset: 0, slice: text }
+    return
+  }
+  let offset = 0
+  while (offset < text.length) {
+    yield { offset, slice: text.slice(offset, offset + WINDOW_CHARS) }
+    if (offset + WINDOW_CHARS >= text.length) break
+    offset += WINDOW_CHARS - WINDOW_OVERLAP
+  }
+}
+
+function buildSpans(text: string, toks: NerToken[], threshold: number): Span[] {
+  const lower = text.toLowerCase()
+  const spans: Span[] = []
+  let cur: (Span & { lastIndex: number }) | null = null
+  let cursor = 0
+
+  for (const tok of toks) {
+    if (tok.score < threshold) continue
+    const type = tok.entity.replace(/^[BI]-/, '')
+    let start = typeof tok.start === 'number' ? tok.start : null
+    let end = typeof tok.end === 'number' ? tok.end : null
+    if (start === null || end === null) {
+      const located = locateToken(lower, cursor, tok.word)
+      if (!located) continue
+      start = located.start
+      end = located.end
+    }
+    cursor = Math.max(cursor, end)
+
+    if (cur && cur.type === type && tok.index === cur.lastIndex + 1) {
+      cur.end = Math.max(cur.end, end)
+      cur.score = Math.max(cur.score, tok.score)
+      cur.lastIndex = tok.index
+    } else {
+      if (cur) spans.push({ start: cur.start, end: cur.end, type: cur.type, score: cur.score })
+      cur = { start, end, type, score: tok.score, lastIndex: tok.index }
+    }
+  }
+  if (cur) spans.push({ start: cur.start, end: cur.end, type: cur.type, score: cur.score })
+  return spans
+}
+
+function mergeSpans(spans: Span[]): Span[] {
+  const sorted = [...spans].sort((a, b) => a.start - b.start || b.end - a.end)
+  const merged: Span[] = []
+  for (const span of sorted) {
+    const last = merged[merged.length - 1]
+    if (last && span.start < last.end) {
+      last.end = Math.max(last.end, span.end)
+      if (span.score > last.score) last.type = span.type
+    } else {
+      merged.push({ ...span })
+    }
+  }
+  return merged
+}
+
+function replaceSpans(text: string, spans: (Span & { placeholder: string })[]): string {
+  let out = text
+  for (const span of [...spans].sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, span.start) + span.placeholder + out.slice(span.end)
+  }
+  return out
+}
+
+function isAllowed(spanText: string, allow: string[]): boolean {
+  const norm = spanText.trim().toLowerCase()
+  if (!norm) return false
+  return allow.some((entry) => {
+    const e = entry.trim().toLowerCase()
+    return e === norm || e.split(/\s+/).includes(norm)
+  })
+}
+
+export class PiiScrubber {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private pipe: any = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private loading: Promise<any> | null = null
+
+  constructor(pipe?: NerPipeline) {
+    this.pipe = pipe ?? null
+  }
+
+  private async ensurePipe(): Promise<NerPipeline> {
+    if (this.pipe) return this.pipe
+    if (!this.loading) {
+      this.loading = (async () => {
+        configureModelEnv()
+        const t0 = Date.now()
+        const { pipeline } = await import('@huggingface/transformers')
+        const pipe = await pipeline('token-classification', MODEL_NAME, { dtype: MODEL_DTYPE })
+        log.debug(`[PiiScrubber] loaded ${MODEL_NAME} in ${Date.now() - t0}ms`)
+        return pipe
+      })()
+      this.loading.catch(() => {
+        this.loading = null
+      })
+    }
+    this.pipe = await this.loading
+    return this.pipe
+  }
+
+  async scrubBatch(texts: string[], allow: string[] = []): Promise<string[]> {
+    if (texts.length === 0) return []
+    const pipe = await this.ensurePipe()
+    const t0 = Date.now()
+    let spanCount = 0
+    let charCount = 0
+    const out: string[] = []
+    for (const text of texts) {
+      charCount += text.length
+      if (!text.trim()) {
+        out.push(text)
+        continue
+      }
+      const spans: Span[] = []
+      for (const { offset, slice } of windows(text)) {
+        const raw = await pipe(slice)
+        for (const span of buildSpans(slice, raw, SCORE_THRESHOLD)) {
+          spans.push({ ...span, start: span.start + offset, end: span.end + offset })
+        }
+      }
+      const kept = spans.filter(
+        (s) =>
+          !SKIP_TYPES.has(normalizeLabel(s.type)) && !isAllowed(text.slice(s.start, s.end), allow),
+      )
+      spanCount += kept.length
+      const resolved = mergeSpans(kept).map((s) => ({
+        ...s,
+        placeholder: LABEL_PLACEHOLDERS[normalizeLabel(s.type)] ?? '[redacted]',
+      }))
+      out.push(scrubPII(replaceSpans(text, resolved)))
+    }
+    log.debug(
+      `[PiiScrubber] scrubBatch n=${texts.length} chars=${charCount} spans=${spanCount} ms=${Date.now() - t0}`,
+    )
+    return out
+  }
+}

--- a/src/main/services/ml-worker-client.ts
+++ b/src/main/services/ml-worker-client.ts
@@ -3,6 +3,7 @@ import type { UtilityProcess } from 'electron'
 import * as os from 'os'
 import * as path from 'path'
 import log from '@main/utils/logger'
+import { scrubPII } from '@/shared/sanitize'
 import { getBundledModelPath, getModelCacheDir } from '@main/utils/paths'
 import { isWorkerLogEvent, logWorkerEvent, type WorkerLogEvent } from '@main/utils/worker-log'
 import type { ActivityEmbeddingService } from '@main/activity/activity-transformer-types'
@@ -26,6 +27,9 @@ function workerScriptPath(): string {
 const INIT_TIMEOUT_MS = 15 * 60 * 1000
 const EMBED_TIMEOUT_MS = 60 * 1000
 const CLUSTER_TIMEOUT_MS = 2 * 60 * 1000
+// First scrub may download the NER model in dev, and a timeout kills the
+// shared worker that also serves embeddings — err far on the generous side.
+const SCRUB_TIMEOUT_MS = 5 * 60 * 1000
 const RESPAWN_WINDOW_MS = 60 * 1000
 const MAX_SPAWNS_PER_WINDOW = 3
 
@@ -84,6 +88,22 @@ export class MlWorkerClient implements ActivityEmbeddingService {
     )
     if (result.type !== 'groups') throw new Error(`ml-worker: unexpected ${result.type} response`)
     return result.groups
+  }
+
+  /** NER + regex PII scrub in the worker; falls back to the local regex scrub
+   * on any worker error so egress is never left unscrubbed. */
+  async scrubBatch(texts: string[], allow?: string[]): Promise<string[]> {
+    if (texts.length === 0) return []
+    try {
+      await this.ensureReady()
+      const result = await this.request({ type: 'scrubBatch', texts, allow }, SCRUB_TIMEOUT_MS)
+      if (result.type !== 'scrubbed')
+        throw new Error(`ml-worker: unexpected ${result.type} response`)
+      return result.texts
+    } catch (error) {
+      log.warn('[MlWorker] scrubBatch failed; falling back to regex scrub', error)
+      return texts.map(scrubPII)
+    }
   }
 
   dispose(): void {

--- a/src/main/services/ml-worker-protocol.ts
+++ b/src/main/services/ml-worker-protocol.ts
@@ -8,6 +8,7 @@ export type MlWorkerRequestBody =
   | { type: 'init'; bundledModelPath: string | null; cacheDir: string; maxThreads: number | null }
   | { type: 'embedBatch'; texts: string[] }
   | { type: 'clusterVectors'; vectors: ArrayBuffer; dims: number; threshold: number }
+  | { type: 'scrubBatch'; texts: string[]; allow?: string[] }
 
 export type MlWorkerRequest = MlWorkerRequestBody & { id: number }
 
@@ -15,6 +16,7 @@ export type MlWorkerResult =
   | { type: 'ready' }
   | { type: 'vectors'; vectors: ArrayBuffer; dims: number }
   | { type: 'groups'; groups: number[][] }
+  | { type: 'scrubbed'; texts: string[] }
 
 export type MlWorkerResponse =
   | { id: number; ok: true; result: MlWorkerResult }

--- a/src/main/services/ml-worker.test.ts
+++ b/src/main/services/ml-worker.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { handleMlWorkerRequest } from './ml-worker'
 import { packVectors, unpackVectors } from './ml-worker-protocol'
+import { PiiScrubber } from '@main/processor/pii-scrub'
 import type { EmbeddingService } from '@main/processor/embedding'
 
 const fakeService = {
@@ -51,6 +52,20 @@ describe('handleMlWorkerRequest', () => {
     expect(response.ok).toBe(true)
     if (!response.ok || response.result.type !== 'groups') throw new Error('wrong response')
     expect(response.result.groups).toEqual([[0, 1], [2]])
+  })
+
+  it('scrubBatch returns scrubbed texts', async () => {
+    const scrubber = new PiiScrubber(async () => [
+      { entity: 'B-GIVENNAME', score: 0.9, index: 1, word: 'jane', start: null, end: null },
+    ])
+    const response = await handleMlWorkerRequest(
+      { id: 4, type: 'scrubBatch', texts: ['ping Jane about it'] },
+      fakeService,
+      scrubber,
+    )
+    expect(response.ok).toBe(true)
+    if (!response.ok || response.result.type !== 'scrubbed') throw new Error('wrong response')
+    expect(response.result.texts).toEqual(['ping [redacted name] about it'])
   })
 
   it('maps a thrown error to ok:false', async () => {

--- a/src/main/services/ml-worker.ts
+++ b/src/main/services/ml-worker.ts
@@ -1,4 +1,5 @@
 import { EmbeddingService, configureModelEnv } from '@main/processor/embedding'
+import { PiiScrubber } from '@main/processor/pii-scrub'
 import { averageLinkageGroupIndices } from '@main/services/task-miner/clustering/attach'
 import { forwardLogsToParent, type WorkerLogEvent } from '@main/utils/worker-log'
 import {
@@ -15,11 +16,13 @@ import {
  */
 
 const embedder = new EmbeddingService()
+const piiScrubber = new PiiScrubber()
 
 /** Exported for unit tests; the parentPort wiring below is the runtime path. */
 export async function handleMlWorkerRequest(
   request: MlWorkerRequest,
   service: EmbeddingService = embedder,
+  scrubber: PiiScrubber = piiScrubber,
 ): Promise<MlWorkerResponse> {
   try {
     switch (request.type) {
@@ -40,6 +43,10 @@ export async function handleMlWorkerRequest(
         const vectors = unpackVectors(request.vectors, request.dims)
         const groups = averageLinkageGroupIndices(vectors, request.threshold)
         return { id: request.id, ok: true, result: { type: 'groups', groups } }
+      }
+      case 'scrubBatch': {
+        const texts = await scrubber.scrubBatch(request.texts, request.allow ?? [])
+        return { id: request.id, ok: true, result: { type: 'scrubbed', texts } }
       }
     }
   } catch (error) {

--- a/src/main/services/task-miner/clustering/index.ts
+++ b/src/main/services/task-miner/clustering/index.ts
@@ -53,6 +53,8 @@ export interface ClusteringDeps {
   ) => Promise<number[][]>
   /** Absent → deterministic steps only (offline / tests). */
   provider?: InferenceProvider
+  /** NER egress scrub for model-written review output; absent → regex-only downstream. */
+  scrub?: (texts: string[], allow?: string[]) => Promise<string[]>
   model: string
   now?: number
   onProgress?: ProgressCallback
@@ -171,7 +173,7 @@ export async function runClustering(deps: ClusteringDeps): Promise<ClusteringRun
     try {
       const review = deps.structureReview
         ? await deps.structureReview(input)
-        : await runStructureReview(provider, model, input, progress)
+        : await runStructureReview(provider, model, input, progress, deps.scrub)
       summary.tokenUsage.input += review.tokenUsage.input
       summary.tokenUsage.output += review.tokenUsage.output
       if (!review.output) {
@@ -246,7 +248,7 @@ async function contentRound(
     try {
       const round = deps.contentReview
         ? await deps.contentReview(input)
-        : await runContentReview(provider, model, input, progress)
+        : await runContentReview(provider, model, input, progress, deps.scrub)
       summary.tokenUsage.input += round.tokenUsage.input
       summary.tokenUsage.output += round.tokenUsage.output
       if (!round.output) {

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -110,4 +110,48 @@ describe('PII scrubbing', () => {
     expect(call.prompt).toContain('[redacted password]')
     expect(call.prompt).toContain('jane.doe@acme.co')
   })
+
+  it('scrubs model-written output through the injected scrubber before returning', async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: JSON.stringify({
+        clusters: [
+          {
+            id: 'c1',
+            label: 'Email Jane Novak the report',
+            description: 'Weekly report emailing',
+            steps: ['mail.google.com: mail Jane Novak'],
+            variables: ['recipient'],
+          },
+        ],
+      }),
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never)
+    const scrub = vi.fn(async (texts: string[]) =>
+      texts.map((t) => t.replace(/Jane Novak/g, '[redacted name]')),
+    )
+
+    const result = await runContentReview(provider, 'model', memberInput, undefined, scrub)
+
+    expect(scrub).toHaveBeenCalledWith(expect.arrayContaining(['Email Jane Novak the report']), [
+      'mail.google.com',
+    ])
+    expect(result.output?.clusters?.[0]).toEqual({
+      id: 'c1',
+      label: 'Email [redacted name] the report',
+      description: 'Weekly report emailing',
+      steps: ['mail.google.com: mail [redacted name]'],
+      variables: ['recipient'],
+    })
+  })
+
+  it('returns output untouched when no scrubber is provided', async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: '{"clusters":[{"id":"c1","label":"Email Jane Novak"}]}',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never)
+
+    const result = await runContentReview(provider, 'model', memberInput)
+
+    expect(result.output?.clusters?.[0].label).toBe('Email Jane Novak')
+  })
 })

--- a/src/main/services/task-miner/clustering/llm-review.ts
+++ b/src/main/services/task-miner/clustering/llm-review.ts
@@ -17,6 +17,8 @@ export interface ReviewCallResult {
   tokenUsage: { input: number; output: number }
 }
 
+export type ReviewScrubber = (texts: string[], allow?: string[]) => Promise<string[]>
+
 function scrubReviewInputForPrompt(input: ReviewInput): ReviewInput {
   return {
     mergeCandidates: input.mergeCandidates,
@@ -34,6 +36,51 @@ function scrubReviewInputForPrompt(input: ReviewInput): ReviewInput {
   }
 }
 
+/** Runs here because applyStructure/applyContent transactions cannot await;
+ * fields are unvalidated model output, so only strings are touched. */
+async function scrubReviewOutput(
+  output: ReviewOutput,
+  input: ReviewInput,
+  scrub: ReviewScrubber,
+): Promise<ReviewOutput> {
+  if (!Array.isArray(output.clusters)) return output
+  const texts: string[] = []
+  const collect = (value: unknown): number => {
+    if (typeof value !== 'string' || value === '') return -1
+    texts.push(value)
+    return texts.length - 1
+  }
+  const slots = output.clusters.map((verdict) => ({
+    label: collect(verdict.label),
+    description: collect(verdict.description),
+    mechanism: collect(verdict.mechanism),
+    steps: Array.isArray(verdict.steps) ? verdict.steps.map(collect) : [],
+    variables: Array.isArray(verdict.variables) ? verdict.variables.map(collect) : [],
+  }))
+  if (texts.length === 0) return output
+
+  const allow = [...new Set(input.clusters.flatMap((c) => c.members.flatMap((m) => m.apps)))]
+  const scrubbed = await scrub(texts, allow)
+  const pick = <T>(index: number, original: T): T | string =>
+    index >= 0 ? scrubbed[index] : original
+
+  return {
+    ...output,
+    clusters: output.clusters.map((verdict, i) => ({
+      ...verdict,
+      ...(slots[i].label >= 0 && { label: scrubbed[slots[i].label] }),
+      ...(slots[i].description >= 0 && { description: scrubbed[slots[i].description] }),
+      ...(slots[i].mechanism >= 0 && { mechanism: scrubbed[slots[i].mechanism] }),
+      ...(Array.isArray(verdict.steps) && {
+        steps: verdict.steps.map((step, j) => pick(slots[i].steps[j], step)),
+      }),
+      ...(Array.isArray(verdict.variables) && {
+        variables: verdict.variables.map((v, j) => pick(slots[i].variables[j], v)),
+      }),
+    })),
+  }
+}
+
 /**
  * Attempts cover thrown errors too — a transient timeout on a long call must
  * not forfeit the whole pass. The last attempt rethrows so the caller's error
@@ -46,6 +93,7 @@ async function callReview(
   input: ReviewInput,
   describe: (attempt: number) => string,
   progress?: ProgressCallback,
+  scrub?: ReviewScrubber,
 ): Promise<ReviewCallResult> {
   const prompt = serializeReviewInput(scrubReviewInputForPrompt(input))
   const tokenUsage = { input: 0, output: 0 }
@@ -63,7 +111,10 @@ async function callReview(
       tokenUsage.output += result.usage.outputTokens ?? 0
 
       const parsed = extractJsonObject<ReviewOutput>(result.text)
-      if (parsed) return { output: parsed, tokenUsage }
+      if (parsed) {
+        const output = scrub ? await scrubReviewOutput(parsed, input, scrub) : parsed
+        return { output, tokenUsage }
+      }
       progress?.(
         `[Clustering] Could not parse review response` +
           (attempt < CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS ? ' — retrying' : ''),
@@ -83,6 +134,7 @@ export async function runStructureReview(
   model: string,
   input: ReviewInput,
   progress?: ProgressCallback,
+  scrub?: ReviewScrubber,
 ): Promise<ReviewCallResult> {
   return callReview(
     provider,
@@ -94,6 +146,7 @@ export async function runStructureReview(
       `${input.mergeCandidates.length} merge candidates with ${model}` +
       (attempt > 1 ? ` (attempt ${attempt}/${CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS})` : ''),
     progress,
+    scrub,
   )
 }
 
@@ -103,6 +156,7 @@ export async function runContentReview(
   model: string,
   input: ReviewInput,
   progress?: ProgressCallback,
+  scrub?: ReviewScrubber,
 ): Promise<ReviewCallResult> {
   return callReview(
     provider,
@@ -113,5 +167,6 @@ export async function runContentReview(
       `[Clustering] Content review: ${input.clusters.length} clusters with ${model}` +
       (attempt > 1 ? ` (attempt ${attempt}/${CLUSTERING_CONFIG.LLM_MAX_ATTEMPTS})` : ''),
     progress,
+    scrub,
   )
 }

--- a/src/main/services/task-miner/index.ts
+++ b/src/main/services/task-miner/index.ts
@@ -430,6 +430,7 @@ export class TaskMiner {
         storage: this.storage,
         embedder: this.embedder,
         clusterVectors: this.embedder.clusterVectors?.bind(this.embedder),
+        scrub: this.embedder.scrubBatch?.bind(this.embedder),
         provider:
           this.enabled && model && this.provider?.isConfigured() ? this.provider : undefined,
         model,
@@ -588,6 +589,7 @@ export class TaskMiner {
         storage: this.storage,
         embedder: this.embedder,
         clusterVectors: this.embedder.clusterVectors?.bind(this.embedder),
+        scrub: this.embedder.scrubBatch?.bind(this.embedder),
         provider,
         model: this.clusterModel ?? cfg.model,
         onProgress,

--- a/src/main/services/task-miner/types.ts
+++ b/src/main/services/task-miner/types.ts
@@ -53,6 +53,7 @@ export interface MinerEmbedder {
   embed(text: string): Promise<number[]>
   embedBatch(texts: string[]): Promise<number[][]>
   clusterVectors?(vectors: readonly (readonly number[])[], threshold: number): Promise<number[][]>
+  scrubBatch?(texts: string[], allow?: string[]): Promise<string[]>
 }
 
 /** A discrete task instance proposed by the broad scan. */

--- a/src/main/ui/main-window.ts
+++ b/src/main/ui/main-window.ts
@@ -148,6 +148,7 @@ interface MainWindowDependencies {
   evalRecorder: EvalRecorder
   evalFixtureStore: EvalFixtureStore
   taskFixtureStore: TaskFixtureStore
+  scrubTexts: (texts: string[], allow?: string[]) => Promise<string[]>
 }
 
 let mainWindow: BrowserWindow | null = null
@@ -700,6 +701,11 @@ export function initMainWindowIPC(dependencies: MainWindowDependencies): void {
   handle('main-window:getSubscriptionStatus', () => {
     if (!deps) return 'idle'
     return deps.accessProvider.getAccessState().customerSubscriptionStatus ?? 'idle'
+  })
+
+  handle('main-window:scrubTexts', (_event, texts: string[], allow?: string[]) => {
+    if (!deps) return texts
+    return deps.scrubTexts(texts, allow)
   })
 
   // Patterns (task clusters)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -70,6 +70,8 @@ contextBridge.exposeInMainWorld('mainWindowAPI', {
   resetCaptureSettings: () => ipcRenderer.invoke('main-window:resetCaptureSettings'),
   // Patterns (task clusters) — new TaskMiner view
   getClusters: () => ipcRenderer.invoke('main-window:getClusters'),
+  scrubTexts: (texts: string[], allow?: string[]) =>
+    ipcRenderer.invoke('main-window:scrubTexts', texts, allow),
   getClusterDetail: (id: string) => ipcRenderer.invoke('main-window:getClusterDetail', id),
   // Task-mining progress (ledger sweep)
   getMiningStatus: () => ipcRenderer.invoke('main-window:getMiningStatus'),

--- a/src/renderer/pages/main-window/components/ClusterDetailPane.tsx
+++ b/src/renderer/pages/main-window/components/ClusterDetailPane.tsx
@@ -7,7 +7,11 @@ import type { ClusterDetailInfo, ClusterInfo, MainWindowAPI } from '@types'
 import { formatMinutes, formatMonthlyHours, formatSightingTime } from './activities/format'
 import { WeeklyTrend } from './WeeklyTrend'
 import { ClaudeWordmark } from './ClaudeWordmark'
-import { buildClusterAgentPrompt, buildClusterAnalyzePrompt } from './claude-prompts'
+import {
+  buildClusterAgentPrompt,
+  buildClusterAnalyzePrompt,
+  scrubClusterForShare,
+} from './claude-prompts'
 
 interface ClusterDetailPaneProps {
   api: MainWindowAPI
@@ -75,21 +79,23 @@ export function ClusterDetailPane({ api, cluster }: ClusterDetailPaneProps): Rea
   const trendTimestamps = useMemo(() => (detail?.sightings ?? []).map((s) => s.startedAt), [detail])
 
   const handleCopyPrompt = (): void => {
-    navigator.clipboard
-      .writeText(buildClusterAnalyzePrompt(cluster, sightings))
+    scrubClusterForShare(cluster, sightings, api.scrubTexts)
+      .then((clean) =>
+        navigator.clipboard.writeText(buildClusterAnalyzePrompt(clean.cluster, clean.sightings)),
+      )
       .then(() => toast.success('Copied! Paste it into Claude Cowork'))
       .catch((err) => {
-        console.warn('[clusters] clipboard.writeText failed', err)
+        console.warn('[clusters] copy prompt failed', err)
         toast.error('Could not copy prompt to clipboard')
       })
   }
 
   const handleCopyAgentPrompt = (): void => {
-    navigator.clipboard
-      .writeText(buildClusterAgentPrompt(cluster))
+    scrubClusterForShare(cluster, [], api.scrubTexts)
+      .then((clean) => navigator.clipboard.writeText(buildClusterAgentPrompt(clean.cluster)))
       .then(() => toast.success('Agent prompt copied to clipboard'))
       .catch((err) => {
-        console.warn('[clusters] clipboard.writeText failed', err)
+        console.warn('[clusters] copy prompt failed', err)
         toast.error('Could not copy prompt to clipboard')
       })
   }

--- a/src/renderer/pages/main-window/components/claude-prompts.test.ts
+++ b/src/renderer/pages/main-window/components/claude-prompts.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ClusterInfo, ClusterSightingInfo } from '@types'
+import {
+  buildClusterAgentPrompt,
+  buildClusterAnalyzePrompt,
+  scrubClusterForShare,
+} from './claude-prompts'
+
+const cluster: ClusterInfo = {
+  id: 'c1',
+  title: 'Email Jane Novak the report',
+  description: 'Weekly report for jane.doe@acme.co',
+  apps: ['mail.google.com'],
+  timesSeen: 3,
+  timesPerWeek: 1.5,
+  observedDays: 14,
+  avgActiveMin: 12,
+  mechanism: '',
+  steps: ['mail.google.com: mail Jane Novak'],
+  variables: ['recipient'],
+  lastSeenAt: 0,
+  recurrence: [],
+}
+
+const sightings: ClusterSightingInfo[] = [
+  {
+    id: 's1',
+    title: 'Email Jane Novak the report',
+    subject: 'Q3 report',
+    apps: ['mail.google.com'],
+    startedAt: 1753600000000,
+    activeMin: 10,
+    activityIds: ['550e8400-e29b-41d4-a716-446655440000', '3f2a9c81-77de-4b02-9e41-c05a12ef88a3'],
+  },
+]
+
+const fakeScrub = vi.fn(async (texts: string[]) =>
+  texts.map((t) => t.replace(/Jane Novak/g, '[redacted name]')),
+)
+
+describe('scrubClusterForShare', () => {
+  it('routes every interpolated field through the scrubber with the app allowlist', async () => {
+    const clean = await scrubClusterForShare(cluster, sightings, fakeScrub)
+
+    expect(fakeScrub).toHaveBeenCalledWith(expect.arrayContaining([cluster.title]), [
+      'mail.google.com',
+    ])
+    expect(clean.cluster.title).toBe('Email [redacted name] the report')
+    expect(clean.cluster.steps).toEqual(['mail.google.com: mail [redacted name]'])
+    expect(clean.sightings[0].title).toBe('Email [redacted name] the report')
+    expect(clean.sightings[0].subject).toBe('Q3 report')
+    expect(clean.sightings[0].activityIds).toEqual(sightings[0].activityIds)
+  })
+})
+
+describe('buildClusterAnalyzePrompt', () => {
+  it('keeps activity-id UUIDs intact in the assembled prompt', async () => {
+    const clean = await scrubClusterForShare(cluster, sightings, fakeScrub)
+    const prompt = buildClusterAnalyzePrompt(clean.cluster, clean.sightings)
+
+    expect(prompt).toContain('550e8400-e29b-41d4-a716-446655440000')
+    expect(prompt).toContain('3f2a9c81-77de-4b02-9e41-c05a12ef88a3')
+    expect(prompt).not.toContain('Jane Novak')
+  })
+})
+
+describe('buildClusterAgentPrompt', () => {
+  it('keeps the regex backstop over the final string', () => {
+    const prompt = buildClusterAgentPrompt(cluster)
+    expect(prompt).not.toContain('jane.doe@acme.co')
+    expect(prompt).toContain('[email address]')
+  })
+})

--- a/src/renderer/pages/main-window/components/claude-prompts.ts
+++ b/src/renderer/pages/main-window/components/claude-prompts.ts
@@ -3,9 +3,36 @@ import { scrubPII } from '@/shared/sanitize'
 import { formatFrequency, formatSightingTime } from './activities/format'
 
 /** Clipboard prompts for the "Analyze with Claude" / "Build AI agent" buttons.
- * The analyze prompt is NOT scrubbed: activity ids are UUIDs, and
- * scrubPII's id/phone patterns would corrupt all-digit segments (DEU-207
- * tracks the egress-scrub redesign). */
+ * Callers pre-scrub the interpolated fields via scrubClusterForShare (NER in
+ * the main process); the assembled strings are never scrubbed whole, so
+ * activity-id UUIDs survive intact. */
+
+export async function scrubClusterForShare(
+  cluster: ClusterInfo,
+  sightings: ClusterSightingInfo[],
+  scrubTexts: (texts: string[], allow?: string[]) => Promise<string[]>,
+): Promise<{ cluster: ClusterInfo; sightings: ClusterSightingInfo[] }> {
+  const texts = [
+    cluster.title,
+    cluster.description,
+    ...cluster.steps,
+    ...cluster.variables,
+    ...sightings.flatMap((s) => [s.title, s.subject]),
+  ]
+  const scrubbed = await scrubTexts(texts, cluster.apps)
+  let i = 0
+  const next = (): string => scrubbed[i++]
+  return {
+    cluster: {
+      ...cluster,
+      title: next(),
+      description: next(),
+      steps: cluster.steps.map(() => next()),
+      variables: cluster.variables.map(() => next()),
+    },
+    sightings: sightings.map((s) => ({ ...s, title: next(), subject: next() })),
+  }
+}
 
 export function buildClusterAnalyzePrompt(
   cluster: ClusterInfo,
@@ -89,9 +116,8 @@ export function buildClusterAnalyzePrompt(
   return lines.filter((l) => l !== null).join('\n')
 }
 
-/** Tool-agnostic prompt; scrubPII runs over the final string. For labeled
- * clusters that backstops the recipe's LLM de-identification; for fallback
- * member steps it is the only scrub, and it does not catch names. */
+/** Tool-agnostic prompt; the final-string scrubPII stays as the regex
+ * backstop behind the caller's scrubClusterForShare NER pass. */
 export function buildClusterAgentPrompt(cluster: ClusterInfo): string {
   const lines: string[] = [
     `Build an AI agent that automates this task.`,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -430,6 +430,8 @@ export interface MainWindowAPI {
   // Patterns (task clusters) — new TaskMiner view
   getClusters: () => Promise<ClustersView>
   getClusterDetail: (id: string) => Promise<ClusterDetailInfo | null>
+  /** NER + regex PII scrub in the main process, for share/copy surfaces. */
+  scrubTexts: (texts: string[], allow?: string[]) => Promise<string[]>
   // Task-mining progress (ledger sweep)
   getMiningStatus: () => Promise<MiningStatus>
   onMiningProgressChanged: (callback: (status: MiningStatus) => void) => () => void


### PR DESCRIPTION
Split from #270 (3/3), stacked on #272 (merge that first; GitHub retargets this to main automatically). Where text becomes a shareable artifact it gets Rampart NER (`nationaldesignstudio/rampart`, q4, 14 MB, ~3.5 ms/text) + full `scrubPII` (emails included):

- cluster review **output** (labels/descriptions/mechanisms/recipes), scrubbed pre-transaction — the stored copy is what every share surface reads; `sanitizeRecipe` stays as the in-transaction regex backstop
- the two renderer copy prompts, via a `main-window:scrubTexts` IPC to the ml-worker; fields are pre-scrubbed so activity-id UUIDs survive, the renderer fails closed (no copy), the main-process client fails open to regex

`PiiScrubber` rides the existing ml-worker as a fourth message (`scrubBatch`), lazy-loaded so startup cost is unchanged. `MinerEmbedder` gains optional `scrubBatch?` — CLI/enode mining degrades to regex-only. Rampart is bundled via `download-model.js` (+14 MB); offline load asserted in `embedding-bundle.test.ts`.

Eval (same harness as #259): shipped NER + regex = **98/99 @ 18 FP**, 3.5 ms/text (decision bar 84/99 @ 23 FP). The one leak is an unlabeled username mid-OCR (known NER gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)