### PR TITLE
Gate the "Viewed X" heuristic at 60s

### DIFF
--- a/src/main/activity/activity-transformer.test.ts
+++ b/src/main/activity/activity-transformer.test.ts
@@ -9,6 +9,7 @@ import type {
   ActivityVideoAsset,
 } from './activity-transformer-types'
 import type { Frame } from '@main/recorder/screen-capturer'
+import { ACTIVITY_CONFIG } from '@constants'
 import log from '@main/utils/logger'
 
 vi.mock('@main/utils/logger', () => ({
@@ -37,11 +38,12 @@ function makeFrame(index: number): ActivityFrame {
 function makeActivity(
   frameCount: number,
   interactions: Activity['interactions'] = [{ type: 'click', timestamp: 1500 }],
+  durationMs = 1000,
 ): Activity {
   return {
     id: 'activity-1',
     startTimestamp: 1000,
-    endTimestamp: 2000,
+    endTimestamp: 1000 + durationMs,
     context: {
       appName: 'Code',
       bundleId: 'com.microsoft.VSCode',
@@ -234,14 +236,79 @@ describe('DefaultActivityTransformer', () => {
       expect(result.ocrText).toBe('ocr text')
     })
 
-    it('still stitches video so the activity remains viewable', async () => {
+    it('skips the stitch — the video is only ever used to summarize', async () => {
       const { stitcher, ocr, semantic, embedder } = makeDeps()
       const transformer = new DefaultActivityTransformer(stitcher, ocr, semantic, embedder, {
         outputDir: OUTPUT_DIR,
       })
 
       await transformer.transform(makeActivity(3, []))
+      expect(stitcher.stitch).not.toHaveBeenCalled()
+    })
+
+    it('records a passive outcome on the summary-mode tracker', async () => {
+      const { stitcher, ocr, semantic, embedder } = makeDeps()
+      const summaryModeTracker = { record: vi.fn() }
+      const transformer = new DefaultActivityTransformer(stitcher, ocr, semantic, embedder, {
+        outputDir: OUTPUT_DIR,
+        summaryModeTracker,
+      })
+
+      await transformer.transform(makeActivity(3, []))
+
+      expect(summaryModeTracker.record).toHaveBeenCalledExactlyOnceWith({
+        mode: 'passive',
+        reason: 'passive',
+        failureDetail: '',
+      })
+    })
+
+    it('leaves the LLM path to record its own outcome', async () => {
+      const { stitcher, ocr, semantic, embedder } = makeDeps()
+      const summaryModeTracker = { record: vi.fn() }
+      const transformer = new DefaultActivityTransformer(stitcher, ocr, semantic, embedder, {
+        outputDir: OUTPUT_DIR,
+        summaryModeTracker,
+      })
+
+      await transformer.transform(makeActivity(3))
+
+      expect(summaryModeTracker.record).not.toHaveBeenCalled()
+    })
+
+    it('sends a passive view past the duration threshold to the LLM', async () => {
+      const { stitcher, ocr, semantic, embedder } = makeDeps()
+      const summaryModeTracker = { record: vi.fn() }
+      const transformer = new DefaultActivityTransformer(stitcher, ocr, semantic, embedder, {
+        outputDir: OUTPUT_DIR,
+        summaryModeTracker,
+      })
+
+      const activity = makeActivity(3, [], ACTIVITY_CONFIG.HEURISTIC_SUMMARY_MAX_DURATION_MS)
+      const result = await transformer.transform(activity)
+
       expect(stitcher.stitch).toHaveBeenCalledOnce()
+      expect(semantic.summarizeFromVideo).toHaveBeenCalledWith({
+        activity,
+        videoPath: '/output/activity-1.mp4',
+      })
+      expect(result.summary).toBe('A summary of the activity')
+      expect(result.summaryModel).toBe('test-model')
+      expect(summaryModeTracker.record).not.toHaveBeenCalled()
+    })
+
+    it('keeps the cheap label just under the duration threshold', async () => {
+      const { stitcher, ocr, semantic, embedder } = makeDeps()
+      const transformer = new DefaultActivityTransformer(stitcher, ocr, semantic, embedder, {
+        outputDir: OUTPUT_DIR,
+      })
+
+      const result = await transformer.transform(
+        makeActivity(3, [], ACTIVITY_CONFIG.HEURISTIC_SUMMARY_MAX_DURATION_MS - 1),
+      )
+
+      expect(semantic.summarizeFromVideo).not.toHaveBeenCalled()
+      expect(result.summaryModel).toBe('heuristic:viewed')
     })
 
     it('sends scroll-only activities to the LLM (scroll is engagement, not passive)', async () => {

--- a/src/main/activity/activity-transformer.ts
+++ b/src/main/activity/activity-transformer.ts
@@ -8,11 +8,15 @@ import type {
   ActivityEmbeddingService,
 } from './activity-transformer-types'
 import type { SemanticPipelinePreference } from '@main/semantic/activity-semantic-service'
+import type { SummaryModeTrackerLike } from '@main/semantic/types'
+import { isPassiveView } from './passive-view'
+import { ACTIVITY_CONFIG } from '@constants'
 import log from '@main/utils/logger'
 
 export interface DefaultActivityTransformerConfig {
   outputDir: string
   getPipelinePreference?: () => SemanticPipelinePreference
+  summaryModeTracker?: SummaryModeTrackerLike
 }
 
 const OCR_FRAME_POSITION_FROM_END = 5
@@ -36,10 +40,12 @@ export class DefaultActivityTransformer implements ActivityTransformer {
       timestamp: f.frame.timestamp,
     }))
 
-    const shouldStitchVideo = this.config.getPipelinePreference?.() !== 'image'
-    const outputPath = shouldStitchVideo ? `${this.config.outputDir}/${activity.id}.mp4` : undefined
+    const durationMs = activity.endTimestamp - activity.startTimestamp
+    const useHeuristic =
+      isPassiveView(activity) && durationMs < ACTIVITY_CONFIG.HEURISTIC_SUMMARY_MAX_DURATION_MS
 
-    const passiveView = this.isPassiveView(activity)
+    const shouldStitchVideo = !useHeuristic && this.config.getPipelinePreference?.() !== 'image'
+    const outputPath = shouldStitchVideo ? `${this.config.outputDir}/${activity.id}.mp4` : undefined
 
     const [videoAsset, ocrText] = await Promise.all([
       shouldStitchVideo && outputPath
@@ -48,12 +54,12 @@ export class DefaultActivityTransformer implements ActivityTransformer {
       this.extractOcrText(activity),
     ])
 
-    // A passive view (no clicks/keystrokes/scrolls — only app focus, or nothing)
-    // carries little narrative for an LLM to summarize, so skip the expensive
-    // inference and label it from its on-screen context. We embed its OCR'd
-    // contents rather than the "Viewed X" label so it stays findable by what was
-    // actually on screen.
-    const { summary, summaryModel, textToEmbed } = passiveView
+    // A short passive view (no clicks/keystrokes/scrolls — only app focus, or
+    // nothing) carries little narrative for an LLM to summarize, so skip the
+    // expensive inference and label it from its on-screen context. We embed its
+    // OCR'd contents rather than the "Viewed X" label so it stays findable by
+    // what was actually on screen.
+    const { summary, summaryModel, textToEmbed } = useHeuristic
       ? this.buildPassiveSummary(activity, ocrText)
       : await this.buildSemanticSummary(activity, videoAsset?.videoPath, ocrText)
 
@@ -109,24 +115,15 @@ export class DefaultActivityTransformer implements ActivityTransformer {
   ): { summary: string; summaryModel: string; textToEmbed: string } {
     const { windowTitle, tld, appName } = activity.context
     const label = windowTitle?.trim() || tld || appName
+    this.config.summaryModeTracker?.record({
+      mode: 'passive',
+      reason: 'passive',
+      failureDetail: '',
+    })
     return {
       summary: `Viewed ${label}`,
       summaryModel: HEURISTIC_VIEWED_MODEL,
       textToEmbed: ocrText || `Viewed ${label}`,
     }
-  }
-
-  /**
-   * A view with no clicks, keystrokes, or scrolls — only app focus, presence
-   * heartbeats, or nothing. Defined as the absence of active-engagement events
-   * so synthetic 'presence' keep-alives don't push a read onto the LLM path.
-   */
-  private isPassiveView(activity: Activity): boolean {
-    return !activity.interactions.some(
-      (interaction) =>
-        interaction.type === 'click' ||
-        interaction.type === 'keyboard' ||
-        interaction.type === 'scroll',
-    )
   }
 }

--- a/src/main/activity/passive-view.test.ts
+++ b/src/main/activity/passive-view.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { isPassiveView } from './passive-view'
+import type { Activity } from './activity-types'
+
+function makeActivity(interactions: Activity['interactions']): Activity {
+  return {
+    id: 'activity-1',
+    startTimestamp: 1000,
+    endTimestamp: 2000,
+    context: {
+      appName: 'Code',
+      bundleId: 'com.microsoft.VSCode',
+      windowTitle: 'Editor',
+      tld: 'github.com',
+    },
+    interactions,
+    frames: [],
+    provenance: {
+      eventWindowOffsets: [],
+      frameOffsets: [],
+      sourceWindowIds: [],
+      sourceClosedBy: [],
+    },
+  }
+}
+
+describe('isPassiveView', () => {
+  it.each([
+    ['empty interactions', []],
+    ['app_change only', [{ type: 'app_change' as const, timestamp: 1500 }]],
+    [
+      'app_change + presence heartbeats',
+      [
+        { type: 'app_change' as const, timestamp: 1100 },
+        { type: 'presence' as const, timestamp: 1500 },
+        { type: 'presence' as const, timestamp: 1900 },
+      ],
+    ],
+  ])('is true for %s', (_name, interactions) => {
+    expect(isPassiveView(makeActivity(interactions))).toBe(true)
+  })
+
+  it.each([
+    ['click', [{ type: 'click' as const, timestamp: 1500 }]],
+    ['keyboard', [{ type: 'keyboard' as const, timestamp: 1500, keyCount: 4 }]],
+    [
+      'scroll',
+      [{ type: 'scroll' as const, timestamp: 1500, scrollDirection: 'vertical' as const }],
+    ],
+  ])('is false for %s', (_name, interactions) => {
+    expect(isPassiveView(makeActivity(interactions))).toBe(false)
+  })
+})

--- a/src/main/activity/passive-view.ts
+++ b/src/main/activity/passive-view.ts
@@ -1,0 +1,15 @@
+import type { Activity } from './activity-types'
+
+/**
+ * A view with no clicks, keystrokes, or scrolls — only app focus, presence
+ * heartbeats, or nothing. Defined as the absence of active-engagement events
+ * so synthetic 'presence' keep-alives don't push a read onto the LLM path.
+ */
+export function isPassiveView(activity: Activity): boolean {
+  return !activity.interactions.some(
+    (interaction) =>
+      interaction.type === 'click' ||
+      interaction.type === 'keyboard' ||
+      interaction.type === 'scroll',
+  )
+}

--- a/src/main/runtime.ts
+++ b/src/main/runtime.ts
@@ -166,6 +166,7 @@ export async function createMainRuntime(params: {
     {
       outputDir,
       getPipelinePreference: () => semanticService.getPipelinePreference(),
+      summaryModeTracker,
     },
   )
   const sink = new SqliteActivitySink(storage.activities)

--- a/src/main/semantic/prompt.test.ts
+++ b/src/main/semantic/prompt.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { buildSemanticPrompt } from './prompt'
+import type { Activity } from '@main/activity/activity-types'
+
+const PASSIVE_RULE = 'The user did not click, type, or scroll in this window'
+
+function makeActivity(interactions: Activity['interactions']): Activity {
+  return {
+    id: 'activity-1',
+    startTimestamp: 1000,
+    endTimestamp: 121_000,
+    context: {
+      appName: 'Google Chrome',
+      bundleId: 'com.google.Chrome',
+      windowTitle: 'Models | OpenRouter',
+      tld: 'openrouter.ai',
+    },
+    interactions,
+    frames: [],
+    provenance: {
+      eventWindowOffsets: [],
+      frameOffsets: [],
+      sourceWindowIds: [],
+      sourceClosedBy: [],
+    },
+  }
+}
+
+describe('buildSemanticPrompt', () => {
+  it('warns the model off implied actions when nothing was clicked, typed or scrolled', () => {
+    const prompt = buildSemanticPrompt(
+      makeActivity([{ type: 'presence', timestamp: 1500 }]),
+      'video',
+    )
+
+    expect(prompt).toContain(PASSIVE_RULE)
+    expect(prompt).toContain('NEVER imply edits, authorship, or actions taken.')
+  })
+
+  it('omits the rule once the window has real engagement', () => {
+    const prompt = buildSemanticPrompt(makeActivity([{ type: 'click', timestamp: 1500 }]), 'video')
+
+    expect(prompt).not.toContain(PASSIVE_RULE)
+  })
+})

--- a/src/main/semantic/prompt.ts
+++ b/src/main/semantic/prompt.ts
@@ -1,5 +1,6 @@
 import type { InteractionContext } from '../../shared/types'
 import type { Activity } from '@main/activity/activity-types'
+import { isPassiveView } from '@main/activity/passive-view'
 import { scrubPII } from '@/shared/sanitize'
 import type { SemanticMode } from './types'
 
@@ -32,6 +33,10 @@ export function buildSemanticPrompt(
     '- Match verb intensity to evidence: browsing/reviewing (no visible edits) -> "browsed," "reviewed," "checked." Light editing (small visible changes) -> "tweaked," "adjusted." Active work (sustained edits, new code, debugging) -> "implemented," "debugged," "refactored." Evidence of editing = visible changed lines, new code, or diff markers.\n'
   prompt +=
     '- Do NOT exaggerate. Switching files/tabs = browsing, not editing. Opening a file/page = reviewing, not working on it.\n'
+  if (isPassiveView(activity)) {
+    prompt +=
+      '- The user did not click, type, or scroll in this window. Describe what was on screen and what changed on its own. NEVER imply edits, authorship, or actions taken.\n'
+  }
   prompt +=
     '- Distinguish preparation from completion. Seeing a form, dialog, or compose window being filled out is NOT evidence it was submitted. Without visible confirmation (success toast, page redirect, confirmation screen), use preparatory verbs like "started," "drafted," "filled out," "was setting up" — NOT completion verbs like "sent," "submitted," "invited," "created."\n'
   prompt +=

--- a/src/main/semantic/summary-reason.ts
+++ b/src/main/semantic/summary-reason.ts
@@ -2,7 +2,8 @@ import type { SemanticRunDiagnostics } from './types'
 
 /**
  * The summarization outcome persisted per activity (mirrors summary_model):
- *  - `mode`: which pipeline produced the summary ('video' | 'snapshot' | '').
+ *  - `mode`: which pipeline produced the summary ('video' | 'snapshot' | ''),
+ *    or 'passive' for the no-LLM heuristic path stamped by the transformer.
  *  - `reason`: a canonical, queryable category for WHY that mode was chosen —
  *    for fallbacks this is the video-failure cause (video_timeout, etc.).
  *  - `failureDetail`: the raw error string of the deciding failed video attempt

--- a/src/main/services/summary-mode-tracker.ts
+++ b/src/main/services/summary-mode-tracker.ts
@@ -16,7 +16,7 @@ import type { SummaryOutcome } from '../semantic/summary-reason'
 export interface SummaryModeStats {
   /** Total semantic-summary outcomes recorded. */
   total: number
-  /** Count per pipeline that produced the summary: 'video' | 'snapshot' | ''. */
+  /** Count per pipeline that produced the summary: 'video' | 'snapshot' | 'passive' | ''. */
   byMode: Record<string, number>
   /** Count per canonical reason ('video', 'video_timeout', 'not_configured', …). */
   byReason: Record<string, number>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -84,6 +84,9 @@ export const ACTIVITY_CONFIG = {
   MAX_ACTIVITY_DURATION_MS: 5 * 60 * 1000, // Force-split after 5 minutes
   MAX_SCREENSHOTS_FOR_LLM: 6, // Max images sent to LLM
   SEMANTIC_REQUEST_TIMEOUT_MS: 120_000, // Per-model semantic request timeout
+  // A no-input view shorter than this is labelled "Viewed <title>" without an
+  // LLM call; longer ones are real sits (a call, a long read) and get summarized.
+  HEURISTIC_SUMMARY_MAX_DURATION_MS: 60_000,
 }
 
 export const LLM_HEALTH_CONFIG = {


### PR DESCRIPTION
## Why

`heuristic:viewed` labels any activity with no click/keyboard/scroll as `"Viewed <window title>"` and skips the LLM (PR #165). Reviewing 590 of them in the dev DB (since 2026-06-11, 9.6% of activities in that period), the mode earns its place — but not for the reason you'd guess, and its boundary is drawn in the wrong place.

**It stays on honesty grounds, not cost.** Skipping the LLM saves ~$0.0002/summary — about $0.10 over two months. What it actually buys is that an LLM asked to describe a static 3-second screen still emits 40–100 confident words, and those blurbs then feed the miner's scan as evidence-shaped noise. `"Viewed X"` is noise that labels itself.

**It does not capture the copy-paste-between-windows flick,** which was the other hypothesis for keeping it. The there-and-back signature (prev app == next app != this app, gaps < 20s) appears in 21.4% of passive activities and 22.2% of LLM-summarized ones — statistically the same. The presence heartbeat records the flick; the label is orthogonal.

**The boundary is the real defect.** 62 passive activities run ≥60s and hold 2.06h — 60% of all passive time — with only a window title to show for it:

| window | duration |
|---|---|
| Ghostty — `⠐ Claude Code` | 4:46 |
| Chrome — `Meet – 30 minut s uživatelem…` | 3:48 |
| Chrome — `Models \| OpenRouter` | 3:41 |
| Claude — `Claude` (629 chars OCR) | 3:32 |
| Finder — *(no title)* → `"Viewed Finder"` | 3:30 |

No interaction ≠ nothing happened.

## What changed

- **Duration gate** — `ACTIVITY_CONFIG.HEURISTIC_SUMMARY_MAX_DURATION_MS = 60_000`. Longer passive views take the normal semantic path and carry the real model id in `summaryModel`; no new field, no new marker.
- **Skip the stitch** when the heuristic applies. `passiveView` was already computed before the `Promise.all`, but the mp4 was encoded anyway and then deleted unused by `cleanupActivityFiles` — 590 wasted ffmpeg encodes. Nothing else reads it: the eval fixture's `session.mp4` is stitched separately from frames by `stitchSessionVideo`.
- **Shared `isPassiveView` predicate** (`src/main/activity/passive-view.ts`), now also used by `buildSemanticPrompt` to add one rule when it applies: the user did not click, type or scroll — describe what was on screen, never imply edits or authorship. This is what makes routing long reads to the LLM safe.
- **`passive` outcome recorded in `SummaryModeTracker`.** It was only ever called from the semantic service, so if uiohook dies or Accessibility permission is revoked, *every* activity becomes passive, every summary becomes `"Viewed X"`, and the logs bundle shows only a falling `total` with no reason bucket.

Threshold sensitivity, if 60s turns out wrong: 30s → 94 activities / 71% of passive time; 45s → 72 / 64%; **60s → 62 / 60%**; 90s → 29 / 37%. At 60s this is ~1.1 extra LLM calls/day. All activities cap at 5 min (`MAX_ACTIVITY_DURATION_MS`).

## Deliberately not done

Filtering heuristic rows out of the miner scan. They're 8–12% of daily scan rows and carry nothing beyond `window_title` (553/590 summaries are exactly `"Viewed " + window_title`), and they land in only 3 of 119 sighting activity slots — but `computeEpisodeWindow` unions member intervals, so dropping them would shrink measured sighting durations. Separate call.

## Verification

`npm test` (1456 passed), `npm run typecheck`, `npm run lint` all clean.

Replayed `petr-2026-06-23-17-27` through the real producer + transformer with a stub summarizer — the three passive blocks stay heuristic and byte-identical to their goldens, so `eval-summaries` should not churn:

```
dur(s)  path        stitched  summary
   6.6  heuristic   false     Viewed MemoryLane
   4.4  heuristic   false     Viewed History – …age-sweep – Task 0 logs – …
  18.8  llm         true      <LLM WOULD RUN>
  36.0  llm         true      <LLM WOULD RUN>
  78.1  llm         true      <LLM WOULD RUN>
   9.5  heuristic   false     Viewed ⠂ Review new task mining logic implementation

passive outcomes recorded: 3
stitches: 3 of 6 activities
```

Not yet run: `npm run eval-summaries` against a real model (needs `OPENROUTER_API_KEY` — the CLI can't decrypt the app's stored key), and the live check that a >60s sit produces a content summary and a `byMode.passive` bucket in `summary-mode-stats.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)