### PR TITLE
PII scrub for AU/NZ — prompt rule plus deterministic regex (DEU-205)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "backfill-golden-tld": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/backfill-golden-tld.ts",
     "mcpb:pack": "npx @anthropic-ai/mcpb pack mcpb/",
     "cli:build": "cd packages/cli && npm run build",
-    "cli:link": "cd packages/cli && npm link"
+    "cli:link": "cd packages/cli && npm link",
+    "scrub-review": "node ./scripts/enode.js ./node_modules/tsx/dist/cli.mjs scripts/scrub-review.ts"
   },
   "keywords": [],
   "author": {

--- a/scripts/eval-pii-scrub.ts
+++ b/scripts/eval-pii-scrub.ts
@@ -436,13 +436,21 @@ function leaked(output: string, pii: string): boolean {
 /**
  * Did the text around the planted value survive? A scrubber that deletes its
  * surroundings removes the PII too, so a leak-only metric scores destruction as
- * a pass. Checks a 20-char window either side of the plant.
+ * a pass. Checks the 20 chars adjacent to the plant on each side — the tail of
+ * what precedes it, the head of what follows — since that is what a mis-anchored
+ * span eats first.
  */
 function damaged(text: string, pii: string, output: string): boolean {
-  for (const segment of text.split(pii)) {
-    const trimmed = segment.trim()
+  const segments = text.split(pii)
+  for (let i = 0; i < segments.length; i++) {
+    const trimmed = segments[i].trim()
     if (trimmed.length < 4) continue
-    if (!output.includes(trimmed.slice(0, 20))) return true
+    const windows: string[] = []
+    if (i < segments.length - 1) windows.push(trimmed.slice(-20))
+    if (i > 0) windows.push(trimmed.slice(0, 20))
+    for (const w of windows) {
+      if (w.trim().length >= 4 && !output.includes(w)) return true
+    }
   }
   return false
 }

--- a/scripts/eval-pii-scrub.ts
+++ b/scripts/eval-pii-scrub.ts
@@ -22,6 +22,8 @@ import { getDefaultDbPath, getModelCacheDir } from '../src/main/utils/paths'
 import {
   PII_PLANTS,
   CLEAN_CONTROLS,
+  KEEP_CATEGORIES,
+  GAP_CATEGORIES,
   type PiiCategory,
   type PiiPlant,
 } from '../src/main/eval/pii-fixture'
@@ -39,6 +41,10 @@ const CATEGORIES: PiiCategory[] = [
   'username',
   'password',
   'secret',
+  'tfn',
+  'medicare',
+  'ird',
+  'nhi',
 ]
 
 const CATEGORY_LABELS: Record<PiiCategory, string> = {
@@ -54,6 +60,10 @@ const CATEGORY_LABELS: Record<PiiCategory, string> = {
   username: 'user',
   password: 'pass',
   secret: 'secret',
+  tfn: 'tfn',
+  medicare: 'mcare',
+  ird: 'ird',
+  nhi: 'nhi',
 }
 
 const NER_MODELS: Record<string, { id: string; dtype: string }> = {
@@ -423,6 +433,20 @@ function leaked(output: string, pii: string): boolean {
   return false
 }
 
+/**
+ * Did the text around the planted value survive? A scrubber that deletes its
+ * surroundings removes the PII too, so a leak-only metric scores destruction as
+ * a pass. Checks a 20-char window either side of the plant.
+ */
+function damaged(text: string, pii: string, output: string): boolean {
+  for (const segment of text.split(pii)) {
+    const trimmed = segment.trim()
+    if (trimmed.length < 4) continue
+    if (!output.includes(trimmed.slice(0, 20))) return true
+  }
+  return false
+}
+
 interface CategoryResult {
   caught: number
   total: number
@@ -435,6 +459,9 @@ interface FixtureResult {
   caughtTotal: number
   plantTotal: number
   falsePositives: { id: string; kind: string; before: string; after: string }[]
+  wronglyRemoved: PiiPlant[]
+  damagedPlants: PiiPlant[]
+  knownGaps: number
   msPerText: number
   loadMs: number
   footprint: string
@@ -445,12 +472,30 @@ async function runOnFixture(scrubber: Scrubber): Promise<FixtureResult> {
   const byCategory = {} as Record<PiiCategory, CategoryResult>
   for (const c of CATEGORIES) byCategory[c] = { caught: 0, total: 0, missed: [] }
 
+  const wronglyRemoved: PiiPlant[] = []
+  const damagedPlants: PiiPlant[] = []
+  let knownGaps = 0
+
   const t0 = performance.now()
   for (const p of PII_PLANTS) {
     const out = await scrubber.scrub(p.text)
+
+    if (KEEP_CATEGORIES.has(p.category)) {
+      byCategory[p.category].total++
+      if (leaked(out, p.pii)) byCategory[p.category].caught++
+      else wronglyRemoved.push(p)
+      continue
+    }
+
+    if (GAP_CATEGORIES.has(p.category)) {
+      knownGaps++
+      continue
+    }
+
     byCategory[p.category].total++
     if (leaked(out, p.pii)) byCategory[p.category].missed.push(p)
     else byCategory[p.category].caught++
+    if (damaged(p.text, p.pii, out)) damagedPlants.push(p)
   }
 
   const falsePositives: FixtureResult['falsePositives'] = []
@@ -465,8 +510,11 @@ async function runOnFixture(scrubber: Scrubber): Promise<FixtureResult> {
     name: scrubber.name,
     byCategory,
     caughtTotal,
-    plantTotal: PII_PLANTS.length,
+    plantTotal: CATEGORIES.reduce((a, c) => a + byCategory[c].total, 0),
     falsePositives,
+    wronglyRemoved,
+    damagedPlants,
+    knownGaps,
     msPerText: elapsed / (PII_PLANTS.length + CLEAN_CONTROLS.length),
     loadMs: scrubber.loadMs,
     footprint: scrubber.footprint(),
@@ -621,6 +669,38 @@ function renderReport(results: FixtureResult[], dbResults: DbResult[], args: Cli
     )
   }
   lines.push('')
+
+  lines.push('## Preservation')
+  lines.push('')
+  lines.push(
+    'A leak count alone scores deletion as success. `damaged` counts plants where text around the ' +
+      'planted value did not survive; `wrongly removed` counts names and emails the policy keeps ' +
+      'but the scrubber took. Both are defects.',
+  )
+  lines.push('')
+  lines.push('| scrubber | damaged | wrongly removed | known gaps (not scored) |')
+  lines.push('|---|---|---|---|')
+  for (const r of results) {
+    lines.push(
+      `| ${r.name} | ${r.damagedPlants.length} | ${r.wronglyRemoved.length} | ${r.knownGaps} |`,
+    )
+  }
+  lines.push('')
+
+  const withDamage = results.filter((r) => r.damagedPlants.length || r.wronglyRemoved.length)
+  if (withDamage.length) {
+    for (const r of withDamage) {
+      lines.push(`### ${r.name} — preservation defects`)
+      lines.push('')
+      for (const p of r.damagedPlants) {
+        lines.push(`- damaged \`${p.id}\`: \`${p.text}\``)
+      }
+      for (const p of r.wronglyRemoved) {
+        lines.push(`- wrongly removed \`${p.id}\` (${p.category}): \`${p.pii}\``)
+      }
+      lines.push('')
+    }
+  }
 
   lines.push('## Load time and footprint')
   lines.push('')

--- a/scripts/pii-review-sample.txt
+++ b/scripts/pii-review-sample.txt
@@ -1,0 +1,25 @@
+Kickoff notes — Verandah s.r.o. onboarding, 14 March
+
+Jana Prochazkova (jana.prochazkova@verandah.cz) confirmed the engagement scope this morning; Tomas Novak runs the discovery workshops and Petr Ungar covers the technical integration. Route invoicing questions to their finance lead, Martin Dvorak, on +420 777 123 456 or martin.dvorak@verandah.cz. Registered office: Vinohradska 1511/230, 100 00 Praha 10, company id 27082541, VAT CZ27082541. Escalation if Jana is unavailable: David Sedlak at david@bigcorp.io, external to Verandah, who must not receive the internal cost breakdown.
+
+Regional leads — introductions from the partner call
+
+Aleksandra Kowalczyk in Warsaw (a.kowalczyk@verandah.pl, +48 512 774 903) owns the Polish rollout; her PESEL on the contractor form reads 85042812345. Yuki Tanaka in Osaka (yuki.tanaka@verandah.jp, +81 90 1234 5678) handles APAC and files under My Number 1234 5678 9012. Rajesh Iyer in Bengaluru (r.iyer@verandah.in, +91 98450 12345) has PAN ABCDE1234F and Aadhaar 2345 6789 0123 on the vendor record. Fatima Al-Mansouri in Dubai (fatima@verandah.ae, +971 50 123 4567) signs off the Gulf entity, Emirates ID 784-1985-1234567-8. Sofia Rodriguez Garcia in Madrid (sofia.rodriguez@verandah.es, +34 612 345 678) holds NIE X1234567L. Bjorn Andersson in Stockholm (bjorn@verandah.se, +46 70 123 45 67) is personnummer 850412-1234. Mei-Ling Chen in Taipei and Kwame Osei in Accra join next quarter.
+
+Payment run — week 11
+
+Four transfers approved. The retainer goes to the Czech operating account 2901234567/2010 at Raiffeisenbank; the equipment invoice settles to IBAN CZ65 0800 0000 1920 0014 5399. The German subsidiary pays from IBAN DE89 3704 0044 0532 0130 00, the UK entity from GB82 WEST 1234 5698 7654 32, the Dutch office from NL91 ABNA 0417 1643 00, and the French branch from FR14 2004 1010 0505 0001 3M02 606. US payroll clears through routing 021000021, account 000123456789. Card on file for SaaS renewals is 4111 1111 1111 1111, expiry 04/28; backup corporate card 5555 5555 5555 4444. Total was 1 240 000 CZK against a 1 500 000 CZK budget, so we are 17% under. Invoices INV-2026-0417 through INV-2026-0420 sit in NetSuite under Payables > Verandah s.r.o.
+
+New hire packet — scanned, OCR captured
+
+Employee: Lucie Hrabalova. Employee ID: EMP-20419. Date of birth: 14.3.1988. Rodne cislo 885109/1234. Passport CZ1234567, valid to 2031-06-30. Drivers licence D1234567. Home address Krizikova 148/34, 186 00 Praha 8. Personal mobile 606 555 010, emergency contact 602 111 222. Payroll account 19-2000145399/0800. Starts 2026-04-01, needs Slack, NetSuite and VPN on day one. Temporary VPN password
+Summ3r!2026
+must be changed at first login. Her US counterpart Marcus Johnson has SSN 078-05-1120, tax id 12-3456789, and a UK colleague Priya Sharma with NI number QQ 12 34 56 C and NHS number 943 476 5919.
+
+Ops log — integration debugging
+
+Ticket DEU-205 blocked on activity 3f2a9c1e-7b44-4d0a-9e21-8c5f6b0d1234 in the miner. Pulled log bundle memorylane-2026-08-06T11-42-07.log from the box at 10.0.14.203:5432 and diffed against build v1.5.5-alpha.2, commit 67221f6. The sync job retried 4 times and processed 1 000 000 rows in 12 minutes before exit code 137 (OOM). Raised the container limit to 8192 MB and it cleared. Order #100482 in the test fixture still shows the wrong total; PR 273 was reopened to track it. Reference batch DE99 1234 5678 9012 3456 in the vendor export is a shipment code, not an account.
+
+Credentials found on screen during capture
+
+The OCR picked up a Stripe key sk-proj-9fA2kQ7ZxLm4vB0tRw8Nc1Ye in a terminal and a token ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4 in a config file. There was also AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG in an env file and api_key: 9f8e7d6c5b4a in a JSON payload. None of these should ever reach a prompt or a shared artifact. The Q3 2026 revenue figure of 12 500 EUR, the 15% growth rate, and the ¥3 200 000 Osaka forecast are ordinary business numbers and should survive untouched.

--- a/scripts/pii-review-sample.txt
+++ b/scripts/pii-review-sample.txt
@@ -1,25 +1,25 @@
-Kickoff notes — Verandah s.r.o. onboarding, 14 March
+Kickoff notes — Harbourline Logistics Pty Ltd, 14 March
 
-Jana Prochazkova (jana.prochazkova@verandah.cz) confirmed the engagement scope this morning; Tomas Novak runs the discovery workshops and Petr Ungar covers the technical integration. Route invoicing questions to their finance lead, Martin Dvorak, on +420 777 123 456 or martin.dvorak@verandah.cz. Registered office: Vinohradska 1511/230, 100 00 Praha 10, company id 27082541, VAT CZ27082541. Escalation if Jana is unavailable: David Sedlak at david@bigcorp.io, external to Verandah, who must not receive the internal cost breakdown.
+Sarah Chen (sarah.chen@harbourline.com.au) confirmed the engagement scope this morning; Tom Whitaker runs the discovery workshops and Petr Ungar covers the technical integration. Route invoicing questions to their finance lead, Marcus Boyd, on +61 412 345 678 or marcus.boyd@harbourline.com.au. Harbourline trades as ABN 51 824 753 556, ACN 004 085 616, registered at 12 Kent Street, Sydney NSW 2000. Escalation if Sarah is unavailable: Dave Sanderson at dave@thirdparty.io, external to Harbourline, who must not receive the internal cost breakdown.
 
 Regional leads — introductions from the partner call
 
-Aleksandra Kowalczyk in Warsaw (a.kowalczyk@verandah.pl, +48 512 774 903) owns the Polish rollout; her PESEL on the contractor form reads 85042812345. Yuki Tanaka in Osaka (yuki.tanaka@verandah.jp, +81 90 1234 5678) handles APAC and files under My Number 1234 5678 9012. Rajesh Iyer in Bengaluru (r.iyer@verandah.in, +91 98450 12345) has PAN ABCDE1234F and Aadhaar 2345 6789 0123 on the vendor record. Fatima Al-Mansouri in Dubai (fatima@verandah.ae, +971 50 123 4567) signs off the Gulf entity, Emirates ID 784-1985-1234567-8. Sofia Rodriguez Garcia in Madrid (sofia.rodriguez@verandah.es, +34 612 345 678) holds NIE X1234567L. Bjorn Andersson in Stockholm (bjorn@verandah.se, +46 70 123 45 67) is personnummer 850412-1234. Mei-Ling Chen in Taipei and Kwame Osei in Accra join next quarter.
-
-Payment run — week 11
-
-Four transfers approved. The retainer goes to the Czech operating account 2901234567/2010 at Raiffeisenbank; the equipment invoice settles to IBAN CZ65 0800 0000 1920 0014 5399. The German subsidiary pays from IBAN DE89 3704 0044 0532 0130 00, the UK entity from GB82 WEST 1234 5698 7654 32, the Dutch office from NL91 ABNA 0417 1643 00, and the French branch from FR14 2004 1010 0505 0001 3M02 606. US payroll clears through routing 021000021, account 000123456789. Card on file for SaaS renewals is 4111 1111 1111 1111, expiry 04/28; backup corporate card 5555 5555 5555 4444. Total was 1 240 000 CZK against a 1 500 000 CZK budget, so we are 17% under. Invoices INV-2026-0417 through INV-2026-0420 sit in NetSuite under Payables > Verandah s.r.o.
+Aroha Ngata in Auckland (aroha.ngata@harbourline.co.nz, +64 21 555 0134) owns the New Zealand rollout; the NZ entity files under IRD 49-091-850 and NZBN 9429041234567. Wiremu Tane in Wellington (wiremu@harbourline.co.nz, 021 555 0198) covers South Island depots. On the Australian side, Priya Raman in Melbourne (priya.raman@harbourline.com.au, 03 9876 5432) and Jack O'Sullivan in Brisbane (jack.osullivan@harbourline.com.au, +61 7 3210 9876) run the eastern warehouses. Mei-Ling Chen joins the Perth team next quarter.
 
 New hire packet — scanned, OCR captured
 
-Employee: Lucie Hrabalova. Employee ID: EMP-20419. Date of birth: 14.3.1988. Rodne cislo 885109/1234. Passport CZ1234567, valid to 2031-06-30. Drivers licence D1234567. Home address Krizikova 148/34, 186 00 Praha 8. Personal mobile 606 555 010, emergency contact 602 111 222. Payroll account 19-2000145399/0800. Starts 2026-04-01, needs Slack, NetSuite and VPN on day one. Temporary VPN password
+Employee: Nikau Williams. Employee ID: EMP-20419. Date of birth: 14.3.1988. Tax file number 123 456 782. Medicare 2123 45670 1. Passport PA0941234, valid to 2031-06-30. Drivers licence 04829173. Home address 8 Beach Road, Bondi NSW 2026. Personal mobile 0412 987 654, emergency contact +61 400 111 222. Salary goes to BSB 062-000, account 12345678. His NZ-based colleague Hemi Walker has IRD 136-410-132 and NHI ZAC5361, paid into 01-0123-0123456-00. Starts 2026-04-01, needs Slack, NetSuite and VPN on day one. Temporary VPN password
 Summ3r!2026
-must be changed at first login. Her US counterpart Marcus Johnson has SSN 078-05-1120, tax id 12-3456789, and a UK colleague Priya Sharma with NI number QQ 12 34 56 C and NHS number 943 476 5919.
+must be changed at first login. Centrelink CRN 203 456 789A is on the transition form.
+
+Payment run — week 11
+
+Four transfers approved. The retainer settles to BSB 083-004, account 987654321 at NAB; the equipment invoice pays from Westpac BSB 032-002, account 445566778. Card on file for the SaaS renewals is 4111 1111 1111 1111, expiry 04/28; backup corporate card 5555 5555 5555 4444. The Auckland office pays suppliers from 12-3141-0123456-00. Total was 1 240 000 AUD against a 1 500 000 AUD budget, so we are 17% under. Invoices INV-2026-0417 through INV-2026-0420 sit in NetSuite under Payables > Harbourline Logistics.
 
 Ops log — integration debugging
 
-Ticket DEU-205 blocked on activity 3f2a9c1e-7b44-4d0a-9e21-8c5f6b0d1234 in the miner. Pulled log bundle memorylane-2026-08-06T11-42-07.log from the box at 10.0.14.203:5432 and diffed against build v1.5.5-alpha.2, commit 67221f6. The sync job retried 4 times and processed 1 000 000 rows in 12 minutes before exit code 137 (OOM). Raised the container limit to 8192 MB and it cleared. Order #100482 in the test fixture still shows the wrong total; PR 273 was reopened to track it. Reference batch DE99 1234 5678 9012 3456 in the vendor export is a shipment code, not an account.
+Ticket DEU-205 blocked on activity 3f2a9c1e-7b44-4d0a-9e21-8c5f6b0d1234 in the miner. Pulled log bundle memorylane-2026-08-06T11-42-07.log from the box at 10.0.14.203:5432 and diffed against build v1.5.5-alpha.2, commit 67221f6. The sync job retried 4 times and processed 1 000 000 rows in 12 minutes before exit code 137 (OOM). Raised the container limit to 8192 MB and it cleared. Order #100482 in the test fixture still shows the wrong total; PR 273 was reopened to track it. Reference batch 4820 1174 9930 2217 in the vendor export is a shipment code, not a card.
 
 Credentials found on screen during capture
 
-The OCR picked up a Stripe key sk-proj-9fA2kQ7ZxLm4vB0tRw8Nc1Ye in a terminal and a token ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4 in a config file. There was also AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG in an env file and api_key: 9f8e7d6c5b4a in a JSON payload. None of these should ever reach a prompt or a shared artifact. The Q3 2026 revenue figure of 12 500 EUR, the 15% growth rate, and the ¥3 200 000 Osaka forecast are ordinary business numbers and should survive untouched.
+The OCR picked up a Stripe key sk-proj-9fA2kQ7ZxLm4vB0tRw8Nc1Ye in a terminal and a token ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4 in a config file. There was also AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG in an env file and api_key: 9f8e7d6c5b4a in a JSON payload. None of these should ever reach a prompt or a shared artifact. The Q3 2026 revenue figure of 12 500 AUD, the 15% growth rate, and the 8192 MB container limit are ordinary business numbers and should survive untouched.

--- a/scripts/scrub-review.ts
+++ b/scripts/scrub-review.ts
@@ -1,0 +1,134 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { scrubPII } from '../src/shared/sanitize'
+
+const args = process.argv.slice(2)
+const flag = (name: string, fallback?: string): string | undefined => {
+  const i = args.indexOf(`--${name}`)
+  return i === -1 ? fallback : args[i + 1]
+}
+
+const inputPath = resolve(flag('in', 'scripts/pii-review-sample.txt') as string)
+const outPath = flag('out')
+const scrub = scrubPII
+
+const raw = readFileSync(inputPath, 'utf8')
+
+const tokenize = (s: string): string[] => s.match(/\[[^\]\n]+\]|\s+|[^\s[]+|\[/g) ?? []
+
+function diff(a: string[], b: string[]): { kind: 'same' | 'del' | 'add'; text: string }[] {
+  const n = a.length
+  const m = b.length
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1])
+    }
+  }
+  const out: { kind: 'same' | 'del' | 'add'; text: string }[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      out.push({ kind: 'same', text: a[i] })
+      i++
+      j++
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push({ kind: 'del', text: a[i++] })
+    } else {
+      out.push({ kind: 'add', text: b[j++] })
+    }
+  }
+  while (i < n) out.push({ kind: 'del', text: a[i++] })
+  while (j < m) out.push({ kind: 'add', text: b[j++] })
+  return out
+}
+
+const lines: string[] = []
+const say = (s = '') => lines.push(s)
+
+const paragraphs = raw.split(/\n\s*\n/)
+const tally = new Map<string, number>()
+const changes: { before: string; after: string; context: string }[] = []
+
+say('PII scrub review — scrubPII (names and emails kept by policy)')
+say(`source: ${inputPath}`)
+say('='.repeat(100))
+
+for (const para of paragraphs) {
+  if (!para.trim()) continue
+  const cleaned = scrub(para)
+  const parts = diff(tokenize(para), tokenize(cleaned))
+
+  const before: string[] = []
+  const after: string[] = []
+  let pendingDel: string[] = []
+  let pendingAdd: string[] = []
+  const flush = () => {
+    if (!pendingDel.length && !pendingAdd.length) return
+    const b = pendingDel.join('').trim()
+    const a = pendingAdd.join('').trim()
+    if (b || a) {
+      changes.push({ before: b, after: a, context: '' })
+      for (const ph of a.match(/\[[^\]]+\]/g) ?? []) tally.set(ph, (tally.get(ph) ?? 0) + 1)
+    }
+    pendingDel = []
+    pendingAdd = []
+  }
+  for (const p of parts) {
+    if (p.kind === 'same') {
+      flush()
+      before.push(p.text)
+      after.push(p.text)
+    } else if (p.kind === 'del') {
+      pendingDel.push(p.text)
+      before.push(p.text)
+    } else {
+      pendingAdd.push(p.text)
+      after.push(p.text)
+    }
+  }
+  flush()
+
+  say()
+  say(cleaned.trim())
+  say('-'.repeat(100))
+}
+
+say()
+say('='.repeat(100))
+say(`REPLACEMENTS (${changes.length})`)
+say('='.repeat(100))
+const width = Math.max(...changes.map((c) => c.before.length), 10)
+for (const c of changes) {
+  say(`  ${c.before.padEnd(width)}  ->  ${c.after}`)
+}
+
+say()
+say('='.repeat(100))
+say('TALLY')
+say('='.repeat(100))
+for (const [ph, n] of [...tally.entries()].sort((a, b) => b[1] - a[1])) {
+  say(`  ${String(n).padStart(3)}x  ${ph}`)
+}
+
+say()
+say('='.repeat(100))
+say('SURVIVED — read this list and confirm nothing here should have been removed')
+say('='.repeat(100))
+const survivors = [
+  ...new Set(
+    (scrub(raw).match(/[A-Za-z0-9][A-Za-z0-9._%+@/-]{5,}/g) ?? []).filter(
+      (t) => /\d/.test(t) && !t.startsWith('['),
+    ),
+  ),
+]
+for (const s of survivors) say(`  ${s}`)
+
+const report = lines.join('\n')
+if (outPath) {
+  writeFileSync(resolve(outPath), report + '\n')
+  console.log(`wrote ${outPath} (${changes.length} replacements, ${survivors.length} survivors)`)
+} else {
+  console.log(report)
+}

--- a/src/main/eval/pii-fixture.ts
+++ b/src/main/eval/pii-fixture.ts
@@ -19,6 +19,26 @@ export type PiiCategory =
   | 'username'
   | 'password'
   | 'secret'
+  | 'tfn'
+  | 'medicare'
+  | 'ird'
+  | 'nhi'
+
+/**
+ * Categories the policy deliberately preserves. A plant in one of these must
+ * survive verbatim — names, emails and handles are the client-vs-internal
+ * signal that makes a sighting legible, so removing them is a defect, not a
+ * success. Usernames are credential material only on a login screen, and those
+ * are already excluded upstream by the capture gate.
+ */
+export const KEEP_CATEGORIES = new Set<PiiCategory>(['name', 'email', 'username'])
+
+/**
+ * Categories no deterministic rule can reach. Street addresses cannot be
+ * matched without also destroying every "Payables > Acme Corp" path. Reported
+ * as known gaps rather than scored as failures.
+ */
+export const GAP_CATEGORIES = new Set<PiiCategory>(['address'])
 
 export type TextShape = 'window_title' | 'summary' | 'ocr'
 
@@ -551,6 +571,58 @@ export const PII_PLANTS: PiiPlant[] = [
     `${GH_TOKEN} - Search results - 1Password`,
     GH_TOKEN,
   ),
+
+  plant('tfn-01', 'tfn', 'ocr', 'Tax file number 123 456 782\nStatus: verified', '123 456 782'),
+  plant('tfn-02', 'tfn', 'summary', 'Entered the TFN 123456782 into the onboarding form.', '123456782'),
+  plant('tfn-03', 'tfn', 'window_title', 'TFN declaration 876 543 210 - myGov', '876 543 210'),
+  plant('medicare-01', 'medicare', 'ocr', 'Medicare 2123 45670 1\nExpiry 09/29', '2123 45670 1'),
+  plant(
+    'medicare-02',
+    'medicare',
+    'summary',
+    'Copied the Medicare number 2428 77813 2 from the scanned card into the claim.',
+    '2428 77813 2',
+  ),
+  plant('medicare-03', 'medicare', 'ocr', 'Card shows 2123 45670 1 for the dependant', '2123 45670 1'),
+  plant('ird-01', 'ird', 'ocr', 'IRD number 49-091-850\nTax code M', '49-091-850'),
+  plant(
+    'ird-02',
+    'ird',
+    'summary',
+    'Filed the GST return against 136-410-132 for the March period.',
+    '136-410-132',
+  ),
+  plant('ird-03', 'ird', 'window_title', 'IRD 49091850 - myIR', '49091850'),
+  plant('nhi-01', 'nhi', 'ocr', 'NHI ZAC5361\nGP: Northcote Medical', 'ZAC5361'),
+  plant(
+    'nhi-02',
+    'nhi',
+    'summary',
+    'Looked up the patient by NHI ZZZ0016 before booking the referral.',
+    'ZZZ0016',
+  ),
+  plant(
+    'bank-08',
+    'bank',
+    'ocr',
+    'BSB 062-000\nAccount 12345678\nName: N Williams',
+    '12345678',
+  ),
+  plant(
+    'bank-09',
+    'bank',
+    'summary',
+    'Set up the supplier payment to 01-0123-0123456-00 in the banking portal.',
+    '01-0123-0123456-00',
+  ),
+  plant('phone-11', 'phone', 'ocr', 'Mobile: 0412 987 654\nAfter hours only', '0412 987 654'),
+  plant(
+    'phone-12',
+    'phone',
+    'summary',
+    'Rang the depot on +64 21 555 0134 to confirm the pallet count.',
+    '+64 21 555 0134',
+  ),
 ]
 
 function control(id: string, kind: string, text: string): CleanControl {
@@ -610,4 +682,12 @@ export const CLEAN_CONTROLS: CleanControl[] = [
   control('phone-like-01', 'misc', 'Error code 0x80070005 during the update rollback.'),
   control('title-01', 'misc', 'Quarterly business review agenda - Google Docs'),
   control('title-02', 'misc', 'Untitled spreadsheet - Google Sheets'),
+  control('abn-01', 'company_id', 'Harbourline Logistics Pty Ltd, ABN 51 824 753 556'),
+  control('abn-02', 'company_id', 'Supplier 51 824 753 556 approved for the panel.'),
+  control('acn-01', 'company_id', 'ACN 004 085 616 listed on the tax invoice.'),
+  control('nzbn-01', 'company_id', 'NZBN 9429041234567 registered in Auckland.'),
+  control('bsb-01', 'company_id', 'Remit to BSB 062-000 at the Sydney branch.'),
+  control('aunz-misc-01', 'misc', 'Reference batch 4820 1174 9930 2217 in the vendor export.'),
+  control('aunz-misc-02', 'misc', 'Container limit 8192 MB, exit code 137 on retry.'),
+  control('aunz-misc-03', 'misc', 'Invoice total 12 500 AUD, up 15% on Q3 2026.'),
 ]

--- a/src/main/mcp/formatting.ts
+++ b/src/main/mcp/formatting.ts
@@ -1,4 +1,5 @@
 import { ActivitySummary } from '../storage'
+import { scrubPII } from '@/shared/sanitize'
 
 /**
  * Formats a single activity as a compact summary line with duration and screenshot count.
@@ -12,7 +13,7 @@ export function formatActivityLine(activity: {
 }): string {
   const timeStr = new Date(activity.startTimestamp).toLocaleString()
   const appInfo = activity.appName ? ` [${activity.appName}]` : ''
-  const summary = activity.summary || '(no summary)'
+  const summary = activity.summary ? scrubPII(activity.summary) : '(no summary)'
   return `- ${activity.id} | ${timeStr}${appInfo} | ${summary}`
 }
 
@@ -46,8 +47,10 @@ export function activityToTimelineEntry(activity: ActivitySummary): TimelineEntr
 export function formatTimelineEntry(entry: TimelineEntry): string {
   const timeStr = new Date(entry.timestamp).toLocaleString()
   const appInfo = entry.appName ? ` [${entry.appName}]` : ''
-  const windowInfo = entry.windowTitle ? ` [window: ${JSON.stringify(entry.windowTitle)}]` : ''
-  const summary = entry.summary || '(no summary)'
+  const windowInfo = entry.windowTitle
+    ? ` [window: ${JSON.stringify(scrubPII(entry.windowTitle))}]`
+    : ''
+  const summary = entry.summary ? scrubPII(entry.summary) : '(no summary)'
   return `- ${entry.id} | ${timeStr}${appInfo}${windowInfo} | ${summary}`
 }
 

--- a/src/main/mcp/tools.test.ts
+++ b/src/main/mcp/tools.test.ts
@@ -293,6 +293,44 @@ describe('pattern tools (task clusters)', () => {
       expect(text).toContain('Activity IDs: act-a, act-b')
     })
 
+    it('scrubs secrets and phones from sighting fields but keeps emails and IDs verbatim', async () => {
+      addClusterWithMembers(createCluster({ id: 'c1', label: 'Send report' }), [
+        createSighting({
+          id: 's1',
+          subject: 'jane.doe@acme.co',
+          description: 'Used password: hunter42 and called +1 (555) 123-4567',
+          activityIds: ['act-a1', 'act-b2'],
+        }),
+        createSighting({ id: 's2' }),
+      ])
+
+      const text = (await handlers.get('get_pattern_details')!({ patternId: 'c1' })).content[0].text
+      expect(text).not.toContain('hunter42')
+      expect(text).not.toContain('555) 123-4567')
+      expect(text).toContain('[redacted password]')
+      expect(text).toContain('[phone number]')
+      expect(text).toContain('jane.doe@acme.co')
+      expect(text).toContain('Activity IDs: act-a1, act-b2')
+    })
+
+    it('scrubs secrets from activity summaries and OCR in get_activity_details', async () => {
+      storage.activities.add(
+        createStoredActivity({
+          id: 'act-ocr',
+          summary: 'Logged in with password: hunter42',
+          ocrText: 'Username: jane.doe@acme.co\nAPI_KEY=9f8e7d6c5b4a\nCall 555-123-4567',
+        }),
+      )
+
+      const text = (await handlers.get('get_activity_details')!({ ids: ['act-ocr'] })).content[0]
+        .text
+      expect(text).not.toContain('hunter42')
+      expect(text).not.toContain('9f8e7d6c5b4a')
+      expect(text).not.toContain('555-123-4567')
+      expect(text).toContain('jane.doe@acme.co')
+      expect(text).toContain('ID: act-ocr')
+    })
+
     it('never prints raw member step text (steps are not scrubbed for egress)', async () => {
       addClusterWithMembers(createCluster({ id: 'c1', label: 'Daily standup notes' }), [
         createSighting({

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -26,6 +26,7 @@ import {
 import { CLUSTER_VIEW_CONFIG } from '@/shared/constants'
 import type { ClusterInfo } from '../../shared/types'
 import log from '@main/utils/logger'
+import { scrubPII } from '@/shared/sanitize'
 
 export interface MCPServices {
   storage: StorageService
@@ -617,9 +618,11 @@ function formatClusterLine(c: ClusterInfo): string {
   }
   stats.push(`avg ${Math.round(c.avgActiveMin)} min/run`)
   if (c.lastSeenAt) stats.push(`last seen ${new Date(c.lastSeenAt).toLocaleString()}`)
-  const lines = [`- ${c.id} | ${c.title} [${c.apps.join(', ')}] (${stats.join(', ')})`]
-  if (c.description) lines.push(`  ${c.description}`)
-  if (c.mechanism) lines.push(`  Replace with: ${c.mechanism}`)
+  const lines = [
+    `- ${c.id} | ${scrubPII(c.title)} [${c.apps.join(', ')}] (${stats.join(', ')})`,
+  ]
+  if (c.description) lines.push(`  ${scrubPII(c.description)}`)
+  if (c.mechanism) lines.push(`  Replace with: ${scrubPII(c.mechanism)}`)
   return lines.join('\n')
 }
 
@@ -631,8 +634,8 @@ function formatClusterSightingLine(s: Sighting): string {
   const lines = [
     `- ${s.id} | ${start} -> ${end} | ~${activeMin} min active | [${s.apps.join(', ')}]`,
   ]
-  lines.push(`  ${title}`)
-  if (s.description) lines.push(`  ${s.description}`)
+  lines.push(`  ${scrubPII(title)}`)
+  if (s.description) lines.push(`  ${scrubPII(s.description)}`)
   lines.push(`  Activity IDs: ${s.activityIds.join(', ')}`)
   return lines.join('\n')
 }
@@ -830,7 +833,7 @@ async function handleGetUserContext(services: MCPServices | null) {
       content: [
         {
           type: 'text' as const,
-          text: `User profile (last updated: ${updatedAtStr}):\n\nShort summary:\n${ctx.shortSummary}\n\nDetailed summary:\n${ctx.detailedSummary}`,
+          text: `User profile (last updated: ${updatedAtStr}):\n\nShort summary:\n${scrubPII(ctx.shortSummary)}\n\nDetailed summary:\n${scrubPII(ctx.detailedSummary)}`,
         },
       ],
     }
@@ -881,8 +884,9 @@ async function handleGetActivityDetails(services: MCPServices | null, { ids }: {
         const timeStr = new Date(a.startTimestamp).toLocaleString()
         const endTimeStr = new Date(a.endTimestamp).toLocaleString()
         const appInfo = a.appName ? ` [${a.appName}]` : ''
-        const summaryLine = a.summary ? `\nSummary: ${a.summary}` : ''
-        return `ID: ${a.id}\n[${timeStr} → ${endTimeStr}]${appInfo}${summaryLine}\nOCR: ${a.ocrText}`
+        const summaryLine = a.summary ? `\nSummary: ${scrubPII(a.summary)}` : ''
+        const ocrText = a.ocrText ? scrubPII(a.ocrText) : a.ocrText
+        return `ID: ${a.id}\n[${timeStr} → ${endTimeStr}]${appInfo}${summaryLine}\nOCR: ${ocrText}`
       })
       .join('\n\n---\n\n')
 

--- a/src/main/semantic/prompt.ts
+++ b/src/main/semantic/prompt.ts
@@ -1,5 +1,6 @@
 import type { InteractionContext } from '../../shared/types'
 import type { Activity } from '@main/activity/activity-types'
+import { scrubPII } from '@/shared/sanitize'
 import type { SemanticMode } from './types'
 
 export function buildSemanticPrompt(
@@ -26,6 +27,8 @@ export function buildSemanticPrompt(
   prompt +=
     '- Be specific: name files, functions, errors, URLs, and UI elements visible in the provided media.\n'
   prompt +=
+    '- NEVER transcribe credentials, API keys, tax file / Medicare / IRD / NHI numbers, bank accounts, card numbers, passports or licences. Name the kind instead ([redacted password], [redacted secret], [payment card], [bank account], [tax file number], [medicare number], [ird number], [nhi number], [id number]) — never silently omit what happened. Names, companies and email addresses are fine to record.\n'
+  prompt +=
     '- Match verb intensity to evidence: browsing/reviewing (no visible edits) -> "browsed," "reviewed," "checked." Light editing (small visible changes) -> "tweaked," "adjusted." Active work (sustained edits, new code, debugging) -> "implemented," "debugged," "refactored." Evidence of editing = visible changed lines, new code, or diff markers.\n'
   prompt +=
     '- Do NOT exaggerate. Switching files/tabs = browsing, not editing. Opening a file/page = reviewing, not working on it.\n'
@@ -44,7 +47,7 @@ export function buildSemanticPrompt(
   prompt += '## Context\n'
   prompt += `- App: ${activity.context.appName}\n`
   if (activity.context.windowTitle) {
-    prompt += `- Window: ${activity.context.windowTitle}\n`
+    prompt += `- Window: ${scrubPII(activity.context.windowTitle)}\n`
   }
   if (activity.context.tld) {
     prompt += `- TLD: ${activity.context.tld}\n`
@@ -53,7 +56,7 @@ export function buildSemanticPrompt(
   prompt += `- Start: ${new Date(activity.startTimestamp).toISOString()}\n`
   prompt += `- End: ${new Date(activity.endTimestamp).toISOString()}\n`
   if (userContext) {
-    prompt += `- User: ${userContext}\n`
+    prompt += `- User: ${scrubPII(userContext)}\n`
   }
   prompt += `- ${sourceNote}\n\n`
 
@@ -86,7 +89,7 @@ function buildInteractionTimeline(activity: Activity): string {
   const items: string[] = []
   for (const interaction of interactions.slice(0, maxItems)) {
     const offsetSeconds = ((interaction.timestamp - activity.startTimestamp) / 1000).toFixed(1)
-    items.push(`- t+${offsetSeconds}s: ${describeInteraction(interaction)}`)
+    items.push(`- t+${offsetSeconds}s: ${scrubPII(describeInteraction(interaction))}`)
   }
 
   if (interactions.length > maxItems) {

--- a/src/main/services/task-miner/clustering/apply-review.test.ts
+++ b/src/main/services/task-miner/clustering/apply-review.test.ts
@@ -496,7 +496,10 @@ describe('applyContent', () => {
             id: 'c1',
             label: 'Follow up',
             description: 'x',
-            steps: ['Open the thread in Gmail (mail.google.com)', 'Email jane@acme.co the recap'],
+            steps: [
+              'Open the thread in Gmail (mail.google.com)',
+              'Email jane@acme.co the recap, card 4111 1111 1111 1111',
+            ],
             variables: ['customer name'],
           },
         ],
@@ -506,7 +509,7 @@ describe('applyContent', () => {
 
     const cluster = storage.clusters.getById('c1')!
     expect(cluster.steps[0]).toBe('Open the thread in Gmail (mail.google.com)')
-    expect(cluster.steps[1]).toBe('Email [email address] the recap')
+    expect(cluster.steps[1]).toBe('Email jane@acme.co the recap, card [payment card]')
     expect(cluster.variables).toEqual(['customer name'])
   })
 

--- a/src/main/services/task-miner/clustering/llm-review.test.ts
+++ b/src/main/services/task-miner/clustering/llm-review.test.ts
@@ -178,3 +178,43 @@ describe('runContentReview', () => {
     expect(mockedGenerateText).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('PII scrubbing', () => {
+  const memberInput = {
+    clusters: [
+      {
+        id: 'c1',
+        splittable: false,
+        label: '',
+        stats: { times_seen: 2, span_days: 3, median_active_min: 5 },
+        members: [
+          {
+            sighting_id: 's1',
+            title: 'Email jane.doe@acme.co the report',
+            subject: 'password: hunter42',
+            description: 'Sent the weekly report',
+            steps: ['mail.google.com: mail jane.doe@acme.co'],
+            apps: ['mail.google.com'],
+            active_min: 5,
+            date: '2026-07-30',
+          },
+        ],
+      },
+    ],
+    mergeCandidates: [] as [string, string][],
+  }
+
+  it('scrubs secrets from the prompt but keeps emails for context', async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: '{"clusters":[]}',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never)
+
+    await runContentReview(provider, 'model', memberInput)
+
+    const call = mockedGenerateText.mock.calls[0][0] as { prompt: string }
+    expect(call.prompt).not.toContain('hunter42')
+    expect(call.prompt).toContain('[redacted password]')
+    expect(call.prompt).toContain('jane.doe@acme.co')
+  })
+})

--- a/src/main/services/task-miner/clustering/llm-review.ts
+++ b/src/main/services/task-miner/clustering/llm-review.ts
@@ -2,6 +2,7 @@ import { generateText } from 'ai'
 import type { InferenceProvider } from '@main/llm'
 import { extractJsonObject, formatApiError } from '../helpers'
 import { PATTERN_DETECTION_CONFIG } from '@/shared/constants'
+import { scrubPII } from '@/shared/sanitize'
 import type { ReviewInput, ReviewOutput } from './types'
 import { CLUSTERING_CONFIG } from './types'
 import {
@@ -18,6 +19,23 @@ export interface ReviewCallResult {
   mergesIncomplete?: boolean
 }
 
+function scrubReviewInputForPrompt(input: ReviewInput): ReviewInput {
+  return {
+    mergeCandidates: input.mergeCandidates,
+    clusters: input.clusters.map((cluster) => ({
+      ...cluster,
+      label: scrubPII(cluster.label),
+      members: cluster.members.map((member) => ({
+        ...member,
+        title: scrubPII(member.title),
+        subject: scrubPII(member.subject),
+        description: scrubPII(member.description),
+        ...(member.steps && { steps: member.steps.map(scrubPII) }),
+      })),
+    })),
+  }
+}
+
 /**
  * Attempts cover thrown errors too — a transient timeout on a long call must
  * not forfeit the whole pass. The last attempt rethrows so the caller's error
@@ -31,7 +49,7 @@ async function callReview(
   describe: (attempt: number) => string,
   progress?: ProgressCallback,
 ): Promise<ReviewCallResult> {
-  const { input: aliased, aliases } = aliasReviewInput(input)
+  const { input: aliased, aliases } = aliasReviewInput(scrubReviewInputForPrompt(input))
   const prompt = serializeReviewInput(aliased)
   const tokenUsage = { input: 0, output: 0 }
 

--- a/src/main/services/task-miner/clustering/prompts.ts
+++ b/src/main/services/task-miner/clustering/prompts.ts
@@ -69,7 +69,7 @@ Rules:
 - Cluster ids are short handles ("c1"). Copy them back exactly as given — never invent, renumber, or reformat one. A mis-copied id discards that verdict.
 - Do not mention counts, frequencies, or durations in labels/descriptions — those are computed separately.
 - When unsure of the kind, choose the non-eliminable reading — a wrongly promised automation costs more than a missed one.
-- steps and variables carry NO personal data: no real names, companies, emails, phone numbers, ids, or PII/PHI. When in doubt, replace the specific with a generic variable.
+- labels, descriptions, steps, and variables carry NO personal data: no real names, companies, emails, phone numbers, credentials, account numbers, or PII/PHI. They are copied into outside tools; when in doubt, replace the specific with a generic variable.
 
 Output a single JSON object, no other text:
 

--- a/src/main/services/task-miner/clustering/prompts.ts
+++ b/src/main/services/task-miner/clustering/prompts.ts
@@ -69,7 +69,7 @@ Rules:
 - Cluster ids are short handles ("c1"). Copy them back exactly as given — never invent, renumber, or reformat one. A mis-copied id discards that verdict.
 - Do not mention counts, frequencies, or durations in labels/descriptions — those are computed separately.
 - When unsure of the kind, choose the non-eliminable reading — a wrongly promised automation costs more than a missed one.
-- labels, descriptions, steps, and variables carry NO personal data: no real names, companies, emails, phone numbers, credentials, account numbers, or PII/PHI. They are copied into outside tools; when in doubt, replace the specific with a generic variable.
+- labels, descriptions, steps, and variables carry no personal identifying numbers: no tax file, Medicare, IRD or NHI numbers, bank accounts, card numbers, passports, licences, credentials, or phone numbers. Name the kind instead. People, companies and email addresses may be named — they are what makes a task legible. When in doubt about anything else, replace the specific with a generic variable.
 
 Output a single JSON object, no other text:
 

--- a/src/main/services/task-miner/prompts.test.ts
+++ b/src/main/services/task-miner/prompts.test.ts
@@ -33,10 +33,12 @@ describe('buildScanSystemPrompt', () => {
     expect(prompt).toContain('describe only actions the cited activities evidence')
   })
 
-  it('forbids copying credentials or account numbers into any field', () => {
+  it('forbids identifying numbers but permits people, companies and emails', () => {
     const prompt = buildScanSystemPrompt('Monday')
-    expect(prompt).toContain('Never copy credentials, passwords, API keys')
+    expect(prompt).toContain('Never copy a tax file number')
     expect(prompt).toContain('[bank account]')
+    expect(prompt).toContain('[medicare number]')
+    expect(prompt).toContain('People, companies and email addresses belong in the output')
   })
 
   it('instructs canonical, object-free titles', () => {
@@ -58,10 +60,11 @@ describe('buildGroundingSystemPrompt', () => {
     activity_ids: [UUID],
   }
 
-  it('forbids copying credentials from the OCR into any field', () => {
+  it('forbids identifying numbers from the OCR but permits names and emails', () => {
     const prompt = buildGroundingSystemPrompt(candidate, ['admin.acme.com'], ['a1'])
-    expect(prompt).toContain('Never copy credentials, passwords, API keys')
+    expect(prompt).toContain('never copy a tax file number')
     expect(prompt).toContain('[redacted secret]')
+    expect(prompt).toContain('Names, companies and email addresses from the OCR are fine to use')
   })
 
   it('carries subject through the keep-JSON so scanOnly=false persists it', () => {

--- a/src/main/services/task-miner/prompts.test.ts
+++ b/src/main/services/task-miner/prompts.test.ts
@@ -33,6 +33,12 @@ describe('buildScanSystemPrompt', () => {
     expect(prompt).toContain('describe only actions the cited activities evidence')
   })
 
+  it('forbids copying credentials or account numbers into any field', () => {
+    const prompt = buildScanSystemPrompt('Monday')
+    expect(prompt).toContain('Never copy credentials, passwords, API keys')
+    expect(prompt).toContain('[bank account]')
+  })
+
   it('instructs canonical, object-free titles', () => {
     const prompt = buildScanSystemPrompt('Monday')
     expect(prompt).toContain(
@@ -51,6 +57,12 @@ describe('buildGroundingSystemPrompt', () => {
     steps: ['admin.acme.com: create the tenant'],
     activity_ids: [UUID],
   }
+
+  it('forbids copying credentials from the OCR into any field', () => {
+    const prompt = buildGroundingSystemPrompt(candidate, ['admin.acme.com'], ['a1'])
+    expect(prompt).toContain('Never copy credentials, passwords, API keys')
+    expect(prompt).toContain('[redacted secret]')
+  })
 
   it('carries subject through the keep-JSON so scanOnly=false persists it', () => {
     expect(buildGroundingSystemPrompt(candidate, ['admin.acme.com'], ['a1'])).toContain('"subject"')

--- a/src/main/services/task-miner/prompts.ts
+++ b/src/main/services/task-miner/prompts.ts
@@ -50,7 +50,7 @@ A run of a repeatable multi-step procedure that CHANGES something — creates, p
 - Every description ENDS with exactly one sentence naming the mechanism: "Replace with: <the concrete script, integration, alert, or platform feature>." If you cannot write that sentence concretely, the finding does not exist.
 - \`steps\` describe only actions the cited activities evidence, one action per line, each starting with that activity's \`app\` — never a browser name.
 - Titles name the procedure, subjects name the object: title "Process invoice", subject "Customer ABC" — never title "Process invoice for Customer ABC". The title is worded so every run of the procedure gets it identically; the specific object goes in \`subject\`. Two runs of the same procedure on different objects share one title and differ only in subject. \`subject\` is optional — leave it empty when the run acted on no single nameable object.
-- Never copy credentials, passwords, API keys, or payment/account/government-id numbers into \`title\`, \`subject\`, \`description\`, or \`steps\`. Where the object is only identifiable by one, name the kind instead: [id number], [bank account], [payment card], [phone number], [redacted secret], [redacted password].
+- People, companies and email addresses belong in the output — they are how a task reads as client work or internal work. Personal identifying numbers do not. Never copy a tax file number, Medicare/IRD/NHI number, bank account, card number, passport, licence, credential or password into \`title\`, \`subject\`, \`description\`, or \`steps\`. Where the object is only identifiable by one, name the kind instead: [tax file number], [medicare number], [ird number], [nhi number], [bank account], [payment card], [id number], [phone number], [redacted secret], [redacted password].
 ${knownProceduresSection}
 ## Output
 
@@ -115,7 +115,7 @@ If this is a real, grounded run:
 \`\`\`
 If you cannot write the "Replace with:" sentence concretely, reject.
 
-Never copy credentials, passwords, API keys, or payment/account/government-id numbers from the OCR into any field. Name the kind instead: [id number], [bank account], [payment card], [redacted secret], [redacted password].
+Names, companies and email addresses from the OCR are fine to use. Personal identifying numbers are not: never copy a tax file number, Medicare/IRD/NHI number, bank account, card number, passport, licence, credential or password into any field. Name the kind instead: [tax file number], [medicare number], [ird number], [nhi number], [bank account], [payment card], [id number], [redacted secret], [redacted password].
 
 ### Reject
 Reject if the evidence shows checking/watching, re-checks of that day's work in progress, dev-loop mechanics, a one-off action, creative or judgment work; if the cited activities don't support the claim; or if fewer than 2 substantive activities remain after cleanup. Keep only what you could defend to the client from the evidence on screen:

--- a/src/main/services/task-miner/prompts.ts
+++ b/src/main/services/task-miner/prompts.ts
@@ -50,6 +50,7 @@ A run of a repeatable multi-step procedure that CHANGES something — creates, p
 - Every description ENDS with exactly one sentence naming the mechanism: "Replace with: <the concrete script, integration, alert, or platform feature>." If you cannot write that sentence concretely, the finding does not exist.
 - \`steps\` describe only actions the cited activities evidence, one action per line, each starting with that activity's \`app\` — never a browser name.
 - Titles name the procedure, subjects name the object: title "Process invoice", subject "Customer ABC" — never title "Process invoice for Customer ABC". The title is worded so every run of the procedure gets it identically; the specific object goes in \`subject\`. Two runs of the same procedure on different objects share one title and differ only in subject. \`subject\` is optional — leave it empty when the run acted on no single nameable object.
+- Never copy credentials, passwords, API keys, or payment/account/government-id numbers into \`title\`, \`subject\`, \`description\`, or \`steps\`. Where the object is only identifiable by one, name the kind instead: [id number], [bank account], [payment card], [phone number], [redacted secret], [redacted password].
 ${knownProceduresSection}
 ## Output
 
@@ -113,6 +114,8 @@ If this is a real, grounded run:
 }
 \`\`\`
 If you cannot write the "Replace with:" sentence concretely, reject.
+
+Never copy credentials, passwords, API keys, or payment/account/government-id numbers from the OCR into any field. Name the kind instead: [id number], [bank account], [payment card], [redacted secret], [redacted password].
 
 ### Reject
 Reject if the evidence shows checking/watching, re-checks of that day's work in progress, dev-loop mechanics, a one-off action, creative or judgment work; if the cited activities don't support the claim; or if fewer than 2 substantive activities remain after cleanup. Keep only what you could defend to the client from the evidence on screen:

--- a/src/main/services/task-miner/run-detection.test.ts
+++ b/src/main/services/task-miner/run-detection.test.ts
@@ -67,6 +67,32 @@ describe('runDetection day commit', () => {
     deleteDbFiles(TEST_DB_PATH)
   })
 
+  it('scrubs secrets and phones from the scan prompt but keeps emails and names', async () => {
+    storage.activities.add({
+      id: 'act-pii',
+      appName: 'TestApp',
+      windowTitle: 'Call Jane Novak at +1 (555) 123-4567',
+      tld: null,
+      startTimestamp: dayStart(1) + 5000,
+      endTimestamp: dayStart(1) + 5500,
+      summary: 'Mailed jane.doe@acme.co the password: hunter42',
+      summaryModel: '',
+      ocrText: '',
+      vector: v(0.1),
+    })
+    mockedGenerateText.mockResolvedValue(scanResponse('[]'))
+
+    await runDetection(provider, storage, embedder, { lookbackDays: 1 })
+
+    const call = mockedGenerateText.mock.calls[0][0] as { prompt: string }
+    expect(call.prompt).not.toContain('555) 123-4567')
+    expect(call.prompt).not.toContain('hunter42')
+    expect(call.prompt).toContain('[phone number]')
+    expect(call.prompt).toContain('[redacted password]')
+    expect(call.prompt).toContain('Jane Novak')
+    expect(call.prompt).toContain('jane.doe@acme.co')
+  })
+
   it('throws after all scan attempts return unusable output, leaving the day uncommitted', async () => {
     mockedGenerateText.mockResolvedValue(scanResponse('not json at all'))
     const onCommit = vi.fn()

--- a/src/main/services/task-miner/run-detection.ts
+++ b/src/main/services/task-miner/run-detection.ts
@@ -23,6 +23,7 @@ import {
 } from './helpers'
 import { getDayBoundaries } from '@main/utils/day'
 import { deriveSightingApps } from '@/shared/app-utils'
+import { scrubPII } from '@/shared/sanitize'
 import { buildVerificationTools } from './tools'
 import { normalizeScanCandidates, normalizeSteps } from './candidate-normalizer'
 import { buildScanSystemPrompt, buildGroundingSystemPrompt } from './prompts'
@@ -113,12 +114,12 @@ export async function runDetection(
   // 2. User context (optional flavor for the scan)
   const userCtx = storage.userContext.get()
   const userContextStr = userCtx
-    ? `${userCtx.shortSummary}\n\n${userCtx.detailedSummary}`
+    ? scrubPII(`${userCtx.shortSummary}\n\n${userCtx.detailedSummary}`)
     : undefined
 
   // Canonical titles of established procedures, fed back so recurring work
   // reuses its name cross-day. Empty on fresh/eval DBs — section omitted.
-  const knownProcedures = getKnownProcedureTitles(storage)
+  const knownProcedures = getKnownProcedureTitles(storage).map(scrubPII)
 
   // =========================================================================
   // Phase 1: Scan — discover discrete task instances
@@ -128,7 +129,13 @@ export async function runDetection(
   // models mangle long opaque ids when citing them (dropping whole findings),
   // and short handles cut prompt tokens. Mapped back right after parsing.
   const activityIds = new PositionalAliases('a')
-  const serialized = serializeActivities(activities).map((row, i) => ({
+  const serialized = serializeActivities(
+    activities.map((a) => ({
+      ...a,
+      windowTitle: scrubPII(a.windowTitle),
+      summary: scrubPII(a.summary),
+    })),
+  ).map((row, i) => ({
     ...row,
     id: activityIds.encode(activities[i].id),
   }))
@@ -260,8 +267,15 @@ export async function runDetection(
       let parsed: Record<string, unknown> = {}
       if (!cfg.scanOnly) {
         const candidateActivities = storage.activities.getByIds(candidate.activity_ids)
+        const promptCandidate = {
+          ...candidate,
+          title: scrubPII(candidate.title),
+          subject: scrubPII(candidate.subject),
+          description: scrubPII(candidate.description),
+          steps: candidate.steps.map(scrubPII),
+        }
         const groundPrompt = buildGroundingSystemPrompt(
-          candidate,
+          promptCandidate,
           deriveSightingApps(candidateActivities),
           candidate.activity_ids.map((id) => activityIds.encode(id)),
         )
@@ -269,18 +283,18 @@ export async function runDetection(
         const enrichedActivities = candidateActivities.map((a) => ({
           id: activityIds.encode(a.id),
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
           end_time: new Date(a.endTimestamp).toISOString(),
-          summary: a.summary,
+          summary: scrubPII(a.summary),
         }))
 
         const candidateInput = `Investigate this candidate task:\n\n\`\`\`json\n${JSON.stringify(
           {
-            title: candidate.title,
-            subject: candidate.subject,
-            description: candidate.description,
-            steps: candidate.steps,
+            title: promptCandidate.title,
+            subject: promptCandidate.subject,
+            description: promptCandidate.description,
+            steps: promptCandidate.steps,
             activities: enrichedActivities,
           },
           null,

--- a/src/main/services/task-miner/tools.ts
+++ b/src/main/services/task-miner/tools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { StorageService } from '../../storage'
 import type { ActivityEmbeddingService } from '@main/activity/activity-transformer-types'
 import type { PositionalAliases } from '@main/llm/id-codec'
+import { scrubPII } from '@/shared/sanitize'
 
 export function buildVerificationTools(
   storage: StorageService,
@@ -33,10 +34,10 @@ export function buildVerificationTools(
         return activities.map((a) => ({
           id: activityIds.encode(a.id),
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
-          summary: a.summary,
-          ocr_text: a.ocrText || '(no OCR text captured)',
+          summary: scrubPII(a.summary),
+          ocr_text: a.ocrText ? scrubPII(a.ocrText) : '(no OCR text captured)',
         }))
       },
     }),
@@ -58,10 +59,10 @@ export function buildVerificationTools(
         return results.map((a) => ({
           id: activityIds.encode(a.id),
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
           duration_min: Math.round((a.endTimestamp - a.startTimestamp) / 60000),
-          summary: a.summary,
+          summary: scrubPII(a.summary),
         }))
       },
     }),
@@ -94,11 +95,11 @@ export function buildVerificationTools(
         return activities.map((a) => ({
           id: activityIds.encode(a.id),
           app: a.appName,
-          window_title: a.windowTitle,
+          window_title: scrubPII(a.windowTitle),
           time: new Date(a.startTimestamp).toISOString(),
           end_time: new Date(a.endTimestamp).toISOString(),
           duration_min: Math.round((a.endTimestamp - a.startTimestamp) / 60000),
-          summary: a.summary,
+          summary: scrubPII(a.summary),
         }))
       },
     }),

--- a/src/main/services/user-context-builder.ts
+++ b/src/main/services/user-context-builder.ts
@@ -15,6 +15,7 @@ import type { StorageService, ActivityDetail } from '../storage'
 import type { InferenceProvider } from '../llm'
 import type { UserContext } from '../storage/user-context-repository'
 import { PATTERN_DETECTION_CONFIG, USER_CONTEXT_CONFIG } from '../../shared/constants'
+import { scrubPII } from '@/shared/sanitize'
 import log from '@main/utils/logger'
 
 // ---------------------------------------------------------------------------
@@ -92,7 +93,7 @@ function aggregateActivities(activities: ActivityDetail[]): AggregatedProfile {
       top_windows: [...stats.windows.entries()]
         .sort((a, b) => b[1] - a[1])
         .slice(0, 5)
-        .map(([title]) => title),
+        .map(([title]) => scrubPII(title)),
     }))
 
   // Sample up to 80 unique summaries evenly across the set
@@ -101,7 +102,7 @@ function aggregateActivities(activities: ActivityDetail[]): AggregatedProfile {
   const step = Math.max(1, Math.floor(allSummaries.length / maxSamples))
   const sample_summaries: string[] = []
   for (let i = 0; i < allSummaries.length && sample_summaries.length < maxSamples; i += step) {
-    sample_summaries.push(allSummaries[i])
+    sample_summaries.push(scrubPII(allSummaries[i]))
   }
 
   const totalMs = activities.reduce((sum, a) => sum + (a.endTimestamp - a.startTimestamp), 0)

--- a/src/shared/sanitize.test.ts
+++ b/src/shared/sanitize.test.ts
@@ -77,6 +77,19 @@ describe('scrubPII — Australian identifiers', () => {
     expect(scrubPII('BSB 062-000, account 12345678')).toBe('BSB 062-000, account [bank account]')
   })
 
+  it('redacts the account when only the BSB is labelled', () => {
+    expect(scrubPII('Remit to BSB 062-000, 12345678')).toBe('Remit to BSB 062-000, [bank account]')
+    expect(scrubPII('BSB 062-000 / 12345678')).toBe('BSB 062-000 / [bank account]')
+    expect(scrubPII('BSB 062-000 Acct 12345678')).toBe('BSB 062-000 Acct [bank account]')
+    expect(scrubPII('BSB 062-000 A/C 12345678')).toBe('BSB 062-000 A/C [bank account]')
+  })
+
+  it('keeps space-grouped money after a bank label', () => {
+    expect(scrubPII('Account 4 500 000 AUD in the ledger')).toBe(
+      'Account 4 500 000 AUD in the ledger',
+    )
+  })
+
   it('types passports, licences and Centrelink references', () => {
     expect(scrubPII('Passport PA0941234 expires soon')).toBe('Passport [id number] expires soon')
     expect(scrubPII('Drivers licence 04829173')).toBe('Drivers licence [id number]')
@@ -96,6 +109,11 @@ describe('scrubPII — New Zealand identifiers', () => {
   it('types IRD and NHI numbers', () => {
     expect(scrubPII('IRD 49-091-850')).toBe('IRD [ird number]')
     expect(scrubPII('NHI ZAC5361 on the referral')).toBe('NHI [nhi number] on the referral')
+  })
+
+  it('types a GST number but keeps a GST amount', () => {
+    expect(scrubPII('GST 49091850 filed')).toBe('GST [ird number] filed')
+    expect(scrubPII('GST 100 000 payable this quarter')).toBe('GST 100 000 payable this quarter')
   })
 
   it('detects an unlabelled IRD number by checksum and range', () => {
@@ -147,6 +165,13 @@ describe('scrubPII — universal classes', () => {
     )
     expect(scrubPII('DOB: 04/12/1985')).toBe('DOB: [redacted date of birth]')
     expect(scrubPII('Employee ID: EMP-04481')).toBe('Employee ID: [redacted employee id]')
+  })
+
+  it('leaves the sentence punctuation that follows a credential', () => {
+    expect(scrubPII('Set password: hunter42, then log in')).toBe(
+      'Set password: [redacted password], then log in',
+    )
+    expect(scrubPII('api_key: 9f8e7d6c5b4a.')).toBe('api_key: [redacted secret].')
   })
 
   it('requires a valid Luhn before claiming a payment card', () => {

--- a/src/shared/sanitize.test.ts
+++ b/src/shared/sanitize.test.ts
@@ -1,41 +1,191 @@
 import { describe, expect, it } from 'vitest'
-import { scrubPII } from './sanitize'
+import {
+  passesAbn,
+  passesAcn,
+  passesIrd,
+  passesLuhn,
+  passesMedicare,
+  passesNhi,
+  passesTfn,
+  scrubPII,
+} from './sanitize'
 
-describe('scrubPII', () => {
-  it('replaces email addresses with a typed slot', () => {
-    expect(scrubPII('email jane.doe@acme.co about it')).toBe('email [email address] about it')
+const OPENAI_KEY = 'sk-' + 'proj-Ab12Cd34Ef56Gh78Ij90'
+const GH_TOKEN = 'ghp_' + 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4'
+const GH_PAT = 'github_pat_' + '11ABCDEFG0abcdefghijklmnop'
+const AWS_KEY_ID = 'AKIA' + 'IOSFODNN7EXAMPLE'
+const JWT = 'eyJ' + 'hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9P'
+
+describe('checksum validators', () => {
+  it('accepts published valid numbers and rejects one-digit variants', () => {
+    expect(passesAbn('51 824 753 556')).toBe(true)
+    expect(passesAbn('51 824 753 557')).toBe(false)
+
+    expect(passesAcn('004 085 616')).toBe(true)
+    expect(passesAcn('004 085 617')).toBe(false)
+
+    expect(passesTfn('123 456 782')).toBe(true)
+    expect(passesTfn('123 456 789')).toBe(false)
+
+    expect(passesMedicare('2123 45670 1')).toBe(true)
+    expect(passesMedicare('2123 45671 1')).toBe(false)
+
+    expect(passesIrd('49-091-850')).toBe(true)
+    expect(passesIrd('49-091-851')).toBe(false)
+
+    expect(passesNhi('ZAC5361')).toBe(true)
+    expect(passesNhi('ZAC5362')).toBe(false)
+
+    expect(passesLuhn('4111111111111111')).toBe(true)
+    expect(passesLuhn('4111111111111112')).toBe(false)
   })
 
-  it('replaces phone numbers in common formats', () => {
-    expect(scrubPII('call +1 (555) 123-4567 now')).toBe('call [phone number] now')
-    expect(scrubPII('555-123-4567')).toBe('[phone number]')
+  it('rejects numbers of the wrong length or out of the issued range', () => {
+    expect(passesTfn('12 345 678')).toBe(false)
+    expect(passesAbn('51 824 753 55')).toBe(false)
+    expect(passesMedicare('2123 4567')).toBe(false)
+    expect(passesIrd('12-345-678')).toBe(false)
   })
 
-  it('replaces long identifier runs', () => {
-    expect(scrubPII('order 100294 shipped')).toBe('order [id number] shipped')
+  it('rejects Medicare numbers outside the published first-digit range', () => {
+    expect(passesMedicare('1123 45670 1')).toBe(false)
+    expect(passesMedicare('7123 45670 1')).toBe(false)
   })
 
-  it('preserves ordinary numbers in prose', () => {
-    expect(scrubPII('4 steps, top 10 results')).toBe('4 steps, top 10 results')
-    expect(scrubPII('sorted by rating')).toBe('sorted by rating')
+  it('treats the Medicare IRN as outside the checksum', () => {
+    expect(passesMedicare('2123 45670 1')).toBe(true)
+    expect(passesMedicare('2123 45670 9')).toBe(true)
+  })
+})
+
+describe('scrubPII — Australian identifiers', () => {
+  it('types tax file and Medicare numbers', () => {
+    expect(scrubPII('Tax file number 123 456 782')).toBe('Tax file number [tax file number]')
+    expect(scrubPII('TFN: 123456782')).toBe('TFN: [tax file number]')
+    expect(scrubPII('Medicare 2123 45670 1')).toBe('Medicare [medicare number]')
   })
 
-  it('preserves dates and year ranges', () => {
-    expect(scrubPII('filter to 2026-07-19')).toBe('filter to 2026-07-19')
-    expect(scrubPII('the 2026/7/9 export')).toBe('the 2026/7/9 export')
-    expect(scrubPII('fiscal year 2024-2025 report')).toBe('fiscal year 2024-2025 report')
-    expect(scrubPII('due 19.07.2026')).toBe('due 19.07.2026')
-    expect(scrubPII('due 19. 7. 2026')).toBe('due 19. 7. 2026')
+  it('detects an unlabelled Medicare number by checksum', () => {
+    expect(scrubPII('card shows 2123 45670 1 on it')).toBe('card shows [medicare number] on it')
   })
 
-  it('preserves space-grouped amounts but still scrubs spaced phones', () => {
-    expect(scrubPII('budgets over 1 000 000')).toBe('budgets over 1 000 000')
-    expect(scrubPII('call 777 123 456')).toBe('call [phone number]')
-    expect(scrubPII('call +420 777 123 456')).toBe('call [phone number]')
+  it('leaves an unlabelled nine-digit run alone rather than guessing TFN', () => {
+    expect(scrubPII('batch 123 456 782 processed')).toBe('batch 123 456 782 processed')
   })
 
-  it('leaves clean recipe text untouched', () => {
-    const text = 'Open the customer thread in Gmail (mail.google.com) and read the latest reply.'
+  it('redacts an account number but keeps the BSB', () => {
+    expect(scrubPII('BSB 062-000, account 12345678')).toBe('BSB 062-000, account [bank account]')
+  })
+
+  it('types passports, licences and Centrelink references', () => {
+    expect(scrubPII('Passport PA0941234 expires soon')).toBe('Passport [id number] expires soon')
+    expect(scrubPII('Drivers licence 04829173')).toBe('Drivers licence [id number]')
+    expect(scrubPII('Centrelink CRN 203 456 789A is on file')).toBe(
+      'Centrelink [id number] is on file',
+    )
+  })
+
+  it('matches Australian phone formats', () => {
+    expect(scrubPII('call +61 412 345 678 now')).toBe('call [phone number] now')
+    expect(scrubPII('call 0412 987 654 now')).toBe('call [phone number] now')
+    expect(scrubPII('call 03 9876 5432 now')).toBe('call [phone number] now')
+  })
+})
+
+describe('scrubPII — New Zealand identifiers', () => {
+  it('types IRD and NHI numbers', () => {
+    expect(scrubPII('IRD 49-091-850')).toBe('IRD [ird number]')
+    expect(scrubPII('NHI ZAC5361 on the referral')).toBe('NHI [nhi number] on the referral')
+  })
+
+  it('detects an unlabelled IRD number by checksum and range', () => {
+    expect(scrubPII('files under 136-410-132 this year')).toBe(
+      'files under [ird number] this year',
+    )
+  })
+
+  it('types a New Zealand bank account', () => {
+    expect(scrubPII('paid into 01-0123-0123456-00')).toBe('paid into [bank account]')
+  })
+
+  it('matches New Zealand phone formats', () => {
+    expect(scrubPII('call +64 21 555 0134 now')).toBe('call [phone number] now')
+    expect(scrubPII('call 021 555 0198 now')).toBe('call [phone number] now')
+  })
+})
+
+describe('scrubPII — company identifiers stay', () => {
+  it('keeps ABN, ACN and NZBN — public registry data carrying org signal', () => {
+    expect(scrubPII('Harbourline trades as ABN 51 824 753 556')).toBe(
+      'Harbourline trades as ABN 51 824 753 556',
+    )
+    expect(scrubPII('ACN 004 085 616 on the invoice')).toBe('ACN 004 085 616 on the invoice')
+    expect(scrubPII('NZBN 9429041234567 registered')).toBe('NZBN 9429041234567 registered')
+  })
+
+  it('keeps a valid ABN even unlabelled, where a bare digit rule would redact it', () => {
+    expect(scrubPII('supplier 51 824 753 556 approved')).toBe('supplier 51 824 753 556 approved')
+  })
+})
+
+describe('scrubPII — universal classes', () => {
+  it('replaces secret-shaped tokens', () => {
+    expect(scrubPII(`export OPENAI_API_KEY=${OPENAI_KEY}`)).toBe(
+      'export OPENAI_API_KEY=[redacted secret]',
+    )
+    expect(scrubPII(`git push with ${GH_TOKEN}`)).toBe('git push with [redacted secret]')
+    expect(scrubPII(`token ${GH_PAT} created`)).toBe('token [redacted secret] created')
+    expect(scrubPII(`aws configure ${AWS_KEY_ID}`)).toBe('aws configure [redacted secret]')
+    expect(scrubPII(`Authorization: Bearer ${JWT}`)).toBe('Authorization: Bearer [redacted secret]')
+  })
+
+  it('replaces labeled secrets, passwords, birth dates and employee ids', () => {
+    expect(scrubPII('api_key: 9f8e7d6c5b4a')).toBe('api_key: [redacted secret]')
+    expect(scrubPII('password: Tr0ub4dor&3')).toBe('password: [redacted password]')
+    expect(scrubPII('Temporary password\nSumm3r!2026\nChange it')).toBe(
+      'Temporary password\n[redacted password]\nChange it',
+    )
+    expect(scrubPII('DOB: 04/12/1985')).toBe('DOB: [redacted date of birth]')
+    expect(scrubPII('Employee ID: EMP-04481')).toBe('Employee ID: [redacted employee id]')
+  })
+
+  it('requires a valid Luhn before claiming a payment card', () => {
+    expect(scrubPII('card 4111 1111 1111 1111')).toBe('card [payment card]')
+    expect(scrubPII('batch 4820 1174 9930 2217 shipped')).toBe('batch 4820 1174 9930 2217 shipped')
+  })
+
+  it('replaces US social security numbers', () => {
+    expect(scrubPII('SSN 078-05-1120')).toBe('SSN [id number]')
+  })
+})
+
+describe('scrubPII — what must survive', () => {
+  it('keeps names and emails, the client-vs-internal signal', () => {
+    expect(scrubPII('sarah.chen@harbourline.com.au asked Tom Whitaker to sign')).toBe(
+      'sarah.chen@harbourline.com.au asked Tom Whitaker to sign',
+    )
+  })
+
+  it('keeps technical identifiers', () => {
+    const text =
+      'Ticket DEU-205 on 3f2a9c1e-7b44-4d0a-9e21-8c5f6b0d1234, log memorylane-2026-08-06T11-42-07.log, ' +
+      'host 10.0.14.203:5432, build v1.5.5-alpha.2, commit 67221f6'
     expect(scrubPII(text)).toBe(text)
+  })
+
+  it('keeps ordinary business numbers and prose', () => {
+    expect(scrubPII('processed 1 000 000 rows in 4 steps')).toBe(
+      'processed 1 000 000 rows in 4 steps',
+    )
+    expect(scrubPII('Q3 2026 revenue 12 500 AUD, up 15%')).toBe('Q3 2026 revenue 12 500 AUD, up 15%')
+    expect(scrubPII('container limit 8192 MB, exit code 137')).toBe(
+      'container limit 8192 MB, exit code 137',
+    )
+    expect(scrubPII('NetSuite > Payables > Harbourline')).toBe('NetSuite > Payables > Harbourline')
+    expect(scrubPII('INV-2026-0417 due 2026-04-01')).toBe('INV-2026-0417 due 2026-04-01')
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(scrubPII('')).toBe('')
   })
 })

--- a/src/shared/sanitize.test.ts
+++ b/src/shared/sanitize.test.ts
@@ -94,7 +94,7 @@ describe('scrubPII — Australian identifiers', () => {
     expect(scrubPII('Passport PA0941234 expires soon')).toBe('Passport [id number] expires soon')
     expect(scrubPII('Drivers licence 04829173')).toBe('Drivers licence [id number]')
     expect(scrubPII('Centrelink CRN 203 456 789A is on file')).toBe(
-      'Centrelink [id number] is on file',
+      'Centrelink CRN [id number] is on file',
     )
   })
 
@@ -144,6 +144,14 @@ describe('scrubPII — company identifiers stay', () => {
   it('keeps a valid ABN even unlabelled, where a bare digit rule would redact it', () => {
     expect(scrubPII('supplier 51 824 753 556 approved')).toBe('supplier 51 824 753 556 approved')
   })
+
+  it('redacts a labelled identifier that also satisfies a company checksum', () => {
+    expect(passesTfn('100000182') && passesAcn('100000182')).toBe(true)
+    expect(scrubPII('Tax file number 100000182')).toBe('Tax file number [tax file number]')
+    expect(scrubPII('Tax file number 100 000 182')).toBe('Tax file number [tax file number]')
+    expect(passesAbn('51824753556')).toBe(true)
+    expect(scrubPII('Account number 51824753556')).toBe('Account number [bank account]')
+  })
 })
 
 describe('scrubPII — universal classes', () => {
@@ -172,6 +180,12 @@ describe('scrubPII — universal classes', () => {
       'Set password: [redacted password], then log in',
     )
     expect(scrubPII('api_key: 9f8e7d6c5b4a.')).toBe('api_key: [redacted secret].')
+  })
+
+  it('redacts the value, not the label, when the value repeats the label', () => {
+    expect(scrubPII('password: password')).toBe('password: [redacted password]')
+    expect(scrubPII('pass = pass')).toBe('pass = [redacted password]')
+    expect(scrubPII('api_key: api_key123')).toBe('api_key: [redacted secret]')
   })
 
   it('requires a valid Luhn before claiming a payment card', () => {

--- a/src/shared/sanitize.ts
+++ b/src/shared/sanitize.ts
@@ -9,7 +9,10 @@
  *
  * Rules are claimed in table order over the original text; the first rule to
  * claim a span wins and later rules cannot re-match it. `keep` rules claim a
- * span precisely so a looser rule below cannot redact it.
+ * span precisely so a looser rule below cannot redact it. Every labelled rule
+ * claims before any shape rule: a written label is stronger evidence than a
+ * checksum, so "Tax file number <n>" redacts even when <n> also satisfies the
+ * bare ACN check.
  */
 
 interface Rule {
@@ -109,17 +112,15 @@ const labelled = (labels: string, value: string): RegExp =>
 
 const NUMERIC_VALUE = '\\d[\\d \\-]{5,22}\\d'
 const ALNUM_VALUE =
-  '[A-Za-z0-9][A-Za-z0-9-]*(?:[ ][A-Za-z0-9-]*\\d[A-Za-z0-9-]*){0,4}(?:[ ][A-Za-z]\\b)?'
+  '[A-Za-z0-9-]*\\d[A-Za-z0-9-]*(?:[ ][A-Za-z0-9-]*\\d[A-Za-z0-9-]*){0,4}(?:[ ][A-Za-z]\\b)?'
 
 const DATE_LIKE =
   /^\d{4}([-/.])\d{1,2}(?:\1\d{1,2})?$|^\d{1,2}([./-])\s?\d{1,2}\2\s?\d{4}$|^\d{4}-\d{4}$/
 const DOTTED_QUAD = /^\d{1,3}(?:\.\d{1,3}){3}$/
 const GROUPED_AMOUNT = /^\d{1,3}(?: \d{3})+$/
 
-const RULES: Rule[] = [
-  { slot: '', keep: true, pattern: /\b\d{2} ?\d{3} ?\d{3} ?\d{3}\b/g, validate: passesAbn },
+const LABELLED_RULES: Rule[] = [
   { slot: '', keep: true, pattern: labelled('abn|australian business number', NUMERIC_VALUE) },
-  { slot: '', keep: true, pattern: /\b\d{3} ?\d{3} ?\d{3}\b/g, validate: passesAcn },
   { slot: '', keep: true, pattern: labelled('acn|australian company number', NUMERIC_VALUE) },
   { slot: '', keep: true, pattern: labelled('nzbn', NUMERIC_VALUE) },
   { slot: '', keep: true, pattern: /\bBSB:? ?\d{3}[- ]?\d{3}\b(?![- ]?\d)/gi },
@@ -157,8 +158,6 @@ const RULES: Rule[] = [
       /\b(?:employee|badge|worker|staff|emp)\s*(?:id|no|number)?\.?\s*[:#]?\s*((?=[A-Za-z0-9-]*\d{4})[A-Za-z0-9-]{4,})/gi,
   },
 
-  { slot: '[bank account]', pattern: /\b\d{2}-\d{4}-\d{7}-\d{2,3}\b/g },
-  { slot: '[bank account]', pattern: /\b\d{3}[- ]\d{3}[ ,/]+(\d{6,10})\b/g },
   {
     slot: '[bank account]',
     pattern: labelled(
@@ -169,29 +168,12 @@ const RULES: Rule[] = [
   },
   { slot: '[bank account]', pattern: labelled('iban|swift|bic', ALNUM_VALUE), validate: hasDigit },
 
-  {
-    slot: '[medicare number]',
-    pattern: /\b\d{4} ?\d{5} ?\d(?: ?\d)?\b/g,
-    validate: passesMedicare,
-  },
   { slot: '[medicare number]', pattern: labelled('medicare', NUMERIC_VALUE) },
   { slot: '[tax file number]', pattern: labelled('tfn|tax file', NUMERIC_VALUE) },
-  { slot: '[ird number]', pattern: /\b\d{2,3}[- ]\d{3}[- ]\d{3}\b/g, validate: passesIrd },
   { slot: '[ird number]', pattern: labelled('ird', NUMERIC_VALUE) },
   { slot: '[ird number]', pattern: labelled('gst', NUMERIC_VALUE), validate: passesIrd },
-  { slot: '[nhi number]', pattern: /\b[A-HJ-NP-Z]{3}\d{4}\b/g, validate: passesNhi },
   { slot: '[nhi number]', pattern: labelled('nhi', ALNUM_VALUE), validate: hasDigit },
 
-  {
-    slot: '[payment card]',
-    bounded: true,
-    pattern: /\b\d(?:[ -]?\d){12,18}\b/g,
-    validate: (v) => {
-      const d = digitsOf(v)
-      return d.length >= 13 && d.length <= 19 && passesLuhn(d)
-    },
-  },
-  { slot: '[id number]', pattern: /\b\d{3}[- ]\d{2}[- ]\d{4}\b/g },
   { slot: '[id number]', pattern: labelled('ssn|social security|taxpayer id', NUMERIC_VALUE) },
   {
     slot: '[id number]',
@@ -206,6 +188,34 @@ const RULES: Rule[] = [
     slot: '[phone number]',
     pattern: labelled('tel|telephone|phone|mobile|mob|cell|fax|direct line', NUMERIC_VALUE),
   },
+]
+
+const SHAPE_RULES: Rule[] = [
+  { slot: '', keep: true, pattern: /\b\d{2} ?\d{3} ?\d{3} ?\d{3}\b/g, validate: passesAbn },
+  { slot: '', keep: true, pattern: /\b\d{3} ?\d{3} ?\d{3}\b/g, validate: passesAcn },
+
+  { slot: '[bank account]', pattern: /\b\d{2}-\d{4}-\d{7}-\d{2,3}\b/g },
+  { slot: '[bank account]', pattern: /\b\d{3}[- ]\d{3}[ ,/]+(\d{6,10})\b/g },
+
+  {
+    slot: '[medicare number]',
+    pattern: /\b\d{4} ?\d{5} ?\d(?: ?\d)?\b/g,
+    validate: passesMedicare,
+  },
+  { slot: '[ird number]', pattern: /\b\d{2,3}[- ]\d{3}[- ]\d{3}\b/g, validate: passesIrd },
+  { slot: '[nhi number]', pattern: /\b[A-HJ-NP-Z]{3}\d{4}\b/g, validate: passesNhi },
+
+  {
+    slot: '[payment card]',
+    bounded: true,
+    pattern: /\b\d(?:[ -]?\d){12,18}\b/g,
+    validate: (v) => {
+      const d = digitsOf(v)
+      return d.length >= 13 && d.length <= 19 && passesLuhn(d)
+    },
+  },
+  { slot: '[id number]', pattern: /\b\d{3}[- ]\d{2}[- ]\d{4}\b/g },
+
   {
     slot: '[phone number]',
     bounded: true,
@@ -218,7 +228,7 @@ const RULES: Rule[] = [
   {
     slot: '[phone number]',
     bounded: true,
-    pattern: /\+?\d[\d\s().-]{5,22}\d/g,
+    pattern: /(?:\+\d|\(\d{2,4}\)|\b\d{3}[ .-]\d{3}[ .-]\d{2,4}\b)(?:[\d\s().-]{0,18}\d)?/g,
     validate: (v) => {
       if (/^[\d ]+$/.test(v)) return false
       const d = digitsOf(v)
@@ -226,6 +236,14 @@ const RULES: Rule[] = [
     },
   },
 ]
+
+const withIndices = (pattern: RegExp): RegExp =>
+  pattern.flags.includes('d') ? pattern : new RegExp(pattern.source, `${pattern.flags}d`)
+
+const RULES: Rule[] = [...LABELLED_RULES, ...SHAPE_RULES].map((rule) => ({
+  ...rule,
+  pattern: withIndices(rule.pattern),
+}))
 
 const isIdentifierBound = (s: string, start: number, end: number): boolean => {
   for (let i = start - 1; i >= 0 && /[\w-]/.test(s[i]); i--) {
@@ -258,8 +276,10 @@ export function scrubPII(text: string): string {
         rule.pattern.lastIndex++
         continue
       }
-      const matched = m[1] ?? m[0]
-      const start = m[1] === undefined ? m.index : m.index + m[0].indexOf(m[1])
+      const bounds = m.indices?.[1] ?? m.indices?.[0]
+      if (!bounds) continue
+      const [start] = bounds
+      const matched = text.slice(bounds[0], bounds[1])
       const value = matched.replace(/[.,;:!?]+$/, '') || matched
       const end = start + value.length
       if (overlaps(start, end)) continue

--- a/src/shared/sanitize.ts
+++ b/src/shared/sanitize.ts
@@ -114,6 +114,7 @@ const ALNUM_VALUE =
 const DATE_LIKE =
   /^\d{4}([-/.])\d{1,2}(?:\1\d{1,2})?$|^\d{1,2}([./-])\s?\d{1,2}\2\s?\d{4}$|^\d{4}-\d{4}$/
 const DOTTED_QUAD = /^\d{1,3}(?:\.\d{1,3}){3}$/
+const GROUPED_AMOUNT = /^\d{1,3}(?: \d{3})+$/
 
 const RULES: Rule[] = [
   { slot: '', keep: true, pattern: /\b\d{2} ?\d{3} ?\d{3} ?\d{3}\b/g, validate: passesAbn },
@@ -157,13 +158,14 @@ const RULES: Rule[] = [
   },
 
   { slot: '[bank account]', pattern: /\b\d{2}-\d{4}-\d{7}-\d{2,3}\b/g },
-  { slot: '[bank account]', pattern: /\b\d{3}[- ]\d{3}[ ,]+\d{6,10}\b/g },
+  { slot: '[bank account]', pattern: /\b\d{3}[- ]\d{3}[ ,/]+(\d{6,10})\b/g },
   {
     slot: '[bank account]',
     pattern: labelled(
-      'bsb(?: and)?(?: account)?|bank account|account|routing|aba',
+      'bsb(?: and)?(?: account)?|bank account|account|acct|acc|a/c|routing|aba',
       NUMERIC_VALUE,
     ),
+    validate: (v) => !GROUPED_AMOUNT.test(v.trim()),
   },
   { slot: '[bank account]', pattern: labelled('iban|swift|bic', ALNUM_VALUE), validate: hasDigit },
 
@@ -175,7 +177,8 @@ const RULES: Rule[] = [
   { slot: '[medicare number]', pattern: labelled('medicare', NUMERIC_VALUE) },
   { slot: '[tax file number]', pattern: labelled('tfn|tax file', NUMERIC_VALUE) },
   { slot: '[ird number]', pattern: /\b\d{2,3}[- ]\d{3}[- ]\d{3}\b/g, validate: passesIrd },
-  { slot: '[ird number]', pattern: labelled('ird|gst', NUMERIC_VALUE) },
+  { slot: '[ird number]', pattern: labelled('ird', NUMERIC_VALUE) },
+  { slot: '[ird number]', pattern: labelled('gst', NUMERIC_VALUE), validate: passesIrd },
   { slot: '[nhi number]', pattern: /\b[A-HJ-NP-Z]{3}\d{4}\b/g, validate: passesNhi },
   { slot: '[nhi number]', pattern: labelled('nhi', ALNUM_VALUE), validate: hasDigit },
 
@@ -255,8 +258,9 @@ export function scrubPII(text: string): string {
         rule.pattern.lastIndex++
         continue
       }
-      const value = m[1] ?? m[0]
+      const matched = m[1] ?? m[0]
       const start = m[1] === undefined ? m.index : m.index + m[0].indexOf(m[1])
+      const value = matched.replace(/[.,;:!?]+$/, '') || matched
       const end = start + value.length
       if (overlaps(start, end)) continue
       if (rule.validate && !rule.validate(value)) continue

--- a/src/shared/sanitize.ts
+++ b/src/shared/sanitize.ts
@@ -1,30 +1,275 @@
 /**
- * Deterministic PII scrub — the regex backstop behind the LLM's de-identification
- * (the model handles names; this catches emails, phone numbers, and long id runs).
- * Typed slot names instead of [redacted] so the recipe still says what goes there.
- * Conservative by design: must never mangle prose like "4 steps" or dates, and
- * every quantifier is bounded so matching stays linear.
+ * Deterministic PII scrub for AU/NZ corpora.
+ *
+ * Policy: redact identifiers that carry no added value, keep what carries
+ * semantic role. Names, emails and company identifiers (ABN/ACN/NZBN) stay —
+ * they are how a sighting reads as client work rather than internal work.
+ * Personal identifiers become a typed slot naming the class, so a recipe still
+ * says what belongs there.
+ *
+ * Rules are claimed in table order over the original text; the first rule to
+ * claim a span wins and later rules cannot re-match it. `keep` rules claim a
+ * span precisely so a looser rule below cannot redact it.
  */
 
-const EMAIL =
-  /\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9-]{1,63}(?:\.[A-Za-z0-9-]{1,63}){0,4}\.[A-Za-z]{2,24}\b/g
-// Capped at realistic phone length; digit count and date shape re-checked in the replacer.
-const PHONE_LIKE = /\+?\d[\d\s().-]{5,22}\d/g
-const LONG_DIGITS = /\b\d{5,}\b/g
-// 2026-07-19, 2026/7/9, 19.07.2026, 19. 7. 2026, and year ranges like 2024-2025.
+interface Rule {
+  slot: string
+  pattern: RegExp
+  validate?: (value: string) => boolean
+  bounded?: boolean
+  keep?: boolean
+}
+
+const digitsOf = (s: string): string => s.replace(/\D/g, '')
+
+const hasDigit = (s: string): boolean => /\d/.test(s)
+
+const weightedSum = (digits: string, weights: readonly number[]): number =>
+  weights.reduce((sum, w, i) => sum + w * (digits.charCodeAt(i) - 48), 0)
+
+export const passesLuhn = (digits: string): boolean => {
+  let sum = 0
+  let double = false
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48
+    if (double) {
+      d *= 2
+      if (d > 9) d -= 9
+    }
+    sum += d
+    double = !double
+  }
+  return sum % 10 === 0
+}
+
+export const passesTfn = (value: string): boolean => {
+  const d = digitsOf(value)
+  return d.length === 9 && weightedSum(d, [1, 4, 3, 7, 5, 8, 6, 9, 10]) % 11 === 0
+}
+
+export const passesAbn = (value: string): boolean => {
+  const d = digitsOf(value)
+  if (d.length !== 11) return false
+  const adjusted = String(Number(d[0]) - 1) + d.slice(1)
+  return weightedSum(adjusted, [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19]) % 89 === 0
+}
+
+export const passesAcn = (value: string): boolean => {
+  const d = digitsOf(value)
+  if (d.length !== 9) return false
+  const sum = weightedSum(d, [8, 7, 6, 5, 4, 3, 2, 1])
+  return (10 - (sum % 10)) % 10 === Number(d[8])
+}
+
+export const passesMedicare = (value: string): boolean => {
+  const d = digitsOf(value)
+  if (d.length !== 10 && d.length !== 11) return false
+  if (d[0] < '2' || d[0] > '6') return false
+  return weightedSum(d, [1, 3, 7, 9, 1, 3, 7, 9]) % 10 === Number(d[8])
+}
+
+export const passesIrd = (value: string): boolean => {
+  const d = digitsOf(value)
+  if (d.length !== 8 && d.length !== 9) return false
+  const n = Number(d)
+  if (n < 10_000_000 || n > 200_000_000) return false
+  const base = d.slice(0, -1).padStart(8, '0')
+  const check = Number(d[d.length - 1])
+  const calc = (weights: readonly number[]): number => {
+    const rem = weightedSum(base, weights) % 11
+    return rem === 0 ? 0 : 11 - rem
+  }
+  const first = calc([3, 2, 7, 6, 5, 4, 3, 2])
+  if (first !== 10) return first === check
+  return calc([7, 4, 3, 2, 5, 2, 7, 6]) === check
+}
+
+const NHI_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ'
+
+export const passesNhi = (value: string): boolean => {
+  const v = value.toUpperCase().replace(/\s/g, '')
+  if (!/^[A-HJ-NP-Z]{3}\d{4}$/.test(v)) return false
+  let sum = 0
+  for (let i = 0; i < 6; i++) {
+    const ch = v[i]
+    const val = ch >= '0' && ch <= '9' ? Number(ch) : NHI_ALPHABET.indexOf(ch) + 1
+    if (val <= 0 && !(ch >= '0' && ch <= '9')) return false
+    sum += val * (7 - i)
+  }
+  const rem = sum % 11
+  if (rem === 0) return false
+  const check = 11 - rem
+  return (check === 10 ? 0 : check) === Number(v[6])
+}
+
+const LABEL_SUFFIX =
+  '\\)?\\s*(?:number|no|nr|#|declaration|form|details|record|is|reads|shows)?\\.?\\s*[:#=]?\\s*'
+const labelled = (labels: string, value: string): RegExp =>
+  new RegExp(`\\b(?:${labels})${LABEL_SUFFIX}(${value})`, 'gi')
+
+const NUMERIC_VALUE = '\\d[\\d \\-]{5,22}\\d'
+const ALNUM_VALUE =
+  '[A-Za-z0-9][A-Za-z0-9-]*(?:[ ][A-Za-z0-9-]*\\d[A-Za-z0-9-]*){0,4}(?:[ ][A-Za-z]\\b)?'
+
 const DATE_LIKE =
   /^\d{4}([-/.])\d{1,2}(?:\1\d{1,2})?$|^\d{1,2}([./-])\s?\d{1,2}\2\s?\d{4}$|^\d{4}-\d{4}$/
+const DOTTED_QUAD = /^\d{1,3}(?:\.\d{1,3}){3}$/
 
-const countDigits = (s: string): number => s.match(/\d/g)?.length ?? 0
+const RULES: Rule[] = [
+  { slot: '', keep: true, pattern: /\b\d{2} ?\d{3} ?\d{3} ?\d{3}\b/g, validate: passesAbn },
+  { slot: '', keep: true, pattern: labelled('abn|australian business number', NUMERIC_VALUE) },
+  { slot: '', keep: true, pattern: /\b\d{3} ?\d{3} ?\d{3}\b/g, validate: passesAcn },
+  { slot: '', keep: true, pattern: labelled('acn|australian company number', NUMERIC_VALUE) },
+  { slot: '', keep: true, pattern: labelled('nzbn', NUMERIC_VALUE) },
+  { slot: '', keep: true, pattern: /\bBSB:? ?\d{3}[- ]?\d{3}\b(?![- ]?\d)/gi },
+
+  {
+    slot: '[redacted secret]',
+    pattern:
+      /\b(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[A-Z0-9]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{8,})\b/g,
+  },
+  {
+    slot: '[redacted secret]',
+    pattern:
+      /\b[A-Za-z0-9_.-]*(?:secret|token|api[_-]?key|apikey|access[_-]?key|private[_-]?key)\b\s*[:=]\s*(?!\[)(\S{6,})/gi,
+  },
+  {
+    slot: '[redacted password]',
+    pattern: /\b(?:password|passwd|passphrase|pwd|pass)\s*[:=]\s*(?!\[)(\S{4,})/gi,
+  },
+  {
+    slot: '[redacted password]',
+    pattern: /\b(?:password|passphrase)\s+(?!\[)((?=\S*[\d#!@$%^&*+=])\S{6,})/gi,
+  },
+  {
+    slot: '[redacted password]',
+    pattern: /\b(?:password|passwd|passphrase)\s*\n\s*(?!\[)((?=\S*[\d#!@$%^&*+=])\S{6,})/gi,
+  },
+  {
+    slot: '[redacted date of birth]',
+    pattern:
+      /\b(?:date of birth|birth ?date|dob|born(?: on)?)\s*[:=]?\s*(?:(?:to|is)\s+)?((?:\d{1,2}[/. -]){2}\d{2,4}|\d{4}-\d{2}-\d{2}|(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.? \d{1,2},? \d{4})/gi,
+  },
+  {
+    slot: '[redacted employee id]',
+    pattern:
+      /\b(?:employee|badge|worker|staff|emp)\s*(?:id|no|number)?\.?\s*[:#]?\s*((?=[A-Za-z0-9-]*\d{4})[A-Za-z0-9-]{4,})/gi,
+  },
+
+  { slot: '[bank account]', pattern: /\b\d{2}-\d{4}-\d{7}-\d{2,3}\b/g },
+  { slot: '[bank account]', pattern: /\b\d{3}[- ]\d{3}[ ,]+\d{6,10}\b/g },
+  {
+    slot: '[bank account]',
+    pattern: labelled(
+      'bsb(?: and)?(?: account)?|bank account|account|routing|aba',
+      NUMERIC_VALUE,
+    ),
+  },
+  { slot: '[bank account]', pattern: labelled('iban|swift|bic', ALNUM_VALUE), validate: hasDigit },
+
+  {
+    slot: '[medicare number]',
+    pattern: /\b\d{4} ?\d{5} ?\d(?: ?\d)?\b/g,
+    validate: passesMedicare,
+  },
+  { slot: '[medicare number]', pattern: labelled('medicare', NUMERIC_VALUE) },
+  { slot: '[tax file number]', pattern: labelled('tfn|tax file', NUMERIC_VALUE) },
+  { slot: '[ird number]', pattern: /\b\d{2,3}[- ]\d{3}[- ]\d{3}\b/g, validate: passesIrd },
+  { slot: '[ird number]', pattern: labelled('ird|gst', NUMERIC_VALUE) },
+  { slot: '[nhi number]', pattern: /\b[A-HJ-NP-Z]{3}\d{4}\b/g, validate: passesNhi },
+  { slot: '[nhi number]', pattern: labelled('nhi', ALNUM_VALUE), validate: hasDigit },
+
+  {
+    slot: '[payment card]',
+    bounded: true,
+    pattern: /\b\d(?:[ -]?\d){12,18}\b/g,
+    validate: (v) => {
+      const d = digitsOf(v)
+      return d.length >= 13 && d.length <= 19 && passesLuhn(d)
+    },
+  },
+  { slot: '[id number]', pattern: /\b\d{3}[- ]\d{2}[- ]\d{4}\b/g },
+  { slot: '[id number]', pattern: labelled('ssn|social security|taxpayer id', NUMERIC_VALUE) },
+  {
+    slot: '[id number]',
+    pattern: labelled(
+      "passport|driver'?s?\\s*licen[cs]e|licen[cs]e|crn|customer reference|centrelink|visa grant|medicare provider",
+      ALNUM_VALUE,
+    ),
+    validate: hasDigit,
+  },
+
+  {
+    slot: '[phone number]',
+    pattern: labelled('tel|telephone|phone|mobile|mob|cell|fax|direct line', NUMERIC_VALUE),
+  },
+  {
+    slot: '[phone number]',
+    bounded: true,
+    pattern: /(?:\+6[14][ -]?\(?0?\)?[ -]?|\b0)[2-9](?:[ -]?\d){7,9}\b/g,
+    validate: (v) => {
+      const d = digitsOf(v)
+      return d.length >= 9 && d.length <= 12 && !DATE_LIKE.test(v) && !DOTTED_QUAD.test(v)
+    },
+  },
+  {
+    slot: '[phone number]',
+    bounded: true,
+    pattern: /\+?\d[\d\s().-]{5,22}\d/g,
+    validate: (v) => {
+      if (/^[\d ]+$/.test(v)) return false
+      const d = digitsOf(v)
+      return d.length >= 7 && d.length <= 15 && !DATE_LIKE.test(v) && !DOTTED_QUAD.test(v)
+    },
+  },
+]
+
+const isIdentifierBound = (s: string, start: number, end: number): boolean => {
+  for (let i = start - 1; i >= 0 && /[\w-]/.test(s[i]); i--) {
+    if (/[A-Za-z_]/.test(s[i])) return true
+  }
+  for (let j = end; j < s.length && /[\w-]/.test(s[j]); j++) {
+    if (/[A-Za-z_]/.test(s[j])) return true
+  }
+  return false
+}
+
+interface Claim {
+  start: number
+  end: number
+  slot: string
+  keep: boolean
+}
 
 export function scrubPII(text: string): string {
-  return text
-    .replace(EMAIL, '[email address]')
-    .replace(PHONE_LIKE, (m) => {
-      // Digit-and-space-only runs need 9+ digits so spaced amounts like
-      // "1 000 000" survive; real spaced phones (CZ "777 123 456") still hit 9.
-      const minDigits = /^[\d\s]+$/.test(m) ? 9 : 7
-      return countDigits(m) >= minDigits && !DATE_LIKE.test(m) ? '[phone number]' : m
-    })
-    .replace(LONG_DIGITS, '[id number]')
+  if (!text) return text
+  const claims: Claim[] = []
+  const overlaps = (start: number, end: number): boolean =>
+    claims.some((c) => start < c.end && end > c.start)
+
+  for (const rule of RULES) {
+    rule.pattern.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = rule.pattern.exec(text)) !== null) {
+      if (m[0] === '') {
+        rule.pattern.lastIndex++
+        continue
+      }
+      const value = m[1] ?? m[0]
+      const start = m[1] === undefined ? m.index : m.index + m[0].indexOf(m[1])
+      const end = start + value.length
+      if (overlaps(start, end)) continue
+      if (rule.validate && !rule.validate(value)) continue
+      if (rule.bounded && isIdentifierBound(text, start, end)) continue
+      claims.push({ start, end, slot: rule.slot, keep: rule.keep === true })
+    }
+  }
+
+  claims.sort((a, b) => b.start - a.start)
+  let out = text
+  for (const c of claims) {
+    if (c.keep) continue
+    out = out.slice(0, c.start) + c.slot + out.slice(c.end)
+  }
+  return out
 }


### PR DESCRIPTION
Replaces #272 and #273. No model is bundled: detection is a prompt instruction plus deterministic regex.

## Why this shape

#273 shipped a NER tier that measurement showed was broken — transformers.js returns no character offsets for that pipeline, so the span logic anchored matches in the wrong place and **deleted text** (`passport CZ1234567` swallowed 31 characters). The eval never caught it because a leak metric scores deletion as a pass. `openai/privacy-filter` is 875 MB and needs a transformers.js major that would put embeddings in the blast radius; `OpenMed/OpenMed-PII-*` fits well but publishes no ONNX.

Customers are in AU/NZ, so the formats are TFN, Medicare, IRD, NHI, AU/NZ bank and phone shapes.

## Policy

Redact identifiers that carry no added value; keep what carries semantic role.

**Kept** — names, emails and handles (`client.com.au` vs an internal address is what makes a sighting readable), and ABN/ACN/NZBN/lone BSB, which are public registry data identifying the client org. Also every technical identifier: UUIDs, ticket ids, versions, IP:port, row counts.

**Redacted, into a slot naming the class** — TFN, Medicare, IRD, NHI, bank accounts, cards, passports, licences, Centrelink CRN, SSN, secrets, passwords, DOB, employee ids, phones.

## How

`sanitize.ts` is a rule table rather than a chained `.replace()`. Rules claim spans over the original text in table order; first claim wins. `keep` rules claim a span precisely so a looser rule below cannot redact it — that is how a valid ABN survives.

Unlabelled numbers redact only on a passing checksum: TFN mod 11, ABN mod 89, ACN, Medicare mod 10, IRD mod 11 with range, NHI mod 11, Luhn. All are short pure functions, no dependency. Bare 9-digit TFN is deliberately not detected — 1-in-11 false-accept is too noisy for OCR text.

Two libraries were measured and rejected earlier on precision, not recall: `redact-pii` fires `DIGITS` on every number and wrecks ops logs; both leak the ids this now catches.

## Fixture and metric

The harness could not see destruction. It now reports **damaged** (text around a plant that did not survive) and **wrongly removed** (a kept category that was taken). Policy lives in `KEEP_CATEGORIES` / `GAP_CATEGORIES` rather than in which array an entry sits in, so a policy change is a one-line edit.

## Results

`npm run eval-pii-scrub`: **104/104 caught, 0 false positives, 0 damaged, 0 wrongly removed**, 10 known gaps (street addresses — unreachable by regex without eating every `Payables > Acme Corp` path).

Full suite 1438 passing, typecheck and lint clean.

## Reviewing it

`npm run scrub-review` prints redacted prose, every `before -> after`, a tally per slot, and what survived, over a plain-text AU/NZ sample. Reading the prose is the check a leak count cannot do.

## Not included

The DB-upload scrub. Sync still ships summaries, titles, sightings and `user_context` unscrubbed, and remains the largest open egress on DEU-205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)