### PR TITLE
Log token usage in semantic summary success line

### DIFF
--- a/src/main/semantic/model-chain.ts
+++ b/src/main/semantic/model-chain.ts
@@ -130,6 +130,8 @@ export async function trySemanticModelChain(
           mode: params.mode,
           model,
           durationMs,
+          promptTokens: outcome.promptTokens,
+          completionTokens: outcome.completionTokens,
           promptChars: params.prompt.length,
           attemptsSoFar: params.diagnostics.attempts.length,
         }),


### PR DESCRIPTION
The `[ActivitySemanticService] Semantic summary succeeded` log line recorded `durationMs` and `promptChars` but not tokens, so generation speed (t/s) could not be computed from it. `promptTokens`/`completionTokens` were already parsed on both transports (raw `/chat/completions` fetch and `generateText`) and in scope at the log site — this adds them to the log object.

A provider that omits `usage` logs `0`, matching the existing diagnostics convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)