### PR TITLE
Update Explorer plan pricing to $100/mo

### DIFF
--- a/src/renderer/pages/main-window/components/onboarding/CustomerActivationStep.tsx
+++ b/src/renderer/pages/main-window/components/onboarding/CustomerActivationStep.tsx
@@ -18,7 +18,7 @@ export const PLANS: PlanConfig[] = [
   {
     id: 'explorer',
     name: 'Explorer',
-    price: '$50/mo',
+    price: '$100/mo',
     highlighted: true,
     features: ['Automation recommendations', 'No API keys needed', 'Data stored on your device'],
   },


### PR DESCRIPTION
## Summary
- Updates the displayed Explorer plan price from $50/mo to $100/mo in the onboarding checkout UI
- Backend Stripe Price ID update is being handled separately

## Test plan
- [ ] Verify the onboarding plan selection screen shows $100/mo
- [ ] Verify checkout flow still works end-to-end with the new backend price

🤖 Generated with [Claude Code](https://claude.com/claude-code)